### PR TITLE
Do not reset rolled back transactions if they are already in another block.

### DIFF
--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -191,7 +191,7 @@ describe('Testing the challenge http API', () => {
             );
           } else {
             txDataToSign = msg.txDataToSign;
-            console.log(`Created good block with blockHash ${res.block.blockHash}`);
+            console.log(`Created good block with blockHash ${block.blockHash}`);
           }
           await submitTransaction(txDataToSign, privateKey, stateAddress, gas, BLOCK_STAKE);
           counter++;
@@ -362,6 +362,12 @@ describe('Testing the challenge http API', () => {
           web3.eth.abi.encodeEventSignature('Rollback(bytes32,uint256,uint256)'),
           web3.eth.abi.encodeParameter('bytes32', topicsBlockHashDuplicateTransaction),
         ]);
+        const res = await chai
+          .request(url)
+          .post('/deposit')
+          .send({ ercAddress, tokenId, value, zkpPrivateKey, fee });
+        // now we need to sign the transaction and send it to the blockchain
+        await submitTransaction(res.body.txDataToSign, privateKey, shieldAddress, gas, fee);
       });
     });
     describe('Challenge 3: Invalid transaction submitted', () => {


### PR DESCRIPTION
This PR adds `blockNumberL2` to the transactions collections. This field is set during `removeTransactionsFromMempool` which is called either when we assemble a block or receive a `blockProposed` event.

`blockNumberL2` is then used during `addTransactionToMemPool`, which is called during a Rollback, to ensure that we do not add transactions that have been included in other blocks as well (i.e. duplicate transactions).

This fixes #94.