### PR TITLE
westlad/rollback-fix

### DIFF
--- a/nightfall-client/test/neg-http.mjs
+++ b/nightfall-client/test/neg-http.mjs
@@ -4,7 +4,6 @@ import chaiAsPromised from 'chai-as-promised';
 import gen from 'general-number';
 import Queue from 'queue';
 import WebSocket from 'ws';
-import config from 'config';
 import sha256 from '../src/utils/crypto/sha256.mjs';
 import {
   closeWeb3Connection,
@@ -17,7 +16,7 @@ import {
 const { expect } = chai;
 const { GN } = gen;
 const txQueue = new Queue({ autostart: true, concurrency: 1 });
-const { ZERO } = config;
+const ZERO = '0x0000000000000000000000000000000000000000000000000000000000000000';
 chai.use(chaiHttp);
 chai.use(chaiAsPromised);
 


### PR DESCRIPTION
This PR makes sure that Timber re-computes its Merkle tree after a rollback.  Currently it just sets all changed nodes to zero and resets metadata to an earlier time point.  This is inadequate because no recalculation of the changed nodes is done (some of them change but do not become zero). To do this computation, we make use of Timber's update function.
The mechanics of doing this are a little tricky because we need to actually set the tree metadata (latest recalculation) to one history point earlier than the rollback point, otherwise Timber's update will not realise that it needs to run. This is because it checks to see if the latest recalculation takes account of all current leaves and thus the latest recalculation cannot include the leaves that were added immediately prior to the rollback point.

Anyway. It works until proved otherwise.

This PR also fixes a minor bug whereby the tests do not pick up the config.  This is due to them being run from above the nightfall-client folder, where the config file lives.  This was causing the setup of the duplicate nullifier test to go wrong.  As we only use the `ZERO` constant from the config, I've just hardcoded it in the test for now.  It will probably stop being a problem when the configs are refactored.