### PR TITLE
feat: /calculate-root-from-frontier

### DIFF
--- a/timber/src/merkle-tree-controller.mjs
+++ b/timber/src/merkle-tree-controller.mjs
@@ -215,6 +215,14 @@ async function getSiblingPathByLeafIndex(db, leafIndex) {
   return nodes;
 }
 
+async function calculateRootFromFrontier(db, frontier, leafIndex) {
+  logger.debug('src/merkle-tree-controller calculateRootFromFrontier()');
+  const metadataService = new MetadataService(db);
+  const { treeHeight } = await metadataService.getTreeHeight();
+  const root = await utilsMT.calculateRootFromFrontier(frontier, leafIndex, treeHeight);
+  return root;
+}
+
 const nodes = [];
 let hashCount = 0;
 async function updateNodes(node) {
@@ -436,6 +444,7 @@ export default {
   updateLatestLeaf,
   getPathByLeafIndex,
   getSiblingPathByLeafIndex,
+  calculateRootFromFrontier,
   update,
   getTreeHistory,
   getTreeHistoryByCurrentLeafCount,

--- a/timber/src/routes/merkle-tree.routes.mjs
+++ b/timber/src/routes/merkle-tree.routes.mjs
@@ -157,6 +157,34 @@ async function update(req, res, next) {
   }
 }
 
+/**
+ * Special function which calculates the root from a given frontier and the
+ * corresponding leafIndex of the right-most leaf at the time the frontier was * solidified.
+ * req.params {
+ *  frontier: [0x123abc, 0x234bcd, ... ],
+ *  leafIndex: 1234,
+ * }
+ * @param {*} req
+ * @param {*} res - returns the root
+ */
+async function calculateRootFromFrontier(req, res, next) {
+  logger.debug('src/routes/merkle-tree.routes calculateRootFromFrontier()');
+
+  const { db } = req.user;
+  const { frontier } = req.body;
+  let { leafIndex } = req.body;
+  leafIndex = Number(leafIndex); // force to number
+
+  try {
+    const root = await merkleTreeController.calculateRootFromFrontier(db, frontier, leafIndex);
+
+    res.data = { root };
+    next();
+  } catch (err) {
+    next(err);
+  }
+}
+
 async function getTreeHistory(req, res, next) {
   const { db } = req.user;
   const { root } = req.params;
@@ -201,6 +229,8 @@ export default router => {
   router.route('/start').post(startEventFilter);
 
   router.route('/update').patch(update);
+
+  router.get('/calculate-root-from-frontier', calculateRootFromFrontier);
 
   router.get('/siblingPath/:leafIndex', getSiblingPathByLeafIndex);
   router.get('/path/:leafIndex', getPathByLeafIndex);


### PR DESCRIPTION
Code to calculate the merkle tree root from a frontier and its corresponding leafIndex.

See here (https://github.com/EYBlockchain/timber/pull/71) for manual postman tests that were run. (Postman tests were used because of familiarity and time constraints).

*Code has not been tested in the context of this monorepo; only in the context of the timber repo*.

Example GET request:
```js
req.body = {
     frontier: [0x123abc, 0x234bcd, ... ],
     leafIndex: 1234,
}
```




