### PR TITLE
fix: mutex now awaits markNullified function

### DIFF
--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -115,7 +115,7 @@ async function findUsableCommitments(zkpPublicKey, ercAddress, tokenId, _value, 
   );
   if (singleCommitment) {
     logger.info('Found commitment suitable for single transfer or withdraw');
-    markNullified(singleCommitment);
+    await markNullified(singleCommitment);
     return [singleCommitment];
   }
   // If we get here it means that we have not been able to find a single commitment that matches the required value
@@ -187,6 +187,7 @@ async function findUsableCommitments(zkpPublicKey, ercAddress, tokenId, _value, 
     );
   }
   commitmentsToUse.forEach(commitment => markNullified(commitment));
+  await Promise.all(commitmentsToUse);
   return commitmentsToUse;
 }
 

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -186,8 +186,7 @@ async function findUsableCommitments(zkpPublicKey, ercAddress, tokenId, _value, 
       `Found commitments suitable for two-token transfer: ${JSON.stringify(commitmentsToUse)}`,
     );
   }
-  commitmentsToUse.forEach(commitment => markNullified(commitment));
-  await Promise.all(commitmentsToUse);
+  await Promise.all(commitmentsToUse.map(commitment => markNullified(commitment)));
   return commitmentsToUse;
 }
 


### PR DESCRIPTION
I recently added a mutex to prevent two concurrent calls to a nightfall-client endpoint both selecting the same commitment before it was marked nullified.  Unfortunately we do not await the `markNullified` promise before releasing the mutex.  This renders the mutex mostly ineffective because another process can run before the markNullified is complete. 

This PR fixes the bug by awaiting to the `markNullified`.