### PR TITLE
Add entrypoint script to timber

### DIFF
--- a/config/timber.js
+++ b/config/timber.js
@@ -72,7 +72,7 @@ module.exports = {
 
   // web3:
   web3: {
-    host: process.env.BLOCKCHAIN_HOST,
+    host: process.env.BLOCKCHAIN_WS_HOST,
     port: process.env.BLOCKCHAIN_PORT,
 
     options: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,8 +146,11 @@ services:
       - type: bind
         source: ./config/timber.js
         target: /app/config/default.js
+      - type: bind
+        source: ./timber/entrypoint.sh
+        target: /app/entrypoint.sh
     environment:
-      BLOCKCHAIN_HOST: ws://blockchain1
+      BLOCKCHAIN_WS_HOST: blockchain1
       BLOCKCHAIN_PORT: 8546
       MONGO_HOST: timber-database
       MONGO_PORT: 27017

--- a/timber/Dockerfile
+++ b/timber/Dockerfile
@@ -1,12 +1,15 @@
 FROM node:14.17
 
 WORKDIR /app
-
+RUN apt-get update -y
+RUN apt-get install -y netcat-openbsd
 COPY ./package.json ./package-lock.json ./.npmrc ./
 COPY ./src ./src
+COPY entrypoint.sh entrypoint.sh
+RUN chmod +x entrypoint.sh
 # ARG GPR_TOKEN
 RUN npm ci
 RUN rm -f .npmrc
 
 EXPOSE 80
-CMD npm start
+ENTRYPOINT ["./entrypoint.sh"]

--- a/timber/entrypoint.sh
+++ b/timber/entrypoint.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+# wait until there's a blockchain client up
+while ! nc -z ${BLOCKCHAIN_WS_HOST} ${BLOCKCHAIN_PORT}; do sleep 3; done
+
+#sleep 10
+
+npm start

--- a/timber/src/web3.mjs
+++ b/timber/src/web3.mjs
@@ -21,7 +21,7 @@ export default {
 
     logger.info('Blockchain Connecting ...');
     const provider = new Web3.providers.WebsocketProvider(
-      `${config.web3.host}:${config.web3.port}`,
+      `ws://${config.web3.host}:${config.web3.port}`,
       null,
       config.web3.options,
     );


### PR DESCRIPTION
This fixes a potential race condition where the `timber` come up before the `blockchain1` container. This may cause `timber` to crash as it expects a blockchain provider to be available.