### PR TITLE
Westlad/chain reorg Part 1

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -54,4 +54,5 @@ module.exports = {
   HASH_TYPE: 'mimc',
   USE_STUBS: process.env.USE_STUBS === 'true',
   VK_IDS: { deposit: 0, single_transfer: 1, double_transfer: 2, withdraw: 3 }, // used as an enum to mirror the Shield contracts enum for vk types. The keys of this object must correspond to a 'folderpath' (the .zok file without the '.zok' bit)
+  MAX_QUEUE: 5,
 };

--- a/nightfall-client/package-lock.json
+++ b/nightfall-client/package-lock.json
@@ -536,6 +536,14 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
+    "async-mutex": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.1.tgz",
+      "integrity": "sha512-vRfQwcqBnJTLzVQo72Sf7KIUbcSUP5hNchx6udI1U6LuPQpfePgdjJzlCe76yFZ8pxlLjn9lwcl/Ya0TSOv0Tw==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -8141,6 +8149,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
+    },
+    "tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/nightfall-client/package.json
+++ b/nightfall-client/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/EYBlockchain/nightfall-client#readme",
   "dependencies": {
     "amqplib": "^0.8.0",
+    "async-mutex": "^0.3.1",
     "axios": "^0.21.1",
     "body-parser": "1.19.0",
     "chai-as-promised": "^7.1.1",

--- a/nightfall-optimist/package-lock.json
+++ b/nightfall-optimist/package-lock.json
@@ -7468,6 +7468,14 @@
         "strict-uri-encode": "^1.0.0"
       }
     },
+    "queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "requires": {
+        "inherits": "~2.0.3"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",

--- a/nightfall-optimist/package.json
+++ b/nightfall-optimist/package.json
@@ -42,6 +42,7 @@
     "hex-to-binary": "^1.0.1",
     "keccak": "^3.0.1",
     "mongodb": "^3.6.3",
+    "queue": "^6.0.2",
     "safe-buffer": "^5.2.1",
     "tar": "^6.0.2",
     "web3": "^1.3.0",

--- a/nightfall-optimist/src/event-handlers/block-proposed.mjs
+++ b/nightfall-optimist/src/event-handlers/block-proposed.mjs
@@ -51,7 +51,10 @@ async function blockProposedEventHandler(data) {
     if (err instanceof BlockError) {
       logger.warn(`Block Checker - Block invalid, with code ${err.code}! ${err.message}`);
       await createChallenge(block, transactions, err);
-    } else throw new Error(err);
+    } else {
+      logger.error(err.stack);
+      throw new Error(err);
+    }
   }
 }
 

--- a/nightfall-optimist/src/event-handlers/chain-reorg.mjs
+++ b/nightfall-optimist/src/event-handlers/chain-reorg.mjs
@@ -1,0 +1,81 @@
+/**
+Module for processing layer 1 chain reoganisations.
+It's probable that the Ethereum chain will undergo a reorganisation from time to
+time.  This is an issue if our code does not alter its offchain record to take
+account of such reorgs because then its state will be inconsistent with the
+blockchain.
+To address this, we note that each offchain state update is always triggered by
+a blockchain event, which we're subscribed to. Thus we have to reorganise our
+offchain state whenever one of these events is removed by a layer 1 reorg.
+This effectively mean rewriting all state beyond the point (layer 1 blocknumber)
+at which an event is removed by replaying all the events from that point until
+we reach the new present.
+Of course, we could get other events removed while we're doing that. In fact its
+likely that we will if the reorg is a few blocks deep.  That would be a nightmare
+of racing asyncs as each event caused a layer 2 reorg on top of another ongoing
+reorg.
+We can do better by checking, as we re-apply state event-by-event, whether an
+event we're about to rewrite is in our list of removed events (same tx hash) if
+it is then it's been removed as part of the same re-org and we don't need to
+replay state again because of it - it will already be covered by our current re-
+write.  If however its hash does not exist in the state we're re-writing then
+it represents a re-org on our reorg and we must replay it separately.
+*/
+
+import { Mutex } from 'async-mutex';
+import Web3 from '../utils/web3.mjs';
+import {
+  blockProposedEventHandler,
+  rollbackEventHandler,
+  newCurrentProposerEventHandler,
+  committedToChallengeEventHandler,
+} from './index.mjs';
+
+const mutex = new Mutex();
+const removedEventObjects = [];
+async function replayEvents(eventObject) {
+  const web3 = Web3.connection();
+  // get the list of new events that exist after the reorg and order them by
+  // ascending blockNumber then transaction index
+  const eventsToReplay = await web3
+    .getPastEvents('allEvents', {
+      fromBlock: eventObject.blockNumber,
+      toBlock: 'latest',
+    })
+    .sort((a, b) => a.blockNumber - b.blockNumber || a.transactionIndex - b.transactionIndex);
+  // then re-run the events one after the other (using a mutex to do that)
+  for (let i = 0; i < eventsToReplay.length; i++) {
+    mutex.runExclusive(async () => {
+      let handler;
+      switch (eventsToReplay[i].event) {
+        case 'BlockProposed':
+          handler = blockProposedEventHandler;
+          break;
+        case 'RollBack':
+          handler = rollbackEventHandler;
+          break;
+        case 'NewProposer':
+          handler = newCurrentProposerEventHandler;
+          break;
+        case 'CommittedToChallenge':
+          handler = committedToChallengeEventHandler;
+          break;
+        default:
+          handler = Promise.resolve();
+          break;
+      }
+      return handler(eventsToReplay[i]);
+    });
+  }
+}
+
+async function chainReorgEventHandler(eventObject) {
+  // we'll add this (removed) event object to an array and then replay all
+  // subsequent events. We use a mutex to control concurrency to be 1.
+  mutex.runExclusive(async () => {
+    removedEventObjects.push(eventObject);
+    return replayEvents(removedEventObjects.shift());
+  });
+}
+
+export default chainReorgEventHandler;

--- a/nightfall-optimist/src/event-handlers/chain-reorg.mjs
+++ b/nightfall-optimist/src/event-handlers/chain-reorg.mjs
@@ -4,78 +4,128 @@ It's probable that the Ethereum chain will undergo a reorganisation from time to
 time.  This is an issue if our code does not alter its offchain record to take
 account of such reorgs because then its state will be inconsistent with the
 blockchain.
+
 To address this, we note that each offchain state update is always triggered by
 a blockchain event, which we're subscribed to. Thus we have to reorganise our
 offchain state whenever one of these events is removed by a layer 1 reorg.
-This effectively mean rewriting all state beyond the point (layer 1 blocknumber)
-at which an event is removed by replaying all the events from that point until
-we reach the new present.
-Of course, we could get other events removed while we're doing that. In fact its
-likely that we will if the reorg is a few blocks deep.  That would be a nightmare
-of racing asyncs as each event caused a layer 2 reorg on top of another ongoing
-reorg.
-We can do better by checking, as we re-apply state event-by-event, whether an
-event we're about to rewrite is in our list of removed events (same tx hash) if
-it is then it's been removed as part of the same re-org and we don't need to
-replay state again because of it - it will already be covered by our current re-
-write.  If however its hash does not exist in the state we're re-writing then
-it represents a re-org on our reorg and we must replay it separately.
+This is actually fairly straightforward for 'additive' events like a BlockProposed.
+In that case, removal of a BlockProposed event means that any later 2 state after,
+and including, that event is invalid because all subsequent state will depend on
+that removed block. Thus we delete it. The new state will be written as new
+events come in from the new layer 1 fork that we are now following (TBC).
+We have to be careful that new events don't come in while we're deleting state
+or we'll delete the new events too!  We do this by queueing incomming events and
+making them run sequentially (concurrency = 1). This is done via event-buffer.mjs.
+
+Removal of a Rollback event is less straightforward.  The state after, and
+including, the rollback will still be invalid because its built off of the block
+we rolled back to. Thus, this part of the re-organisation is the same as for
+a BlockProposer. However we will also have deleted layer 2 state in the original
+rollback, which we now have to restore. Thus we need to work out the layer 1
+block which contains the last layer 2 block that our rollback removed and replay
+all the events from that layer 1 block (inclusive) but excluding the rollback.
+
+Some events (CommittedToChallenge and NewCurrentProposer) don't cause layer 2
+state updates directly.  They're triggers for the offchain system to do something,
+for example to send a challenge in. That something will probably result in a
+state change but we don't have to do any layer 2 state modification when one of
+these events is removed because any state change that resulted will have been
+initiated by another event, e.g. a Rollback. This is only true of course if the
+responses to such events are idempotent. TODO consider further.
 */
-
-import { Mutex } from 'async-mutex';
-import Web3 from '../utils/web3.mjs';
+import config from 'config';
 import {
-  blockProposedEventHandler,
-  rollbackEventHandler,
-  newCurrentProposerEventHandler,
-  committedToChallengeEventHandler,
-} from './index.mjs';
+  deleteBlocksFromBlockNumberL1,
+  deleteTransactionsFromBlockNumberL1,
+  deleteNullifiersFromBlockNumberL1,
+  getBlockByBlockNumberL2,
+} from '../services/database.mjs';
+import logger from '../utils/logger.mjs';
+import { waitForContract } from './subscribe.mjs';
 
-const mutex = new Mutex();
-const removedEventObjects = [];
-async function replayEvents(eventObject) {
-  const web3 = Web3.connection();
-  // get the list of new events that exist after the reorg and order them by
-  // ascending blockNumber then transaction index
-  const eventsToReplay = await web3
-    .getPastEvents('allEvents', {
-      fromBlock: eventObject.blockNumber,
-      toBlock: 'latest',
-    })
+const {
+  STATE_CONTRACT_NAME,
+  PROPOSERS_CONTRACT_NAME,
+  CHALLENGES_CONTRACT_NAME,
+  SHIELD_CONTRACT_NAME,
+} = config;
+
+/**
+If we've been told that an event that occurred in the L1 block with number
+blockNumberL1, has been removed, this means that all our off-chain L2 state
+records are invalid beyond this point (inclusive of the point).  So we delete
+them.
+*/
+async function deleteState(blockNumberL1) {
+  logger.info('Responding to layer 1 chain reorganisation - deleting state');
+  return Promise.all([
+    deleteBlocksFromBlockNumberL1(blockNumberL1),
+    deleteTransactionsFromBlockNumberL1(blockNumberL1),
+    deleteNullifiersFromBlockNumberL1(blockNumberL1),
+  ]);
+}
+
+/**
+If we've previously removed L2 state and we now wish that we hadn't, we can
+replay the state back with this function. Note the replay is inclusive of
+fromblockNumberL1 and toBlockNumberL1.
+*/
+async function resync(fromblockNumberL1, toBlockNumberL1, eventHandlers, eventQueue) {
+  // get all the events and sort them into causal order by block and transaction
+  const events = await Promise.all([
+    (
+      await waitForContract(STATE_CONTRACT_NAME)
+    ).methods.events.allEvents({
+      fromBlock: fromblockNumberL1,
+      toBlock: toBlockNumberL1,
+    }),
+    (
+      await waitForContract(SHIELD_CONTRACT_NAME)
+    ).methods.events.allEvents({
+      fromBlock: fromblockNumberL1,
+      toBlock: toBlockNumberL1,
+    }),
+    (
+      await waitForContract(PROPOSERS_CONTRACT_NAME)
+    ).methods.events.allEvents({
+      fromBlock: fromblockNumberL1,
+      toBlock: toBlockNumberL1,
+    }),
+    (
+      await waitForContract(CHALLENGES_CONTRACT_NAME)
+    ).methods.events.allEvents({
+      fromBlock: fromblockNumberL1,
+      toBlock: toBlockNumberL1,
+    }),
+  ])
+    .flat()
     .sort((a, b) => a.blockNumber - b.blockNumber || a.transactionIndex - b.transactionIndex);
-  // then re-run the events one after the other (using a mutex to do that)
-  for (let i = 0; i < eventsToReplay.length; i++) {
-    mutex.runExclusive(async () => {
-      let handler;
-      switch (eventsToReplay[i].event) {
-        case 'BlockProposed':
-          handler = blockProposedEventHandler;
-          break;
-        case 'RollBack':
-          handler = rollbackEventHandler;
-          break;
-        case 'NewProposer':
-          handler = newCurrentProposerEventHandler;
-          break;
-        case 'CommittedToChallenge':
-          handler = committedToChallengeEventHandler;
-          break;
-        default:
-          handler = Promise.resolve();
-          break;
-      }
-      return handler(eventsToReplay[i]);
-    });
+  // now replay them in order
+  for (let i = 0; i < events.length; i++) {
+    eventQueue.push(async () => eventHandlers[events[i].event](events[i]));
   }
 }
 
-async function chainReorgEventHandler(eventObject) {
-  // we'll add this (removed) event object to an array and then replay all
-  // subsequent events. We use a mutex to control concurrency to be 1.
-  mutex.runExclusive(async () => {
-    removedEventObjects.push(eventObject);
-    return replayEvents(removedEventObjects.shift());
-  });
+export async function removeBlockProposedEventHandler(eventObject) {
+  await deleteState(eventObject.blockNumber);
+  return resync(eventObject.blockNumber, 'latest');
 }
 
-export default chainReorgEventHandler;
+export async function removeRollbackEventHandler(eventObject) {
+  const { blockNumberL2 } = eventObject.returnValues;
+  // rollback needs to resync not from the point that the event occurred but
+  // from the point that the rollback reached
+  const { blockNumber: blockNumberL1 } = await getBlockByBlockNumberL2(blockNumberL2);
+  await deleteState(blockNumberL1); // TODO can we just call rollback????
+  return resync(blockNumberL1, 'latest');
+}
+
+export async function removeNewCurrentProposerEventHandler(eventObject) {
+  await deleteState(eventObject.blockNumber);
+  return resync(eventObject.blockNumber, 'latest');
+}
+
+export async function removeCommittedToChallengeEventHandler(eventObject) {
+  await deleteState(eventObject.blockNumber);
+  return resync(eventObject.blockNumber, 'latest');
+}

--- a/nightfall-optimist/src/event-handlers/index.mjs
+++ b/nightfall-optimist/src/event-handlers/index.mjs
@@ -1,4 +1,5 @@
 import {
+  subscribeToEvents,
   subscribeToBlockProposedEvent,
   subscribeToNewCurrentProposer,
   subscribeToTransactionSubmitted,
@@ -6,24 +7,43 @@ import {
   subscribeToRollbackEventHandler,
   subscribeToChallengeWebSocketConnection,
   subscribeTocommittedToChallengeEventHandler,
+  subscribeToChainReorgEventHandler,
 } from './subscribe.mjs';
 import blockProposedEventHandler from './block-proposed.mjs';
 import newCurrentProposerEventHandler from './new-current-proposer.mjs';
 import transactionSubmittedEventHandler from './transaction-submitted.mjs';
 import rollbackEventHandler from './rollback.mjs';
 import committedToChallengeEventHandler from './challenge-commit.mjs';
+import {
+  removeRollbackEventHandler,
+  removeBlockProposedEventHandler,
+  removeCommittedToChallengeEventHandler,
+  removeNewCurrentProposerEventHandler,
+} from './chain-reorg.mjs';
+
+const eventHandlers = {
+  BlockProposed: blockProposedEventHandler,
+  TransactionSubmitted: transactionSubmittedEventHandler,
+  Rollback: rollbackEventHandler,
+  CommittedToChallenge: committedToChallengeEventHandler,
+  removers: {
+    Rollback: removeRollbackEventHandler,
+    BlockProposed: removeBlockProposedEventHandler,
+    CommittedToChallenge: removeCommittedToChallengeEventHandler,
+    NewCurrentProposer: removeNewCurrentProposerEventHandler,
+  },
+};
 
 export {
+  subscribeToEvents,
   subscribeToBlockProposedEvent,
-  blockProposedEventHandler,
   subscribeToNewCurrentProposer,
-  newCurrentProposerEventHandler,
   subscribeToTransactionSubmitted,
-  transactionSubmittedEventHandler,
   subscribeToBlockAssembledWebSocketConnection,
   subscribeToRollbackEventHandler,
   subscribeToChallengeWebSocketConnection,
-  rollbackEventHandler,
   subscribeTocommittedToChallengeEventHandler,
-  committedToChallengeEventHandler,
+  subscribeToChainReorgEventHandler,
+  newCurrentProposerEventHandler,
+  eventHandlers,
 };

--- a/nightfall-optimist/src/event-handlers/subscribe.mjs
+++ b/nightfall-optimist/src/event-handlers/subscribe.mjs
@@ -77,6 +77,20 @@ export async function waitForContract(contractName) {
   return instance;
 }
 
+export async function subscribeToEvents(callback, arg) {
+  const emitterState = (await waitForContract(STATE_CONTRACT_NAME)).events.allEvents();
+  const emitterShield = (await waitForContract(SHIELD_CONTRACT_NAME)).events.allEvents();
+  const emitterChallenges = (await waitForContract(CHALLENGES_CONTRACT_NAME)).events.allEvents();
+  emitterState.on('changed', event => callback(event, arg));
+  emitterShield.on('changed', event => callback(event, arg));
+  emitterChallenges.on('changed', event => callback(event, arg));
+  emitterState.on('data', event => callback(event, arg));
+  emitterShield.on('data', event => callback(event, arg));
+  emitterChallenges.on('data', event => callback(event, arg));
+  logger.debug('Subscribed to layer 2 state events');
+  return { emitterState, emitterShield, emitterChallenges };
+}
+
 export async function subscribeToBlockProposedEvent(callback, ...args) {
   const emitter = (await waitForContract(STATE_CONTRACT_NAME)).events.BlockProposed();
   emitter.on('data', event => callback(event, args));
@@ -110,6 +124,19 @@ export async function subscribeToRollbackEventHandler(callback, ...args) {
   emitter.on('data', event => callback(event, args));
   logger.debug('Subscribed to Rollback event');
   return emitter;
+}
+
+export async function subscribeToChainReorgEventHandler(callback, arg) {
+  const emitterState = (await waitForContract(STATE_CONTRACT_NAME)).allEvents();
+  const emitterShield = (await waitForContract(SHIELD_CONTRACT_NAME)).allEvents();
+  const emitterProposers = (await waitForContract(PROPOSERS_CONTRACT_NAME)).allEvents();
+  const emitterChallenges = (await waitForContract(CHALLENGES_CONTRACT_NAME)).allEvents();
+  emitterState.on('changed', event => callback(event, arg));
+  emitterShield.on('changed', event => callback(event, arg));
+  emitterProposers.on('changed', event => callback(event, arg));
+  emitterChallenges.on('changed', event => callback(event, arg));
+  logger.debug('Subscribed to chain reorganisation event');
+  return { emitterState, emitterShield, emitterProposers, emitterChallenges };
 }
 
 export async function subscribeToChallengeWebSocketConnection(callback, ...args) {

--- a/nightfall-optimist/src/index.mjs
+++ b/nightfall-optimist/src/index.mjs
@@ -1,18 +1,12 @@
 import logger from './utils/logger.mjs';
 import app from './app.mjs';
 import {
-  subscribeToBlockProposedEvent,
-  blockProposedEventHandler,
+  subscribeToEvents,
   subscribeToNewCurrentProposer,
-  newCurrentProposerEventHandler,
-  subscribeToTransactionSubmitted,
-  transactionSubmittedEventHandler,
   subscribeToBlockAssembledWebSocketConnection,
-  subscribeToRollbackEventHandler,
   subscribeToChallengeWebSocketConnection,
-  rollbackEventHandler,
-  subscribeTocommittedToChallengeEventHandler,
-  committedToChallengeEventHandler,
+  newCurrentProposerEventHandler,
+  eventHandlers,
 } from './event-handlers/index.mjs';
 import Proposer from './classes/proposer.mjs';
 import {
@@ -21,6 +15,7 @@ import {
 } from './services/block-assembler.mjs';
 import { setChallengeWebSocketConnection } from './services/challenges.mjs';
 import { initialBlockSync } from './services/state-sync.mjs';
+import buffer from './services/event-buffer.mjs';
 
 const main = async () => {
   try {
@@ -37,10 +32,7 @@ const main = async () => {
     // we do not wait for the initial block sync for these event handlers
     // as we want to still listen to incoming events (just not make blocks)
     // subscribe to blockchain events
-    subscribeToBlockProposedEvent(blockProposedEventHandler);
-    subscribeToTransactionSubmitted(transactionSubmittedEventHandler);
-    subscribeToRollbackEventHandler(rollbackEventHandler);
-    subscribeTocommittedToChallengeEventHandler(committedToChallengeEventHandler);
+    subscribeToEvents(buffer, eventHandlers);
     app.listen(80);
   } catch (err) {
     logger.error(err);

--- a/nightfall-optimist/src/services/check-block.mjs
+++ b/nightfall-optimist/src/services/check-block.mjs
@@ -36,9 +36,20 @@ async function checkBlock(block, transactions) {
   // Timber with its optimistic extensions.
   logger.debug(`Checking block with leafCount ${block.leafCount}`);
   await new Promise(resolve => setTimeout(resolve, 1000));
-  const history = await getTreeHistoryByCurrentLeafCount(block.leafCount);
-  logger.debug(`Retrieved history from Timber`);
-  logger.silly(`Timber history was ${JSON.stringify(history, null, 2)}`);
+  // There's a bit of an issue here though.  It's possible that our block didn't
+  // add any new leaves to Timber if it's a block with just withdrawals in.
+  // In this case, Timber won't update its DB and consequently won't write a
+  // new history. To check the block in this case, we make sure the root isn't
+  // changed from the previous block.
+  let history; // this could end up being a Block or Timber history object - as they both have root properties, that's fine.
+  if (block.nCommitments === 0) {
+    history = await getBlockByBlockNumberL2(block.blockNumberL2 - 1);
+    logger.debug('Block has no commitments - checking its root is the same as the previous block');
+  } else {
+    history = await getTreeHistoryByCurrentLeafCount(block.leafCount);
+    logger.debug(`Block has commitments - retrieved history from Timber`);
+    logger.silly(`Timber history was ${JSON.stringify(history, null, 2)}`);
+  }
   if (history.root !== block.root)
     throw new BlockError(
       `The block's root (${block.root}) cannot be reconstructed from the commitment hashes in the transactions in this block and the historic Frontier held by Timber for this root`,
@@ -64,7 +75,6 @@ async function checkBlock(block, transactions) {
   // to check a block against itself (hence the second filter).
   const storedMinedNullifiers = await retrieveMinedNullifiers(); // List of Nullifiers stored by blockProposer
   const blockNullifiers = transactions.map(tNull => tNull.nullifiers).flat(Infinity); // List of Nullifiers in block
-  console.log('MINED NULLIFIERS', storedMinedNullifiers, blockNullifiers);
   const alreadyMinedNullifiers = storedMinedNullifiers
     .filter(sNull => blockNullifiers.includes(sNull.hash))
     .filter(aNull => aNull.blockHash !== block.blockHash);

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -76,11 +76,9 @@ export async function isChallengerAddressMine(address) {
 /**
 function to save a block, so that we can later search the block, for example to
 find which block a transaction went into. Note, we'll save all blocks, that get
-posted to the blockchain, not just ours, although that may not be needed (but
-they're small).
+posted to the blockchain, not just ours.
 */
 export async function saveBlock(_block) {
-  // const block = { ..._block, check: false };
   const block = { _id: _block.blockHash, ..._block };
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -151,12 +151,22 @@ export async function deleteBlock(blockHash) {
 }
 
 /**
-function to delete blocks with a layer 2 blockNumber >= blockNumberL2
+function to delete blocks with a layer 2 block number >= blockNumberL2
 */
 export async function deleteBlocksFromBlockNumberL2(blockNumberL2) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   const query = { blockNumberL2: { $gte: Number(blockNumberL2) } };
+  return db.collection(SUBMITTED_BLOCKS_COLLECTION).deleteMany(query);
+}
+
+/**
+function to delete blocks with a layer 1 block number >= blockNumber
+*/
+export async function deleteBlocksFromBlockNumberL1(blockNumber) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  const query = { blockNumber: { $gte: Number(blockNumber) } };
   return db.collection(SUBMITTED_BLOCKS_COLLECTION).deleteMany(query);
 }
 
@@ -297,13 +307,21 @@ export async function deleteTransferAndWithdraw(transactionHashes) {
   return db.collection(TRANSACTIONS_COLLECTION).deleteMany(query);
 }
 
-export async function saveNullifiers(nullifiers) {
+export async function deleteTransactionsFromBlockNumberL1(blockNumber) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  const query = { blockNumber: { $gte: Number(blockNumber) } };
+  return db.collection(TRANSACTIONS_COLLECTION).deleteMany(query);
+}
+
+export async function saveNullifiers(nullifiers, blockNumber) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   const indexNullifiers = nullifiers.map(n => {
     return {
       hash: n,
       blockHash: null,
+      blockNumber,
     };
   });
   return db.collection(NULLIFIER_COLLECTION).insertMany(indexNullifiers);
@@ -349,6 +367,13 @@ export async function deleteNullifiers(blockHash) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   const query = { blockHash };
+  return db.collection(NULLIFIER_COLLECTION).deleteMany(query);
+}
+
+export async function deleteNullifiersFromBlockNumberL1(blockNumber) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  const query = { blockNumber: { $gte: Number(blockNumber) } };
   return db.collection(NULLIFIER_COLLECTION).deleteMany(query);
 }
 

--- a/nightfall-optimist/src/services/event-buffer.mjs
+++ b/nightfall-optimist/src/services/event-buffer.mjs
@@ -1,0 +1,41 @@
+/**
+If we're changing the layer 2 state, we want to make sure that we can complete
+that change before the state is further altered by incoming events.  A good
+example is when we are deleting the current state. If the new state gets added
+while we're deleting, we may delete state that we didn't want deleted.
+We achieve that here by queuing events and processing them one after the other
+in the strict order that they are received.
+*/
+import Queue from 'queue';
+import config from 'config';
+import logger from '../utils/logger.mjs';
+
+const { MAX_QUEUE } = config;
+const eventQueue = new Queue({ autostart: true, concurrency: 1 });
+
+async function buffer(eventObject, eventHandlers) {
+  // handlers contains the functions needed to handle particular types of event,
+  // including removal of events when a chain reorganisation happens
+  if (!eventHandlers[eventObject.event]) {
+    logger.debug(`Unknown event ${eventObject.event} ignored`);
+    return;
+  }
+  logger.info(`Queued event ${eventObject.event}`);
+  // if the event was removed then we have a chain reorg and need to reset our
+  // layer 2 state accordingly.
+  if (eventObject.removed) {
+    if (!eventHandlers.removers[eventObject.event]) {
+      logger.debug(`Unknown event removal ${eventObject.event} ignored`);
+      return;
+    }
+    eventQueue.push(() =>
+      eventHandlers.removers[eventObject.event](eventObject, eventHandlers, eventQueue),
+    );
+    // otherwise queue the event for processing.
+  } else eventQueue.push(() => eventHandlers[eventObject.event](eventObject));
+  // the queue shouldn't get too long if we're keeping up with the blockchain.
+  if (eventQueue.length > MAX_QUEUE)
+    logger.warn(`The event queue has more than ${MAX_QUEUE} events`);
+}
+
+export default buffer;

--- a/test/chain-reorg.mjs
+++ b/test/chain-reorg.mjs
@@ -1,0 +1,264 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import chaiAsPromised from 'chai-as-promised';
+import gen from 'general-number';
+import WebSocket from 'ws';
+import sha256 from '../nightfall-client/src/utils/crypto/sha256.mjs';
+import {
+  closeWeb3Connection,
+  submitTransaction,
+  connectWeb3,
+  getAccounts,
+  getBalance,
+  topicEventMapping,
+} from './utils.mjs';
+
+const { expect } = chai;
+chai.use(chaiHttp);
+chai.use(chaiAsPromised);
+
+const { GN } = gen;
+
+describe('Testing the http API', () => {
+  let shieldAddress;
+  let stateAddress;
+  let proposersAddress;
+  let challengesAddress;
+  let ercAddress;
+  let connection; // WS connection
+  let blockSubmissionFunction;
+  const zkpPrivateKey = '0xc05b14fa15148330c6d008814b0bdd69bc4a08a1bd0b629c42fa7e2c61f16739'; // the zkp private key we're going to use in the tests.
+  const zkpPublicKey = sha256([new GN(zkpPrivateKey)]).hex();
+  const url = 'http://localhost:8080';
+  const optimistUrl = 'http://localhost:8081';
+  const optimistWsUrl = 'ws:localhost:8082';
+  const tokenId = '0x01';
+  const value = 10;
+  // this is the etherum private key for the test account in openethereum
+  const privateKey = '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d';
+  const gas = 10000000;
+  // this is the openethereum test account (but could be anything)
+  const recipientAddress = '0x00a329c0648769a73afac7f9381e08fb43dbea72';
+  // this is what we pay the proposer for incorporating a transaction
+  const fee = 1;
+  const BLOCK_STAKE = 1000000000000000000; // 1 ether
+  const txPerBlock = 2;
+  const eventLogs = [];
+
+  before(async () => {
+    const web3 = await connectWeb3();
+
+    shieldAddress = (await chai.request(url).get('/contract-address/Shield')).body.address;
+
+    stateAddress = (await chai.request(url).get('/contract-address/State')).body.address;
+
+    proposersAddress = (await chai.request(url).get('/contract-address/Proposers')).body.address;
+
+    challengesAddress = (await chai.request(url).get('/contract-address/Challenges')).body.address;
+
+    web3.eth.subscribe('logs', { address: stateAddress }).on('data', log => {
+      // For event tracking, we use only care about the logs related to 'blockProposed'
+      if (log.topics[0] === topicEventMapping.BlockProposed) eventLogs.push('blockProposed');
+    });
+
+    connection = new WebSocket(optimistWsUrl);
+    connection.onopen = () => {
+      connection.send('challenge');
+      connection.send('blocks');
+    };
+    connection.onmessage = async message => {
+      const msg = JSON.parse(message.data);
+      const { type, txDataToSign } = msg;
+      if (type === 'block') {
+        await blockSubmissionFunction(txDataToSign, privateKey, stateAddress, gas, BLOCK_STAKE);
+      } else {
+        await submitTransaction(txDataToSign, privateKey, challengesAddress, gas);
+      }
+    };
+  });
+
+  describe('Miscellaneous tests', () => {
+    it('should respond with status 200 to the health check', async () => {
+      const res = await chai.request(url).get('/healthcheck');
+      expect(res.status).to.equal(200);
+    });
+
+    it('should generate a new 256 bit zkp private key for a user', async () => {
+      const res = await chai.request(url).get('/generate-zkp-key');
+      expect(res.body.keyId).to.be.a('string');
+      // normally this value would be the private key for subsequent transactions
+      // however we use a fixed one (zkpPrivateKey) to make the tests more independent.
+    });
+
+    it('should get the address of the shield contract', async () => {
+      const res = await chai.request(url).get('/contract-address/Shield');
+      expect(res.body.address).to.be.a('string');
+      // subscribeToGasUsed(shieldAddress);
+    });
+
+    it('should get the address of the test ERC contract stub', async () => {
+      const res = await chai.request(url).get('/contract-address/ERCStub');
+      ercAddress = res.body.address;
+      expect(ercAddress).to.be.a('string');
+    });
+  });
+
+  describe('Basic Proposer tests', () => {
+    let txDataToSign;
+    it('should register a proposer', async () => {
+      const myAddress = (await getAccounts())[0];
+      const res = await chai
+        .request(optimistUrl)
+        .post('/proposer/register')
+        .send({ address: myAddress });
+      txDataToSign = res.body.txDataToSign;
+      expect(txDataToSign).to.be.a('string');
+      // we have to pay 10 ETH to be registered
+      const bond = 10000000000000000000;
+      const gasCosts = 5000000000000000;
+      const startBalance = await getBalance(myAddress);
+      // now we need to sign the transaction and send it to the blockchain
+      const receipt = await submitTransaction(
+        txDataToSign,
+        privateKey,
+        proposersAddress,
+        gas,
+        bond,
+      );
+      const endBalance = await getBalance(myAddress);
+      expect(receipt).to.have.property('transactionHash');
+      expect(receipt).to.have.property('blockHash');
+      expect(endBalance - startBalance).to.closeTo(-bond, gasCosts);
+      await chai.request(url).post('/peers/addPeers').send({
+        address: myAddress,
+        enode: 'http://optimist:80',
+      });
+    });
+  });
+
+  describe('Deposit tests', () => {
+    // blocks should be directly submitted to the blockchain, not queued
+    blockSubmissionFunction = (a, b, c, d, e) => submitTransaction(a, b, c, d, e);
+    // Need at least 5 deposits to perform all the necessary transfers
+    // set the number of deposit transactions blocks to perform.
+    const numDeposits = 1;
+    it('should deposit some crypto into a ZKP commitment', async () => {
+      // We create enough transactions to fill numDeposits blocks full of deposits.
+      const depositTransactions = (
+        await Promise.all(
+          Array.from({ length: txPerBlock * numDeposits }, () =>
+            chai
+              .request(url)
+              .post('/deposit')
+              .send({ ercAddress, tokenId, value, zkpPrivateKey, fee }),
+          ),
+        )
+      ).map(res => res.body);
+      depositTransactions.forEach(({ txDataToSign }) => expect(txDataToSign).to.be.a('string'));
+      const receiptArrays = [];
+      for (let i = 0; i < depositTransactions.length; i++) {
+        const { txDataToSign } = depositTransactions[i];
+        receiptArrays.push(
+          // eslint-disable-next-line no-await-in-loop
+          await submitTransaction(txDataToSign, privateKey, shieldAddress, gas, fee),
+          // we need to await here as we need transactions to be submitted sequentially or we run into nonce issues.
+        );
+      }
+      receiptArrays.forEach(receipt => {
+        expect(receipt).to.have.property('transactionHash');
+        expect(receipt).to.have.property('blockHash');
+      });
+      const totalGas = receiptArrays.reduce((acc, { gasUsed }) => acc + Number(gasUsed), 0);
+      console.log(`     Average Gas used was ${Math.ceil(totalGas / (txPerBlock * numDeposits))}`);
+      // Wait until we see the right number of blocks appear
+      while (eventLogs.length !== numDeposits) {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise(resolve => setTimeout(resolve, 3000));
+      }
+      // Now we can empty the event queue
+      for (let i = 0; i < numDeposits; i++) {
+        eventLogs.shift();
+      }
+    });
+  });
+
+  describe('Withdraw tests', () => {
+    const numWithdraws = 1;
+    it('should withdraw some crypto from a ZKP commitment', async () => {
+      const withdrawTransactions = (
+        await Promise.all(
+          Array.from({ length: txPerBlock * numWithdraws }, () =>
+            chai.request(url).post('/withdraw').send({
+              ercAddress,
+              tokenId,
+              value,
+              zkpPrivateKey,
+              senderZkpPrivateKey: zkpPrivateKey,
+              recipientAddress,
+            }),
+          ),
+        )
+      ).map(wRes => wRes.body);
+      withdrawTransactions.forEach(({ txDataToSign }) => expect(txDataToSign).to.be.a('string'));
+      for (let i = 0; i < withdrawTransactions.length; i++) {
+        const { txDataToSign } = withdrawTransactions[i];
+        // eslint-disable-next-line no-await-in-loop
+        await submitTransaction(txDataToSign, privateKey, shieldAddress, gas, fee);
+      }
+      while (eventLogs.length !== numWithdraws) {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise(resolve => setTimeout(resolve, 3000));
+      }
+      // Now we can empty the event queue
+      for (let i = 0; i < numWithdraws; i++) {
+        eventLogs.shift();
+      }
+    });
+  });
+
+  // now we have some deposited tokens, we can transfer one of them:
+  describe('Single transfer tests', () => {
+    it('should transfer some crypto (back to us) using ZKP', async () => {
+      const res = await chai
+        .request(url)
+        .post('/transfer')
+        .send({
+          ercAddress,
+          tokenId,
+          recipientData: {
+            values: [value],
+            recipientZkpPublicKeys: [zkpPublicKey],
+          },
+          senderZkpPrivateKey: zkpPrivateKey,
+          fee,
+        });
+      expect(res.body.txDataToSign).to.be.a('string');
+      // now we need to sign the transaction and send it to the blockchain
+      const receipt = await submitTransaction(
+        res.body.txDataToSign,
+        privateKey,
+        shieldAddress,
+        gas,
+        fee,
+      );
+      expect(receipt).to.have.property('transactionHash');
+      expect(receipt).to.have.property('blockHash');
+      console.log(`     Gas used was ${Number(receipt.gasUsed)}`);
+
+      // Wait until we see the right number of blocks appear
+      const numSingles = 1;
+      while (eventLogs.length !== numSingles) {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise(resolve => setTimeout(resolve, 3000));
+      }
+      // Now we can empty the event queue
+      for (let i = 0; i < numSingles; i++) {
+        eventLogs.shift();
+      }
+    });
+  });
+  after(() => {
+    closeWeb3Connection();
+    connection.close();
+  });
+});

--- a/timber/src/merkle-tree-controller.mjs
+++ b/timber/src/merkle-tree-controller.mjs
@@ -215,6 +215,14 @@ async function getSiblingPathByLeafIndex(db, leafIndex) {
   return nodes;
 }
 
+async function calculateRootFromFrontier(db, frontier, leafIndex) {
+  logger.debug('src/merkle-tree-controller calculateRootFromFrontier()');
+  const metadataService = new MetadataService(db);
+  const { treeHeight } = await metadataService.getTreeHeight();
+  const root = await utilsMT.calculateRootFromFrontier(frontier, leafIndex, treeHeight);
+  return root;
+}
+
 const nodes = [];
 let hashCount = 0;
 async function updateNodes(node) {
@@ -436,6 +444,7 @@ export default {
   updateLatestLeaf,
   getPathByLeafIndex,
   getSiblingPathByLeafIndex,
+  calculateRootFromFrontier,
   update,
   getTreeHistory,
   getTreeHistoryByCurrentLeafCount,

--- a/timber/src/routes/merkle-tree.routes.mjs
+++ b/timber/src/routes/merkle-tree.routes.mjs
@@ -157,6 +157,34 @@ async function update(req, res, next) {
   }
 }
 
+/**
+ * Special function which calculates the root from a given frontier and the
+ * corresponding leafIndex of the right-most leaf at the time the frontier was * solidified.
+ * req.params {
+ *  frontier: [0x123abc, 0x234bcd, ... ],
+ *  leafIndex: 1234,
+ * }
+ * @param {*} req
+ * @param {*} res - returns the root
+ */
+async function calculateRootFromFrontier(req, res, next) {
+  logger.debug('src/routes/merkle-tree.routes calculateRootFromFrontier()');
+
+  const { db } = req.user;
+  const { frontier } = req.body;
+  let { leafIndex } = req.body;
+  leafIndex = Number(leafIndex); // force to number
+
+  try {
+    const root = await merkleTreeController.calculateRootFromFrontier(db, frontier, leafIndex);
+
+    res.data = { root };
+    next();
+  } catch (err) {
+    next(err);
+  }
+}
+
 async function getTreeHistory(req, res, next) {
   const { db } = req.user;
   const { root } = req.params;
@@ -201,6 +229,8 @@ export default router => {
   router.route('/start').post(startEventFilter);
 
   router.route('/update').patch(update);
+
+  router.get('/calculate-root-from-frontier', calculateRootFromFrontier);
 
   router.get('/siblingPath/:leafIndex', getSiblingPathByLeafIndex);
   router.get('/path/:leafIndex', getPathByLeafIndex);

--- a/timber/src/utils-web3.mjs
+++ b/timber/src/utils-web3.mjs
@@ -150,6 +150,7 @@ async function subscribeToEvent(
   responder,
   responseFunction,
   responseFunctionArgs = {},
+  removerFunction,
 ) {
   logger.info(`Subscribing to event...`);
   logger.info(`contractName: ${contractName}`);
@@ -233,6 +234,17 @@ async function subscribeToEvent(
 
     responder(eventObject, responseFunction, responseFunctionArgs);
   });
+  // we also need to listen for changes to events, which happens if we get a
+  // chain reorg that removes the event.
+  eventSubscription.on('changed', eventData => {
+    logger.info(`New ${contractName}, ${eventName}, event removed`);
+    const eventObject = {
+      eventData,
+      eventJsonInterface,
+    };
+    responder(eventObject, removerFunction, responseFunctionArgs);
+  });
+
   return eventSubscription;
 }
 


### PR DESCRIPTION
This PR pushes some updates that work towards coping with an Ethereum chain reorganisation.  It's not complete but it does already add some potentially useful features that are of interest in themselves. These are:

1) All incoming blockchain events are queued and processed serially in the order that they are received.  This is to prevent async races from changing the order that events are processed in.  Although this has not been an issue to date, it will likely become more of a problem when a chain reorganisation forces extensive re-writes of layer 2 state. For example, new events may be received while outdated layer 2 state is being deleted, and then the new events will be incorrectly removed.
2) A mutex has been added to `findUsableCommitments` calls to stop nightfall-client from attempting to spend the same commitment twice: an async race can cause a second call to nightfall-client to select a commitment that has not yet been marked as nullified by the first call.  To assist with this, the `markNullified` call has been moved into `findUsableCommitments`.
3) Two bugs have been fixed which prevented NF_3 from correctly handling blocks that have no commitments (only withdraw transactions).  Specifically: the `Block` class does not correctly compute a root and; Timber and Optimist do not agree on the leafCount.

 A few code changes (mainly the addition of a chain-reorg test) are not yet functioning.

To test, run `./setup-nightfall` first because some new packages need importing.