### PR TITLE
Fix current race condition in handler

### DIFF
--- a/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
+++ b/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
@@ -26,7 +26,7 @@ async function newCurrentProposerEventHandler(data, args) {
 
     // If we were the last proposer return any transactions that were removed from the mempool
     // because they were included in proposed blocks that did not eventually make it on chain.
-    if (weWereLastProposer) {
+    if (weWereLastProposer && !proposer.isMe) {
       const stateContractInstance = await getContractInstance(STATE_CONTRACT_NAME);
       const onChainBlockCount = Number(
         await stateContractInstance.methods.getNumberOfL2Blocks().call(),


### PR DESCRIPTION
This will fix the current race condition in the proposer handler.

The issue manifests in the test as async block assembler may race the new event queue.

A longer term solution will look to enqueue the block assembler into the event queue as well