### PR TITLE
fix: bug in challengeAccepted

### DIFF
--- a/nightfall-deployer/contracts/Challenges.sol
+++ b/nightfall-deployer/contracts/Challenges.sol
@@ -149,9 +149,9 @@ contract Challenges is Proposers, Key_Registry {
   }
 
   // This gets called when a challenge succeeds
-  function challengeAccepted(Block memory badBlock) private {
+  function challengeAccepted(Block memory badBlock, bytes32 badBlockHash) private {
     // Check to ensure that the block being challenged is less than a week old
-    require(blockHashes[badBlock.blockHash].data >= (block.timestamp - 7 days) , 'Can only challenge blocks less than a week old');
+    require(blockHashes[badBlockHash].data >= (block.timestamp - 7 days) , 'Can only challenge blocks less than a week old');
     // emit the leafCount where the bad block was added. Timber will pick this
     // up and rollback its database to that point.
     emit Rollback(badBlock.root, badBlock.leafCount);


### PR DESCRIPTION
Now that we no-longer pass in the blockHash as part of the Block struct (saves gas in `proposeBlock(...)`), we must compute it locally whenever we need it. The `challengeAccepted(Block badBlock)` function was still expecting it to be part of the Block struct however and fails.  To fix this, we pass the blockHash into the function explicitly (it's always computed in the calling challenge function) as `challengeAccepted(Block badBlock, bytes32 badBlockHash)`.