### PR TITLE
Ensure transaction ordering matches block.

### DIFF
--- a/nightfall-optimist/src/routes/block.mjs
+++ b/nightfall-optimist/src/routes/block.mjs
@@ -31,17 +31,8 @@ router.get('/transaction-hash/:transactionHash', async (req, res, next) => {
     logger.debug(`searching for block containing transaction hash ${transactionHash}`);
     // get data to return
     const block = await getBlockByTransactionHash(transactionHash);
-    // Create a dictionary where we will store the correct position ordering
-    const positions = {};
     if (block !== null) {
-      // Use the ordering of txHashes in the block to fill the dictionary-indexed by txHash
-      // eslint-disable-next-line no-return-assign
-      block.transactionHashes.forEach((t, index) => (positions[t] = index));
-
-      // positions is now a hashmap mapping transaction hashes to index and can be fed into .sort()
-      const transactions = (await getTransactionsByTransactionHashes(block.transactionHashes)).sort(
-        (a, b) => positions[a.transactionHash] - positions[b.transactionHash],
-      );
+      const transactions = await getTransactionsByTransactionHashes(block.transactionHashes);
       const index = block.transactionHashes.indexOf(transactionHash);
       delete block?._id; // this is database specific so no need to send it
       logger.debug(`Found block ${JSON.stringify(block, null, 2)} in database`);


### PR DESCRIPTION
This PR fixes a small quirk in the api endpoint `/block/transaction-hash/`, where the `transactions` returned are not in the same order as they are in `block`. The solution uses a dictionary to be better than O(n^2).

This happens because the call to `getTransactionsByTransactionHashes` uses the mongo `$in` query which does not reflect the order the transactions are in the block (AFAIK `$in` uses the `_id` field which a de-facto "order in which the transaction is received").

Currently `getTransactionsByTransactionHashes` is used in `http.mjs` to retrieve the block containing the withdraw function and in the `optimist` challenge code. 

**I've only been able to verify it is breaking** `http.mjs` **as that is where I've gotten up to with the test refactor. Any issues in the** `optimist` **code may require fixing** `getTransactionsByTransactionHashes`.

The reason the tests have been passing previously is because the tests only had 2 txs per block and until my refactor the `withdraw` transaction is the last transaction submitted - therefore it is fortunately always in the right slot when retrieved. The test refactor happened to invert this ordering which raised this finicky error.

The fundamental problem this introduces is that any on-chain hashing in `isBlockReal` results in the incorrect block hash and unexpected reverted transactions.

![image](https://user-images.githubusercontent.com/9293647/123239002-8a840400-d511-11eb-91ac-00e12da30038.png)


### Testing
If you want to test this, 

1. fetch my refactor branch ( ilyas/event-tests ) that does not include this fix but inverts the order of the withdraw transaction.
2. Run the tests which raises the above error.
3. Rebase on top on this PR and re-run the tests which should pass.
