### PR TITLE
Add event driven tests

### DIFF
--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -182,3 +182,18 @@ export async function testForEvents(contractAddress, topics, timeOut = 30000) {
   // console.log('Events found');
   return events;
 }
+
+export const waitForTimber = async (url, targetLeafCount) => {
+  let timberCurrentLeafCount = 0;
+  do {
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    // eslint-disable-next-line no-await-in-loop
+    timberCurrentLeafCount = await chai.request(url).get('/leaves/count');
+  } while (timberCurrentLeafCount !== targetLeafCount);
+};
+
+export const topicEventMapping = {
+  BlockProposed: '0x566d835e602d4aa5802ee07d3e452e755bc77623507825de7bc163a295d76c0b',
+  Rollback: '0xea34b0bc565cb5f2ac54eaa86422ae05651f84522ef100e16b54a422f2053852',
+};


### PR DESCRIPTION
This PR introduces quite a number of structural changes to the tests.

1. **Event driven Tests**. 
This is done by using a queue, `eventLogs`, to track the emission  of `blockProposed` and `Rollback` events. Tests then await the appearance of these events in the queue before progressing to the next set of tests. This makes the test less subject to variation in processing capabilities of the machines running these tests and removes arbitrary waiting.

2. **Arbitrary transactions per block**
An initial foundation to replace the hardcoded 2 transactions per block assumption in both `http` and `neg-http` with a new variable `txPerBlock`  that should match the `TRANSACTIONS_PER_BLOCK` environmental variable used by `optimist`. 
**Note this only currently works yet for `http`.**


~~**This PR is marked DNM until  #27 and #83 merged**~~

 