### PR TITLE
Westlad/client rollback

### DIFF
--- a/nightfall-client/src/classes/commitment.mjs
+++ b/nightfall-client/src/classes/commitment.mjs
@@ -14,6 +14,8 @@ class Commitment {
 
   isNullified = false;
 
+  isNullifiedOnChain = -1;
+
   #computedIndex; // this is the index of this commitment in the Merkle tree. unlike all other numbers in this class, it's a normal Number, rather than a GN for compaitibility with Timber.
 
   constructor({ zkpPublicKey, ercAddress, tokenId, value, salt }) {

--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -1,0 +1,24 @@
+import logger from '../utils/logger.mjs';
+import { markNullifiedOnChain } from '../services/commitment-storage.mjs';
+import getProposeBlockCalldata from '../services/process-calldata.mjs';
+
+/**
+This handler runs whenever a BlockProposed event is emitted by the blockchain
+*/
+async function blockProposedEventHandler(data) {
+  const { nullifiers, blockNumberL2 } = await getProposeBlockCalldata(data);
+  if (nullifiers.length)
+    logger.debug(
+      `Nullifiers appeared on chain at block number ${blockNumberL2}, ${JSON.stringify(
+        nullifiers,
+        null,
+        2,
+      )}`,
+    );
+  // these nullifiers have now appeared on-chain. Thus their nullification
+  // has been confirmed (barring a rollback) and we need to update the
+  // commitment database to that effect
+  markNullifiedOnChain(nullifiers, blockNumberL2);
+}
+
+export default blockProposedEventHandler;

--- a/nightfall-client/src/event-handlers/index.mjs
+++ b/nightfall-client/src/event-handlers/index.mjs
@@ -1,0 +1,10 @@
+import { subscribeToBlockProposedEvent, subscribeToRollbackEventHandler } from './subscribe.mjs';
+import blockProposedEventHandler from './block-proposed.mjs';
+import rollbackEventHandler from './rollback.mjs';
+
+export {
+  subscribeToBlockProposedEvent,
+  blockProposedEventHandler,
+  subscribeToRollbackEventHandler,
+  rollbackEventHandler,
+};

--- a/nightfall-client/src/event-handlers/rollback.mjs
+++ b/nightfall-client/src/event-handlers/rollback.mjs
@@ -1,0 +1,19 @@
+/**
+Each time the Shield contract removes a block from the blockHash linked-list,
+as a result of a rollback, this event gets fired.  We can use it to remove the
+same blocks from our local database record and to reset cached Frontier and
+leafCount values in the Block class
+*/
+import logger from '../utils/logger.mjs';
+import { clearNullified } from '../services/commitment-storage.mjs';
+
+async function rollbackEventHandler(data) {
+  const { blockNumberL2 } = data.returnValues;
+  logger.info(`Received Rollback event, with layer 2 block number ${blockNumberL2}`);
+  // Any commitments that have been nullified and are now no longer spent because
+  // of the rollback should be made available to be spent again.
+  const { result } = await clearNullified(blockNumberL2);
+  logger.debug(`Rollback removed ${result.nModified} nullfiers`);
+}
+
+export default rollbackEventHandler;

--- a/nightfall-client/src/event-handlers/subscribe.mjs
+++ b/nightfall-client/src/event-handlers/subscribe.mjs
@@ -1,0 +1,53 @@
+/* eslint-disable no-await-in-loop */
+
+/**
+ * Module to subscribe to blockchain events
+ */
+import config from 'config';
+import { getContractInstance, getContractAddress } from '../utils/contract.mjs';
+import logger from '../utils/logger.mjs';
+
+const { STATE_CONTRACT_NAME, RETRIES } = config;
+
+/**
+ * Function that tries to get a (named) contract instance and, if it fails, will
+ * retry after 3 seconds.  After RETRIES attempts, it will give up and throw.
+ * This is useful in case nightfall-client comes up before the contract
+ * is fully deployed.
+ */
+export async function waitForContract(contractName) {
+  let errorCount = 0;
+  let error;
+  let instance;
+  while (errorCount < RETRIES) {
+    try {
+      error = undefined;
+      const address = await getContractAddress(contractName);
+      logger.debug(`${contractName} contract address is ${address}`);
+      if (address === undefined) throw new Error(`${contractName} contract address was undefined`);
+      instance = getContractInstance(contractName, address);
+      return instance;
+    } catch (err) {
+      error = err;
+      errorCount++;
+      logger.warn(`Unable to get a ${contractName} contract instance will try again in 3 seconds`);
+      await new Promise(resolve => setTimeout(() => resolve(), 3000));
+    }
+  }
+  if (error) throw error;
+  return instance;
+}
+
+export async function subscribeToBlockProposedEvent(callback, ...args) {
+  const emitter = (await waitForContract(STATE_CONTRACT_NAME)).events.BlockProposed();
+  emitter.on('data', event => callback(event, args));
+  logger.debug('Subscribed to BlockProposed event');
+  return emitter;
+}
+
+export async function subscribeToRollbackEventHandler(callback, ...args) {
+  const emitter = (await waitForContract(STATE_CONTRACT_NAME)).events.Rollback();
+  emitter.on('data', event => callback(event, args));
+  logger.debug('Subscribed to Rollback event');
+  return emitter;
+}

--- a/nightfall-client/src/index.mjs
+++ b/nightfall-client/src/index.mjs
@@ -4,6 +4,12 @@ import app from './app.mjs';
 import rabbitmq from './utils/rabbitmq.mjs';
 import mongo from './utils/mongo.mjs';
 import queues from './queues/index.mjs';
+import {
+  subscribeToBlockProposedEvent,
+  blockProposedEventHandler,
+  subscribeToRollbackEventHandler,
+  rollbackEventHandler,
+} from './event-handlers/index.mjs';
 
 const main = async () => {
   try {
@@ -11,6 +17,8 @@ const main = async () => {
       await rabbitmq.connect();
       queues();
     }
+    subscribeToBlockProposedEvent(blockProposedEventHandler);
+    subscribeToRollbackEventHandler(rollbackEventHandler);
     await mongo.connection(config.MONGO_URL); // get a db connection
     app.listen(80);
   } catch (err) {

--- a/nightfall-client/src/services/check-message.mjs
+++ b/nightfall-client/src/services/check-message.mjs
@@ -30,8 +30,6 @@ async function isMessageValid(message, recipientZkpPublicKey) {
     zkpPublicKey: recipientZkpPublicKey,
     ...message,
   });
-  console.log('message', message);
-  console.log('commitment.index', await commitment.index);
   if ((await commitment.index) === null) return false;
   return true;
 }

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -63,7 +63,7 @@ export async function clearNullified(blockNumberL2) {
   const query = { isNullifiedOnChain: { $gte: Number(blockNumberL2) } };
   const update = { $set: { isNullifiedOnChain: -1, isNullified: false } };
   const db = connection.db(COMMITMENTS_DB);
-  return db.collection(COMMITMENTS_COLLECTION).update(query, update);
+  return db.collection(COMMITMENTS_COLLECTION).updateMany(query, update);
 }
 
 // function to mark a commitments as nullified on chain for a mongo db
@@ -72,7 +72,7 @@ export async function markNullifiedOnChain(nullifiers, blockNumberL2) {
   const query = { nullifier: { $in: nullifiers } };
   const update = { $set: { isNullifiedOnChain: Number(blockNumberL2) } };
   const db = connection.db(COMMITMENTS_DB);
-  return db.collection(COMMITMENTS_COLLECTION).update(query, update);
+  return db.collection(COMMITMENTS_COLLECTION).updateMany(query, update);
 }
 
 // function to find commitments that can be used in the proposed transfer

--- a/nightfall-client/src/services/process-calldata.mjs
+++ b/nightfall-client/src/services/process-calldata.mjs
@@ -1,0 +1,126 @@
+/**
+Function to retreive calldata associated with a blockchain event.
+This is used, rather than re-emmiting the calldata in the event because it's
+much cheaper, although the offchain part is more complex.
+*/
+import config from 'config';
+import Web3 from '../utils/web3.mjs';
+import { waitForContract } from '../event-handlers/subscribe.mjs';
+
+const { PROPOSE_BLOCK_TYPES, STATE_CONTRACT_NAME, ZERO } = config;
+
+function calcBlockHash(block, transactions) {
+  const web3 = Web3.connection();
+  const { proposer, root, leafCount } = block;
+  const blockArray = [leafCount, proposer, root];
+  const transactionsArray = transactions.map(t => {
+    const {
+      value,
+      historicRootBlockNumberL2,
+      transactionType,
+      publicInputHash,
+      tokenId,
+      ercAddress,
+      recipientAddress,
+      commitments,
+      nullifiers,
+      proof,
+    } = t;
+    return [
+      value,
+      historicRootBlockNumberL2,
+      transactionType,
+      publicInputHash,
+      tokenId,
+      ercAddress,
+      recipientAddress,
+      commitments,
+      nullifiers,
+      proof, // note - this is not compressed here
+    ];
+  });
+  const encoded = web3.eth.abi.encodeParameters(PROPOSE_BLOCK_TYPES, [
+    blockArray,
+    transactionsArray,
+  ]);
+  return web3.utils.soliditySha3({ t: 'bytes', v: encoded });
+}
+
+async function getProposeBlockCalldata(eventData) {
+  const web3 = Web3.connection();
+  const { transactionHash } = eventData;
+  const tx = await web3.eth.getTransaction(transactionHash);
+  // Remove the '0x' and function signature to recove rhte abi bytecode
+  const abiBytecode = `0x${tx.input.slice(10)}`;
+  const decoded = web3.eth.abi.decodeParameters(PROPOSE_BLOCK_TYPES, abiBytecode);
+  const blockData = decoded['0'];
+  const transactionsData = decoded['1'];
+  const [leafCount, proposer, root] = blockData;
+  const block = {
+    proposer,
+    root,
+    leafCount: Number(leafCount),
+  };
+  const transactions = transactionsData.map(t => {
+    const [
+      value,
+      historicRootBlockNumberL2,
+      transactionType,
+      publicInputHash,
+      tokenId,
+      ercAddress,
+      recipientAddress,
+      commitments,
+      nullifiers,
+      proof,
+    ] = t;
+    const transaction = {
+      value,
+      historicRootBlockNumberL2,
+      transactionType,
+      publicInputHash,
+      tokenId,
+      ercAddress,
+      recipientAddress,
+      commitments,
+      nullifiers,
+      proof, // note - this is not decompressed here
+    };
+    // note, this transaction is incomplete in that the 'fee' field is empty.
+    // that shouldn't matter as it's not needed.
+    return transaction;
+  });
+  // Client is only really interested in the nullifiers that have been added
+  // because it needs to know if a commitment has been spent or not. Neither
+  // Optimist or Timber can know this as we don't want them dealing with
+  // zkp private keys.
+  const stateContractInstance = await waitForContract(STATE_CONTRACT_NAME);
+  const nullifiers = transactions
+    .map(t => t.nullifiers)
+    .flat()
+    .filter(n => n !== ZERO);
+  // next, we need to tie these up with the number of the block that they are in
+  // It's a little non-trivial to compute this because of course the on-chain
+  // layer 2 block record may have moved on since we arrived here if other
+  // proposeBlocks have happened, firing off other handler asyncs.
+  // To make sure we get the correct block number, we'll start from the end of
+  // the blockchain record and search backwards until we find 'our' L2 block.
+  // Unless we've spent ages here, it'll be close to the end.
+  const blockHash = calcBlockHash(block, transactions);
+  let blockNumberL2 = Number(await stateContractInstance.methods.getNumberOfL2Blocks().call());
+  do {
+    blockNumberL2--;
+    if (blockNumberL2 < 0)
+      throw new Error(
+        'The begining of the Layer 2 record has been reached and the block was not found',
+      );
+  } while (
+    // we don't want to spawn loads of asyncs because we probably only need to
+    // go a few times round this loop before finding 'our' block
+    // eslint-disable-next-line no-await-in-loop
+    blockHash !== (await stateContractInstance.methods.getBlockData(blockNumberL2).call()).blockHash
+  );
+  return { nullifiers, blockNumberL2 };
+}
+
+export default getProposeBlockCalldata;

--- a/nightfall-client/src/services/withdraw.mjs
+++ b/nightfall-client/src/services/withdraw.mjs
@@ -57,14 +57,6 @@ async function withdraw(transferParams) {
   logger.silly(`SiblingPath was: ${JSON.stringify(siblingPath)}`);
   // public inputs
   const root = siblingPath[0];
-  console.log('public inputs', [
-    oldCommitment.preimage.ercAddress,
-    oldCommitment.preimage.tokenId,
-    oldCommitment.preimage.value,
-    nullifier.hash,
-    recipientAddress,
-    root,
-  ]);
   const publicInputs = new PublicInputs([
     oldCommitment.preimage.ercAddress,
     oldCommitment.preimage.tokenId,
@@ -136,7 +128,6 @@ async function withdraw(transferParams) {
       optimisticWithdrawTransaction.transactionHash = th;
       return { transaction: optimisticWithdrawTransaction };
     }
-    console.log('OPTIMISTIC WITHDRAW TX', optimisticWithdrawTransaction);
     const rawTransaction = await shieldContractInstance.methods
       .submitTransaction(Transaction.buildSolidityStruct(optimisticWithdrawTransaction))
       .encodeABI();

--- a/nightfall-client/src/utils/timber.mjs
+++ b/nightfall-client/src/utils/timber.mjs
@@ -8,7 +8,7 @@ const contractName = config.STATE_CONTRACT_NAME;
 
 export const startEventFilter = async () => {
   try {
-    logger.http(`Calling /start for Timber, with contractName '${contractName}' and url ${url}`);
+    logger.silly(`Calling /start for Timber, with contractName '${contractName}' and url ${url}`);
     const response = await axios.post(
       `${url}/start`,
       {
@@ -18,7 +18,7 @@ export const startEventFilter = async () => {
         timeout: 3600000,
       },
     );
-    logger.http('Timber Response:', response.data.data);
+    logger.silly('Timber Response:', response.data.data);
     return response.data.data;
   } catch (error) {
     throw new Error(error);
@@ -26,7 +26,7 @@ export const startEventFilter = async () => {
 };
 
 export const getLeafIndex = async leafValue => {
-  logger.http(
+  logger.silly(
     `Calling /leaf/value for leafValue ${leafValue}, contractName, ${contractName}, url ${url}`,
   );
   try {
@@ -43,7 +43,7 @@ export const getLeafIndex = async leafValue => {
         timeout: 3600000,
       },
     );
-    logger.http('Timber Response:', response.data.data);
+    logger.silly('Timber Response:', response.data.data);
     if (!response.data.data) return null;
     return response.data.data.leafIndex;
   } catch (error) {
@@ -53,7 +53,7 @@ export const getLeafIndex = async leafValue => {
 };
 
 export const getRoot = async () => {
-  logger.http(`Calling /update for Timber`);
+  logger.silly(`Calling /update for Timber`);
   try {
     const response = await axios.patch(
       `${url}/update`,
@@ -64,7 +64,7 @@ export const getRoot = async () => {
         timeout: 3600000,
       },
     );
-    logger.http('Timber Response:', response.data.data.latestRecalculation);
+    logger.silly('Timber Response:', response.data.data.latestRecalculation);
     // TODO: handle null response
     return response.data.data.latestRecalculation.root;
   } catch (error) {
@@ -73,7 +73,7 @@ export const getRoot = async () => {
 };
 
 export const getSiblingPath = async leafIndex => {
-  logger.http(`Calling /siblingPath/${leafIndex}`);
+  logger.silly(`Calling /siblingPath/${leafIndex}`);
   try {
     const response = await axios.get(
       `${url}/siblingPath/${leafIndex}`, //
@@ -103,7 +103,7 @@ This is useful for checking that the root of an optimistic block is correct
 @param {string} root - the historic root of the merkle tree
 */
 export const getTreeHistory = async root => {
-  logger.http(`Calling /tree-history/${root}`);
+  logger.silly(`Calling /tree-history/${root}`);
   const response = await axios.get(
     `${url}/tree-history/${root}`,
     { params: { contractName } },

--- a/nightfall-optimist/src/event-handlers/rollback.mjs
+++ b/nightfall-optimist/src/event-handlers/rollback.mjs
@@ -8,7 +8,7 @@ import {
   addTransactionsToMemPool,
   deleteBlock,
   findBlocksFromBlockNumberL2,
-  resetNullifiers,
+  deleteNullifiers,
 } from '../services/database.mjs';
 import Block from '../classes/block.mjs';
 import logger from '../utils/logger.mjs';
@@ -28,7 +28,7 @@ async function rollbackEventHandler(data) {
     (await findBlocksFromBlockNumberL2(blockNumberL2))
       .map(async block => [
         addTransactionsToMemPool(block),
-        resetNullifiers(block.blockHash),
+        deleteNullifiers(block.blockHash),
         deleteBlock(block.blockHash),
       ])
       .flat(1),

--- a/nightfall-optimist/src/event-handlers/rollback.mjs
+++ b/nightfall-optimist/src/event-handlers/rollback.mjs
@@ -9,6 +9,7 @@ import {
   deleteBlock,
   findBlocksFromBlockNumberL2,
   deleteNullifiers,
+  deleteTransferAndWithdraw,
 } from '../services/database.mjs';
 import Block from '../classes/block.mjs';
 import logger from '../utils/logger.mjs';
@@ -18,16 +19,27 @@ async function rollbackEventHandler(data) {
   logger.info(`Received Rollback event, with layer 2 block number ${blockNumberL2}`);
   // reset the Block class cached values.
   Block.rollback();
-  // We have to remove all blocks from our database which have a layer 2 block
-  // number >= blockNumberL2, because the blockchain will have deleted these due
-  // to a successful challenge. First we find and then process them.
-  // Return the transactions in the rolled back block to the mempool and
-  // unset blockhashes for nullifiers, finally, delete the blocks
-  // themselves.
+  /*
+   We have to remove all blocks from our database which have a layer 2 block
+   number >= blockNumberL2, because the blockchain will have deleted these due
+   to a successful challenge. First we find and then process them.
+   Return deposit transactions in the rolled back block to the mempool so that
+   they can be picked up again by a new Proposer, but delete transfer and
+   withdraw transactions because we cannot guarantee that these won't be re-
+   proposed before the corresponding transaction that creates the input
+   commitments.  If that were to happen, the block would become challengable
+   even if the Proposer acted in good faith.  Deleteing them obvously prevents
+   this but means that the Transactor looses their fee payment.  TODO fix this,
+   but for now it will do because the fee isn't much and this should be a rare
+   event.
+   Also delete nullifiers and the blocks that no longer exist.
+  */
   return Promise.all(
     (await findBlocksFromBlockNumberL2(blockNumberL2))
       .map(async block => [
-        addTransactionsToMemPool(block),
+        deleteTransferAndWithdraw(block.transactionHashes).then(() =>
+          addTransactionsToMemPool(block),
+        ),
         deleteNullifiers(block.blockHash),
         deleteBlock(block.blockHash),
       ])

--- a/nightfall-optimist/src/routes/proposer.mjs
+++ b/nightfall-optimist/src/routes/proposer.mjs
@@ -189,7 +189,6 @@ router.post('/encode', async (req, res, next) => {
     // normally we re-compute the leafcount. If however block.leafCount is -ve
     // that's a signal to use the value given (once we've flipped the sign back)
     if (block.leafCount < 0) currentLeafCount = -block.leafCount;
-    console.log('CURRENT LEAF COUNT', currentLeafCount, block.leafCount);
     const blockNumberL2 = Number(await stateContractInstance.methods.getNumberOfL2Blocks().call());
 
     const newTransactions = await Promise.all(

--- a/nightfall-optimist/src/services/challenges.mjs
+++ b/nightfall-optimist/src/services/challenges.mjs
@@ -271,7 +271,6 @@ export async function createChallenge(block, transactions, err) {
         const priorBlockTransactions = await getTransactionsByTransactionHashes(
           priorBlockL2.transactionHashes,
         );
-        console.log('BLOCK AND PRIOR BLOCK', block, priorBlockL2);
         txDataToSign = await challengeContractInstance.methods
           .challengeLeafCountCorrect(
             Block.buildSolidityStruct(priorBlockL2), // the block immediately prior to this one

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -328,6 +328,14 @@ export async function resetNullifiers(blockHash) {
   return db.collection(NULLIFIER_COLLECTION).updateMany(query, update);
 }
 
+// delete all the nullifiers in this block
+export async function deleteNullifiers(blockHash) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  const query = { blockHash };
+  return db.collection(NULLIFIER_COLLECTION).deleteMany(query);
+}
+
 export async function getBlocks() {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -155,7 +155,7 @@ describe('Testing the http API', () => {
             chai
               .request(url)
               .post('/deposit')
-              .send({ ercAddress, tokenId, value, zkpPublicKey, fee }),
+              .send({ ercAddress, tokenId, value, zkpPrivateKey, fee }),
           ),
         )
       ).map(res => res.body);
@@ -244,7 +244,7 @@ describe('Testing the http API', () => {
             chai
               .request(url)
               .post('/deposit')
-              .send({ ercAddress, tokenId, value, zkpPublicKey, fee }),
+              .send({ ercAddress, tokenId, value, zkpPrivateKey, fee }),
           ),
         )
       ).map(dRes => dRes.body);
@@ -320,7 +320,7 @@ describe('Testing the http API', () => {
             chai
               .request(url)
               .post('/deposit')
-              .send({ ercAddress, tokenId, value, zkpPublicKey, fee }),
+              .send({ ercAddress, tokenId, value, zkpPrivateKey, fee }),
           ),
         )
       ).map(dRes => dRes.body);
@@ -367,7 +367,7 @@ describe('Testing the http API', () => {
             chai
               .request(url)
               .post('/deposit')
-              .send({ ercAddress, tokenId, value, zkpPublicKey, fee }),
+              .send({ ercAddress, tokenId, value, zkpPrivateKey, fee }),
           ),
         )
       ).map(dRes => dRes.body);
@@ -461,7 +461,7 @@ describe('Testing the http API', () => {
             chai
               .request(url)
               .post('/deposit')
-              .send({ ercAddress, tokenId, value, zkpPublicKey, fee }),
+              .send({ ercAddress, tokenId, value, zkpPrivateKey, fee }),
           ),
         )
       ).map(res => res.body);

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -242,7 +242,7 @@ describe('Testing the challenge http API', () => {
             chai
               .request(url)
               .post('/deposit')
-              .send({ ercAddress, tokenId, value, zkpPublicKey, fee }),
+              .send({ ercAddress, tokenId, value, zkpPrivateKey, fee }),
           ),
         )
       ).map(res => res.body);
@@ -291,7 +291,7 @@ describe('Testing the challenge http API', () => {
             chai
               .request(url)
               .post('/deposit')
-              .send({ ercAddress, tokenId, value, zkpPublicKey, fee }),
+              .send({ ercAddress, tokenId, value, zkpPrivateKey, fee }),
           ),
         )
       ).map(res => res.body);
@@ -400,7 +400,7 @@ describe('Testing the challenge http API', () => {
         const res = await chai
           .request(url)
           .post('/deposit')
-          .send({ ercAddress, tokenId, value, zkpPublicKey, fee });
+          .send({ ercAddress, tokenId, value, zkpPrivateKey, fee });
 
         const { txDataToSign } = res.body;
         expect(txDataToSign).to.be.a('string');
@@ -420,7 +420,7 @@ describe('Testing the challenge http API', () => {
           ercAddress,
           tokenId,
           value,
-          zkpPublicKey,
+          zkpPrivateKey,
           fee,
         });
         const { txDataToSign } = res.body;
@@ -465,7 +465,7 @@ describe('Testing the challenge http API', () => {
           ercAddress,
           tokenId,
           value,
-          zkpPublicKey,
+          zkpPrivateKey,
           fee,
         });
         const { txDataToSign } = res.body;
@@ -487,7 +487,7 @@ describe('Testing the challenge http API', () => {
               ercAddress,
               tokenId,
               value,
-              zkpPublicKey,
+              zkpPrivateKey,
               fee,
             });
           const { txDataToSign } = res.body;

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -122,7 +122,7 @@ describe('Testing the challenge http API', () => {
               .map(t => t.nullifiers.filter(n => n !== ZERO))
               .flat(Infinity);
             console.log(
-              `Created good block to extract duplicate nullifier from with blockHash ${block.blockHash}`,
+              `Created good block to extract duplicate nullifier ${duplicateNullifier} from with blockHash ${block.blockHash}`,
             );
           } else if (counter === 2) {
             res = await createBadBlock('IncorrectRoot', block, transactions, {
@@ -177,7 +177,6 @@ describe('Testing the challenge http API', () => {
             res = await createBadBlock('DuplicateNullifier', block, transactions, {
               duplicateNullifier,
             });
-            // topicsBlockHashesDuplicateNullifier = res.block.blockHash;
             topicsBlockHashDuplicateNullifier = res.block.blockHash;
             txDataToSign = res.txDataToSign;
             console.log(

--- a/test/tx-gas.mjs
+++ b/test/tx-gas.mjs
@@ -4,9 +4,7 @@ Test suite for measuring the gas per transaction
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import chaiAsPromised from 'chai-as-promised';
-import gen from 'general-number';
 import WebSocket from 'ws';
-import sha256 from '../nightfall-client/src/utils/crypto/sha256.mjs';
 import {
   // closeWeb3Connection,
   submitTransaction,
@@ -19,8 +17,6 @@ const { expect } = chai;
 chai.use(chaiHttp);
 chai.use(chaiAsPromised);
 
-const { GN } = gen;
-
 describe('Testing the http API', () => {
   let shieldAddress;
   let challengeAddress;
@@ -30,7 +26,6 @@ describe('Testing the http API', () => {
   let connection; // WS connection
   let blockSubmissionFunction;
   const zkpPrivateKey = '0xc05b14fa15148330c6d008814b0bdd69bc4a08a1bd0b629c42fa7e2c61f16739'; // the zkp private key we're going to use in the tests.
-  const zkpPublicKey = sha256([new GN(zkpPrivateKey)]).hex();
   const url = 'http://localhost:8080';
   const optimistUrl = 'http://localhost:8081';
   const optimistWsUrl = 'ws:localhost:8082';
@@ -157,7 +152,7 @@ describe('Testing the http API', () => {
           ercAddress,
           tokenId,
           value,
-          zkpPublicKey,
+          zkpPrivateKey,
           fee,
         });
         txDataToSign = res.body.txDataToSign;


### PR DESCRIPTION
Currently, nightfall-client does not respond to `Rollback` events.  This causes the problem that a rollback may remove a nullifier from the blockchain record.  This would mean that the corresponding commitment was no longer spent and thus could be spent 'again'.  With no rollback capability, nightfall-client will not, however, know this.  This will have the effect of locking up funds.

This PR fixes #88 i.e. the problem above. It makes nightfall-client respond to both `Rollback` and `BlockProposed` events.  Why does it need `BlockProposed`?  To complete a rollback, nightfall-client needs to know which block a nullifier is in, otherwise it can't tell which nullifiers it has to roll back.  `BlockProposed` gives it this information.

nightfall-client now recognises two states for a commitment: `isNullified` is set as soon as a commitment is spent.  This immediately prevents nightfall-client trying to spend it again. However, the commitment isn't 'properly' nullified until the nullifier appears on-chain, at this point nightfall-client also sets `isNullifiedOnChain` from `-1` to the L2 block number of the block that this particular nullifier is in, so that it can be rolled-back in the future if needed.  Of course, we can still get a situation where `isNullified = true` locks a commitment from being spent again but the nullifier never appears on-chain. This isn't really nightfall-client's faulty though - it's up to the user application to make sure they sign and send blockchain transactions that it's given.

I had considered extracting the information needed for nightfall-client from nightfall-optimist and timber, to avoid another connection to the blockchain client.  However, this doesn't work because only nightfall-client has access to the zkp private key and, without this, it's not possible to associate a commitment with its nullifier.  This means that neither nightfall-optimist or timber can tell nightfall-client which commitments it should release for spending.

To make this all work, some changes were needed to nightfall-optimist.  That's because nightfall-optimist does a duplicate nullifier check but, quite reasonably, did not include the concept of a nullifier being removed in a rollback. To fix this rollbacks now delete rolled-back nullifiers in nightfall-optimist (this is a stronger removal than the isMined flag the went before).  There are some other, minor changes to the duplicate nullifier logic (nullifiers are stamped with a blockHash when a block is saved, rather than after checking the block, to avoid an intermediate state where a block is considered 'mined' but its nullifiers aren't). Rollbacks also delete any Transfer or Withdraw transactions that are rolled back.  This is needed because otherwise they may be re-proposed before the corresponding transactions that created the input commitments, which is a challengeable causality violation.  We don't want to give an innocent proposer this headache.  It will be nice, as a future enhancement, to give the transactor their fee back but we don't do that yet to avoid overcomplicating the PR (hopefully this is a small, rare loss).

This PR does not include a capability for nightfall-client to recover if it falls out of sync.  That's because this PR is already quite big.  We'll do the state-sync as a followup PR.  This isn't too mission-critical because falling out of sync will just mean that (in the event of a rollback) some commitments will remain un-spendable unnecessarily.