### PR TITLE
Clean up transactions that were proposed in blocks but did not make it on chain

### DIFF
--- a/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
+++ b/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
@@ -23,11 +23,10 @@ async function newCurrentProposerEventHandler(data, args) {
     proposer.address = currentProposer;
     // were we the last proposer?
     const weWereLastProposer = proposer.isMe;
-    proposer.isMe = !!(await isRegisteredProposerAddressMine(currentProposer));
 
     // If we were the last proposer return any transactions that were removed from the mempool
     // because they were included in proposed blocks that did not eventually make it on chain.
-    if (weWereLastProposer && !proposer.isMe) {
+    if (weWereLastProposer) {
       const stateContractInstance = await getContractInstance(STATE_CONTRACT_NAME);
       const onChainBlockCount = Number(
         await stateContractInstance.methods.getNumberOfL2Blocks().call(),
@@ -39,6 +38,7 @@ async function newCurrentProposerEventHandler(data, args) {
 
     // !! converts this to a "is not null" check - i.e. false if is null
     // are we the next proposer?
+    proposer.isMe = !!(await isRegisteredProposerAddressMine(currentProposer));
   } catch (err) {
     // handle errors
     logger.error(err);

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -356,3 +356,14 @@ export async function getBlocks() {
     .find({}, { sort: { blockNumber: 1 } })
     .toArray();
 }
+
+/**
+Function to add a set of transactions from the layer 2 mempool once a block has been rolled back
+*/
+export async function addTransactionsToMemPoolFromBlockNumberL2(blockNumberL2) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  const query = { blockNumberL2: { $gte: Number(blockNumberL2) } };
+  const update = { $set: { mempool: true, blockNumberL2: -1 } };
+  return db.collection(TRANSACTIONS_COLLECTION).updateMany(query, update);
+}


### PR DESCRIPTION
This PR closes #95.

When a new `changeProposer` event is received, check if we were the last proposer. 

If we are the last proposer, use the on-chain L2 information to reset any transactions that we have included in proposed blocks that did not make it on-chain before the `currentProposer` was rotated away from us.