### PR TITLE
Move funds to State contract

### DIFF
--- a/nightfall-deployer/contracts/Proposers.sol
+++ b/nightfall-deployer/contracts/Proposers.sol
@@ -30,6 +30,7 @@ contract Proposers is Stateful, Structures, Config {
   //add the proposer to the circular linked list
   function registerProposer() external payable {
     require(REGISTRATION_BOND == msg.value, 'The registration payment is incorrect');
+    payable(address(state)).transfer(REGISTRATION_BOND);
     LinkedAddress memory currentProposer = state.getCurrentProposer();
     // cope with this being the first proposer
     if (currentProposer.thisAddress == address(0)) {

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -34,6 +34,7 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
     // slow down or stop our transaction)
     bytes32 transactionHash = Utils.hashTransaction(t);
     if (feeBook[transactionHash] < msg.value) feeBook[transactionHash] = msg.value;
+    payable(address(state)).transfer(msg.value);
   }
 
   // function to enable a proposer to get paid for proposing a block
@@ -50,6 +51,7 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
       payment += feeBook[transactionHash];
       feeBook[transactionHash] = 0; // clear the payment
     }
+    payment += BLOCK_STAKE;
     state.addPendingWithdrawal(msg.sender, payment);
   }
 

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -41,6 +41,10 @@ contract State is Structures, Config {
       _;
   }
 
+  receive() external payable{
+    //fallback for payable
+  }
+
   /**
   * Allows a Proposer to propose a new block of state updates.
   * @param b the block being proposed.  This function is kept in State.sol

--- a/nightfall-deployer/contracts/Stateful.sol
+++ b/nightfall-deployer/contracts/Stateful.sol
@@ -26,7 +26,7 @@ abstract contract Stateful {
   }
 
   // point this contract at its global state.
-  function setStateContract(address stateAddress) external onlyOnce {
+  function setStateContract(address payable stateAddress) external onlyOnce {
     state = State(stateAddress);
   }
 }


### PR DESCRIPTION
This PR transfers funds collected in `Proposers` and `Shield` to `State` as this is where withdrawals ultimately take place.

In contrast to past conversations, I've changed from low-level calls  to transferring the funds in the `submitTransaction` and `registerProposer` functions directly. 

This has the smallest impact to the existing code base, a lower gas cost than direct `address.call` (~5k gas per call), does not require additional modifiers and doesn't require passing along `msg.sender` for some `registerProposer`.

The only tradeoff is that the `State` contract can now be paid to - which is only a problem if a 'paying' transaction is incorrectly sent to it.

There is also a new test in `http` that checks that the balances in `Shield` and `Proposers` are zero and the funds are now in `State`.