### PR TITLE
Check well-formed deposit with historic root

### DIFF
--- a/nightfall-deployer/contracts/ChallengesUtil.sol
+++ b/nightfall-deployer/contracts/ChallengesUtil.sol
@@ -82,7 +82,8 @@ library ChallengesUtil {
       transaction.commitments.length != 1 ||
       nZeroNullifiers == 0 ||
       /* transaction.nullifiers.length != 0 || // TODO in NO */
-      nZeroProof > 0,
+      nZeroProof > 0 ||
+      transaction.historicRootBlockNumberL2 != 0,
       'This deposit transaction type is valid'
     );
   }

--- a/nightfall-optimist/src/services/transaction-checker.mjs
+++ b/nightfall-optimist/src/services/transaction-checker.mjs
@@ -44,7 +44,9 @@ async function checkTransactionType(transaction) {
         transaction.commitments[1] !== ZERO ||
         transaction.commitments.length !== 2 ||
         transaction.nullifiers.some(n => n !== ZERO) ||
-        transaction.proof.some(p => p === ZERO)
+        transaction.proof.some(p => p === ZERO) ||
+        // This extra check is unique to deposits
+        Number(transaction.historicRootBlockNumberL2) !== 0
       )
         throw new TransactionError(
           'The data provided was inconsistent with a transaction type of DEPOSIT',
@@ -112,7 +114,8 @@ async function checkTransactionType(transaction) {
 }
 
 async function checkHistoricRoot(transaction) {
-  // Deposit transaction will not have historic roots
+  // Deposit transaction have a historic root of 0
+  // the validity is tested in checkTransactionType
   if (
     Number(transaction.transactionType) === 1 ||
     Number(transaction.transactionType) === 2 ||


### PR DESCRIPTION
While `deposits` do not contain historic roots, there is still a `historicRootBlockNumberL2` field that is emitted with a value of 0 from the on-chain event. 

We should add extra checks and challenges to the "well-formedness"  of `deposit` to ensure that these fields are actually 0. Currently, you are able to change this field to any value while still being considered a valid transaction. 

AFAIK, I cannot think of how this might be exploitable - but it's better to be safe.

@ChaitanyaKonda can you think of any more areas where more checks are needed?