### PR TITLE
Improve deregister proposer code

### DIFF
--- a/nightfall-deployer/contracts/Challenges.sol
+++ b/nightfall-deployer/contracts/Challenges.sol
@@ -260,8 +260,7 @@ contract Challenges is Stateful, Key_Registry, Config {
     // blocks
     removeBlockHashes(badBlockNumberL2);
     // remove the proposer and give the proposer's block stake to the challenger
-    state.removeProposer(badBlock.proposer);
-    state.addPendingWithdrawal(msg.sender, BLOCK_STAKE);
+    state.rewardChallenger(msg.sender, badBlock.proposer);
 
     // TODO repay the fees of the transactors and any escrowed funds held by the
     // Shield contract.

--- a/nightfall-deployer/contracts/Structures.sol
+++ b/nightfall-deployer/contracts/Structures.sol
@@ -65,4 +65,9 @@ contract Structures {
     address previousAddress;
     address nextAddress;
   }
+
+  struct TimeLockedBond {
+    uint256 amount; // The amount held
+    uint256 time; // The time the funds were locked from
+  }
 }

--- a/nightfall-optimist/src/routes/proposer.mjs
+++ b/nightfall-optimist/src/routes/proposer.mjs
@@ -77,6 +77,22 @@ router.post('/de-register', async (req, res, next) => {
 });
 
 /**
+ * Function to withdraw bond for a de-registered proposer
+ */
+
+router.post('/withdrawBond', async (req, res, next) => {
+  logger.debug(`withdrawBond endpoint received GET`);
+  try {
+    const stateContractInstance = await getContractInstance(PROPOSERS_CONTRACT_NAME);
+    const txDataToSign = await stateContractInstance.methods.withdrawBond().encodeABI();
+    res.json({ txDataToSign });
+  } catch (error) {
+    logger.error(error);
+    next(error);
+  }
+});
+
+/**
  * Function to withdraw funds owing to an account.  This could be profits made
  * Through a successful challenge or proposing state updates. This just
  * provides the tx data, the user will need to call the blockchain client.

--- a/nightfall-optimist/src/routes/proposer.mjs
+++ b/nightfall-optimist/src/routes/proposer.mjs
@@ -47,8 +47,20 @@ router.post('/register', async (req, res, next) => {
 router.get('/proposers', async (req, res, next) => {
   logger.debug(`list proposals endpoint received GET ${JSON.stringify(req.body, null, 2)}`);
   try {
-    const proposersContractInstance = await getContractInstance(PROPOSERS_CONTRACT_NAME);
-    const proposers = await proposersContractInstance.methods.getProposers().call();
+    const proposersContractInstance = await getContractInstance(STATE_CONTRACT_NAME);
+    // proposers is an on-chain mapping so to get proposers we need to key to start iterating
+    // the safest to start with is the currentProposer
+    const currentProposer = await proposersContractInstance.methods.currentProposer().call();
+    const proposers = [];
+    let thisPtr = currentProposer.thisAddress;
+    // Loop through the circular list until we run back into the currentProposer.
+    do {
+      // eslint-disable-next-line no-await-in-loop
+      const proposer = await proposersContractInstance.methods.proposers(thisPtr).call();
+      proposers.push(proposer);
+      thisPtr = proposer.thisAddress;
+    } while (thisPtr !== currentProposer.thisAddress);
+
     logger.debug('returning raw transaction data');
     logger.silly(`raw transaction is ${JSON.stringify(proposers, null, 2)}`);
     res.json({ proposers });


### PR DESCRIPTION
This closes #98 as well as the comments in that issue.

This PR improves the handling of deregistering proposers:

1. In `deRegisterProposer`, we rotate proposer if the `currentProposer` is being deregistered and now correctly un-splice the deregistering proposer from the linked list.

2. A new `TimeLockedBond` struct is used to hold the bond of deregistering proposers that are waiting out the challenge period.

3. Bonds are now withdrawn using `withdrawBond` that checks that enough time has passed before a withdraw can be processed. A new api endpoint in `optimist` is used to trigger this.