### PR TITLE
Update wording in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Nightfall_3 is an application for transferring ERC20, ERC721 and ERC1155 applications under Zero Knowledge.  It abstracts away any need to deal directly with ZKP artefacts and provides a simple token-transfer API.  When used correctly, it will hide the recipient and the token being transferred.
 
-Nightfall_3 uses optimisttic rollups to counter the high gas costs of direct ZKP transactions. It can complete a ZKP transfer for approximately 10 kGas (this will soon be reduced to 8 kGas with a pending update).  This compares with 700 kGas for the original Nightfall application. As a Layer 2 solution with on-chain data availability, Nightfall_3 can perform a  private transfer for less than half the cost of a public ERCx transfer whilst maintaining the security and consensus assumptions from the Ethereum Mainnet.
+Nightfall_3 uses optimistic rollups to counter the high gas costs of direct ZKP transactions. It can complete a ZKP transfer for approximately 10 kGas (this will soon be reduced to 8 kGas with a pending update).  This compares with 700 kGas for the original Nightfall application. As a Layer 2 solution with on-chain data availability, Nightfall_3 can perform a  private transfer for less than half the cost of a public ERCx transfer whilst maintaining the security and consensus assumptions from the Ethereum Mainnet.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Nightfall_3 is an application for transferring ERC20, ERC721 and ERC1155 applications under Zero Knowledge.  It abstracts away any need to deal directly with ZKP artefacts and provides a simple token-transfer API.  When used correctly, it will hide the recipient and the token being transferred.
 
-Nightfall_3 operates optimistically to counter the high gas costs of direct ZKP transactions.  It can complete a ZKP transfer for approximately 10 kGas (this will soon be reduced to 8 kGas with a pending update).  This compares with 700 kGas for the original Nightfall application. Using Nightfall_3 you can make a private transfer for less than half the cost of a public ERCx transfer, with no loss of decentralisation.
+Nightfall_3 uses optimisttic rollups to counter the high gas costs of direct ZKP transactions. It can complete a ZKP transfer for approximately 10 kGas (this will soon be reduced to 8 kGas with a pending update).  This compares with 700 kGas for the original Nightfall application. As a Layer 2 solution with on-chain data availability, Nightfall_3 can perform a  private transfer for less than half the cost of a public ERCx transfer whilst maintaining the security and consensus assumptions from the Ethereum Mainnet.
 
 ## Setup
 


### PR DESCRIPTION
The use of the word 'decentralisation' in this context is ambiguous. While the L2 chain **may** have less (although not guaranteed to be) block producers than the Ethereum mainnet, the properties of the optimistic rollup ensure that the network is still trustless.

The key property that on-chain data availability scaling solutions such as `Nightfall_3` have is that it inherits much of the key security and consensus properties from the Ethereum mainnet itself   - as opposed to `Validium-based` or sidechain solutions (which may roll their own).

The documentation is updated to reflect this. Closes #72 