### PR TITLE
fix: enforce correct proposer address

### DIFF
--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -50,10 +50,10 @@ contract State is Structures, Config {
   */
   function proposeBlock(Block calldata b, Transaction[] calldata t) external payable onlyCurrentProposer {
     require(BLOCK_STAKE == msg.value, 'The stake payment is incorrect');
+    require(b.proposer == msg.sender, 'The proposer address is not the sender');
     // We need to check that the block has correctly stored its leaf count. This
     // is needed in case of a roll-back of a bad block, but cannot be checked by
     // a Challenge function (at least i haven't thought of a way to do it).
-
     require(b.leafCount == leafCount, 'The leaf count stored in the Block is not correct');
     // We need to set the blockHash on chain here, because there is no way to
     // convince a challenge function of the (in)correctness by an offchain


### PR DESCRIPTION
fixes #80
If an evil proposer sends a bad block which also contains the address of another proposer, the evil proposer can cause the other proposer to get slashed and demoted. 

I don't _think_ this can be fixed by a challenge, which would be maximally gas-efficient (because there's no way to prove on-chain which address proposed a layer 2 block after the fact).  It's simple to check in `proposeBlock` though and doesn't use much gas.