### PR TITLE
feat: add another miner, improved start script

### DIFF
--- a/docker-compose.geth.yml
+++ b/docker-compose.geth.yml
@@ -47,17 +47,35 @@ services:
     command:
       --ws.port 8546 --ws --ws.origins '*' --ws.addr 0.0.0.0 --verbosity 2
 
-  blockchain-miner:
+  blockchain-miner1:
     image: ethereum/client-go:stable
     volumes:
       - type: bind
         source: ./config/geth
         target: /setup
       - type: volume
-        source: geth-miner-chain
+        source: geth-miner-chain1
         target: /data
       - type: volume
-        source: dag
+        source: dag1
+        target: /dag
+    networks:
+      nightfall_network:
+    entrypoint: /setup/entrypoint.sh
+    command:
+      --ws.port 8546 --ws --ws.origins '*' --ws.addr 0.0.0.0 --mine --verbosity 2
+
+  blockchain-miner2:
+    image: ethereum/client-go:stable
+    volumes:
+      - type: bind
+        source: ./config/geth
+        target: /setup
+      - type: volume
+        source: geth-miner-chain2
+        target: /data
+      - type: volume
+        source: dag2
         target: /dag
     networks:
       nightfall_network:
@@ -84,5 +102,7 @@ services:
 volumes:
   geth1-chain:
   geth2-chain:
-  geth-miner-chain:
-  dag:
+  geth-miner-chain1:
+  dag1:
+  geth-miner-chain2:
+  dag2:

--- a/start-nightfall
+++ b/start-nightfall
@@ -29,39 +29,60 @@ while [ "$1" != "" ]; do
   shift
 done
 
+# shut down cleanly in the event of a cntl-c etc. We don't want to leave containers running
+trap "docker-compose -f docker-compose.yml $FILE down --remove-orphans -t 1; exit 1" SIGHUP SIGINT SIGTERM
+
 docker-compose -f docker-compose.yml $FILE down --remove-orphans
 
 # if-else block checks - volume exist and then removes it.
 if [[ $(echo $VOLUME_LIST | grep nightfall_3_timber-database-volume) ]]; then
+  echo -n 'Removing '
   docker volume rm nightfall_3_timber-database-volume
 fi
 
 if [[ $(echo $VOLUME_LIST | grep nightfall_3_mongodb) ]]; then
+  echo -n 'Removing '
   docker volume rm nightfall_3_mongodb
 fi
 
 if [[ $(echo $VOLUME_LIST | grep nightfall_3_build) ]]; then
+  echo -n 'Removing '
   docker volume rm nightfall_3_build
 fi
 
 if [[ $(echo $VOLUME_LIST | grep nightfall_3_geth1-chain) ]]; then
+  echo -n 'Removing '
   docker volume rm nightfall_3_geth1-chain
 fi
 
 if [[ $(echo $VOLUME_LIST | grep nightfall_3_geth2-chain) ]]; then
+  echo -n 'Removing '
   docker volume rm nightfall_3_geth2-chain
 fi
 
-if [[ $(echo $VOLUME_LIST | grep nightfall_3_geth-miner-chain) ]]; then
-  docker volume rm nightfall_3_geth-miner-chain
+if [[ $(echo $VOLUME_LIST | grep nightfall_3_geth-miner-chain1) ]]; then
+  echo -n 'Removing '
+  docker volume rm nightfall_3_geth-miner-chain1
 fi
-if [[ $(echo $VOLUME_LIST | grep nightfall_3_dag) ]]; then
-  docker volume rm nightfall_3_dag
+
+if [[ $(echo $VOLUME_LIST | grep nightfall_3_dag1) ]]; then
+  echo -n 'Removing '
+  docker volume rm nightfall_3_dag1
+fi
+
+if [[ $(echo $VOLUME_LIST | grep nightfall_3_geth-miner-chain2) ]]; then
+  echo -n 'Removing '
+  docker volume rm nightfall_3_geth-miner-chain2
+fi
+
+if [[ $(echo $VOLUME_LIST | grep nightfall_3_dag2) ]]; then
+  echo -n 'Removing '
+  docker volume rm nightfall_3_dag2
 fi
 
 DIR=./common-files/node_modules
 if [[ -d "$DIR" ]]; then
   rm -dr common-files/node_modules
 fi
-docker-compose -f docker-compose.yml $FILE up -d deployer
+#docker-compose -f docker-compose.yml $FILE up -d deployer
 docker-compose -f docker-compose.yml $FILE up


### PR DESCRIPTION
A small PR that adds a second miner to the Geth private test network.  This will be required for testing chain-reorgs so that we can continue to mine if half of the nodes are paused.

It also adds a `trap` to `./start-nightfall` which ensures any running containers are removed if cntl-c is pressed (or another linux stop signal is received.  Without this, it's possible (but not common) to stop the application but leave containers running, which puts an unnecessary load on ones CPU.