### PR TITLE
Fix resyncing

### DIFF
--- a/nightfall-client/dropAll.sh
+++ b/nightfall-client/dropAll.sh
@@ -13,4 +13,4 @@ docker exec -t nightfall_3_optimist_1 bash -c \
     db.nullifiers.drop( { writeConcern: { w: \"majority\" } } );
     db.transactions.drop( { writeConcern: { w: \"majority\" } } );
     db.metadata.drop( { writeConcern: { w: \"majority\" } } );
-    db.metadata.insert( { \"_id\" : ObjectId(\"60913a97d2515d00e807ba07\"), \"proposer\" : \"0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1\" })"'
+    db.metadata.insert( { \"_id\" : ObjectId(\"60913a97d2515d00e807ba07\"), \"proposer\" : \"0x9C8B2276D490141Ae1440Da660E470E7C0349C63\" })"'

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -31,7 +31,7 @@ export async function storeCommitment(commitment, zkpPrivateKey) {
     _id: commitment.hash.hex(32),
     preimage: commitment.preimage.all.hex(32),
     isDeposited: commitment.isDeposited || false,
-    isOnChain: Number(commitment.isOnChain),
+    isOnChain: Number(commitment.isOnChain) || -1,
     isPendingNullification: false, // will not be pending when stored
     isNullified: commitment.isNullified,
     isNullifiedOnChain: Number(commitment.isNullifiedOnChain),
@@ -44,7 +44,7 @@ export async function storeCommitment(commitment, zkpPrivateKey) {
 // function to mark a commitments as on chain for a mongo db
 export async function markOnChain(commitments, blockNumberL2) {
   const connection = await mongo.connection(MONGO_URL);
-  const query = { _id: { $in: commitments } };
+  const query = { _id: { $in: commitments }, isOnChain: { $eq: -1 } };
   const update = { $set: { isOnChain: Number(blockNumberL2) } };
   const db = connection.db(COMMITMENTS_DB);
   return db.collection(COMMITMENTS_COLLECTION).updateMany(query, update);
@@ -121,7 +121,7 @@ export async function dropRollbackCommitments(blockNumberL2) {
 // function to mark a commitments as nullified on chain for a mongo db
 export async function markNullifiedOnChain(nullifiers, blockNumberL2) {
   const connection = await mongo.connection(MONGO_URL);
-  const query = { nullifier: { $in: nullifiers } };
+  const query = { nullifier: { $in: nullifiers }, isNullifiedOnChain: { $eq: -1 } };
   const update = { $set: { isNullifiedOnChain: Number(blockNumberL2) } };
   const db = connection.db(COMMITMENTS_DB);
   return db.collection(COMMITMENTS_COLLECTION).updateMany(query, update);
@@ -152,7 +152,6 @@ async function findUsableCommitments(zkpPublicKey, ercAddress, tokenId, _value, 
   const commitments = commitmentArray
     .filter(commitment => Number(commitment.isOnChain) > Number(-1)) // filters for on chain commitments
     .map(ct => new Commitment(ct.preimage));
-
   // if we have an exact match, we can do a single-commitment transfer.
   const [singleCommitment] = commitments.filter(c => c.preimage.value.hex(32) === value.hex(32));
   if (singleCommitment) {

--- a/nightfall-optimist/src/event-handlers/rollback.mjs
+++ b/nightfall-optimist/src/event-handlers/rollback.mjs
@@ -11,11 +11,8 @@ import {
   findBlocksFromBlockNumberL2,
   deleteNullifiers,
   deleteTransferAndWithdraw,
-  getMempoolTransactions,
-  deleteTransactionsByTransactionHashes,
 } from '../services/database.mjs';
 import Block from '../classes/block.mjs';
-// import checkTransaction from '../services/transaction-checker.mjs';
 
 async function rollbackEventHandler(data) {
   const { blockNumberL2 } = data.returnValues;
@@ -37,20 +34,6 @@ async function rollbackEventHandler(data) {
    event.
    Also delete nullifiers and the blocks that no longer exist.
   */
-
-  /*
-  Block State Rollback
-  1) Get all blocks from the L2 number - this is all blocks involved in the rollback
-  2) Collect all transactions in this block, splitting them between deposits and others.
-  3) All deposits are returned to the mempool : true;
-  4) All other transactions need to be re-checked for validity
-  5) These transactions and all transactions in the mempool need to be rechecked with timber, to ensure the commitments exist.
-  */
-
-  const mempool = await getMempoolTransactions();
-  const mempoolHashes = mempool.map(m => m.transactionHash);
-
-  await deleteTransactionsByTransactionHashes(mempoolHashes);
   return Promise.all(
     (await findBlocksFromBlockNumberL2(blockNumberL2))
       .map(async block => [

--- a/nightfall-optimist/src/event-handlers/rollback.mjs
+++ b/nightfall-optimist/src/event-handlers/rollback.mjs
@@ -11,8 +11,11 @@ import {
   findBlocksFromBlockNumberL2,
   deleteNullifiers,
   deleteTransferAndWithdraw,
+  getMempoolTransactions,
+  deleteTransactionsByTransactionHashes,
 } from '../services/database.mjs';
 import Block from '../classes/block.mjs';
+// import checkTransaction from '../services/transaction-checker.mjs';
 
 async function rollbackEventHandler(data) {
   const { blockNumberL2 } = data.returnValues;
@@ -34,6 +37,20 @@ async function rollbackEventHandler(data) {
    event.
    Also delete nullifiers and the blocks that no longer exist.
   */
+
+  /*
+  Block State Rollback
+  1) Get all blocks from the L2 number - this is all blocks involved in the rollback
+  2) Collect all transactions in this block, splitting them between deposits and others.
+  3) All deposits are returned to the mempool : true;
+  4) All other transactions need to be re-checked for validity
+  5) These transactions and all transactions in the mempool need to be rechecked with timber, to ensure the commitments exist.
+  */
+
+  const mempool = await getMempoolTransactions();
+  const mempoolHashes = mempool.map(m => m.transactionHash);
+
+  await deleteTransactionsByTransactionHashes(mempoolHashes);
   return Promise.all(
     (await findBlocksFromBlockNumberL2(blockNumberL2))
       .map(async block => [

--- a/nightfall-optimist/src/event-handlers/subscribe.mjs
+++ b/nightfall-optimist/src/event-handlers/subscribe.mjs
@@ -106,10 +106,12 @@ export async function subscribeToTransactionSubmitted(callback, ...args) {
 }
 
 export async function subscribeToNewCurrentProposer(callback, ...args) {
-  const emitter = (await waitForContract(PROPOSERS_CONTRACT_NAME)).events.NewCurrentProposer();
-  emitter.on('data', event => callback(event, args));
+  const emitterProp = (await waitForContract(PROPOSERS_CONTRACT_NAME)).events.NewCurrentProposer();
+  const emitterState = (await waitForContract(STATE_CONTRACT_NAME)).events.NewCurrentProposer();
+  emitterProp.on('data', event => callback(event, args));
+  emitterState.on('data', event => callback(event, args));
   logger.debug('Subscribed to NewCurrentProposer event');
-  return emitter;
+  return { emitterProp, emitterState };
 }
 
 export async function subscribeTocommittedToChallengeEventHandler(callback, ...args) {

--- a/nightfall-optimist/src/routes/proposer.mjs
+++ b/nightfall-optimist/src/routes/proposer.mjs
@@ -236,7 +236,6 @@ router.post('/encode', async (req, res, next) => {
     const newTransactions = await Promise.all(
       transactions.map(t => {
         const transaction = t;
-        logger.info(`/endoce Transactions: ${JSON.stringify(transaction)}`);
         transaction.transactionHash = Transaction.calcHash(transaction);
         return transaction;
       }),

--- a/nightfall-optimist/src/routes/proposer.mjs
+++ b/nightfall-optimist/src/routes/proposer.mjs
@@ -10,7 +10,7 @@ import logger from 'common-files/utils/logger.mjs';
 import { getContractInstance } from 'common-files/utils/contract.mjs';
 import Block from '../classes/block.mjs';
 import { Transaction, TransactionError } from '../classes/index.mjs';
-import { setRegisteredProposerAddress } from '../services/database.mjs';
+import { setRegisteredProposerAddress, getMempoolTransactions } from '../services/database.mjs';
 import { waitForContract } from '../event-handlers/subscribe.mjs';
 import { getFrontier, getLeafCount } from '../utils/timber.mjs';
 import transactionSubmittedEventHandler from '../event-handlers/transaction-submitted.mjs';
@@ -200,6 +200,21 @@ router.get('/change', async (req, res, next) => {
 });
 
 /**
+ * Function to get mempool of a connected proposer
+ */
+router.get('/mempool', async (req, res, next) => {
+  logger.debug(`proposer/mempool endpoint received GET ${JSON.stringify(req.body, null, 2)}`);
+  try {
+    const mempool = await getMempoolTransactions();
+    logger.debug('returning mempool');
+    res.json({ result: mempool });
+  } catch (err) {
+    logger.error(err);
+    next(err);
+  }
+});
+
+/**
  * Function to Propose a state update block  This just
  * provides the tx data, the user will need to call the blockchain client
  * @deprecated - this is now an automated process - no need to manually propose
@@ -221,6 +236,7 @@ router.post('/encode', async (req, res, next) => {
     const newTransactions = await Promise.all(
       transactions.map(t => {
         const transaction = t;
+        logger.info(`/endoce Transactions: ${JSON.stringify(transaction)}`);
         transaction.transactionHash = Transaction.calcHash(transaction);
         return transaction;
       }),

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -407,6 +407,5 @@ export async function addTransactionsToMemPoolFromBlockNumberL2(blockNumberL2) {
 export async function getMempoolTransactions() {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
-  const query = { mempool: true };
-  return db.collection(TRANSACTIONS_COLLECTION).find(query).toArray();
+  return db.collection(TRANSACTIONS_COLLECTION).find().toArray();
 }

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -302,8 +302,15 @@ export async function deleteTransferAndWithdraw(transactionHashes) {
   const db = connection.db(OPTIMIST_DB);
   const query = {
     transactionHash: { $in: transactionHashes },
-    transactionType: { $in: [1, 2, 3] },
+    transactionType: { $in: ['1', '2', '3'] },
   };
+  return db.collection(TRANSACTIONS_COLLECTION).deleteMany(query);
+}
+
+export async function deleteTransactionsByTransactionHashes(transactionHashes) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  const query = { transactionHash: { $in: transactionHashes } };
   return db.collection(TRANSACTIONS_COLLECTION).deleteMany(query);
 }
 
@@ -395,4 +402,11 @@ export async function addTransactionsToMemPoolFromBlockNumberL2(blockNumberL2) {
   const query = { blockNumberL2: { $gte: Number(blockNumberL2) } };
   const update = { $set: { mempool: true, blockNumberL2: -1 } };
   return db.collection(TRANSACTIONS_COLLECTION).updateMany(query, update);
+}
+
+export async function getMempoolTransactions() {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  const query = { mempool: true };
+  return db.collection(TRANSACTIONS_COLLECTION).find(query).toArray();
 }

--- a/nightfall-optimist/src/services/process-calldata.mjs
+++ b/nightfall-optimist/src/services/process-calldata.mjs
@@ -90,7 +90,10 @@ export async function getProposeBlockCalldata(eventData) {
       // eslint-disable-next-line no-await-in-loop
       onChainBlockData = await stateContractInstance.methods.blockHashes(counter).call();
     } catch (error) {
-      throw new Error('Could not find blockHash in blockchain record');
+      // Getting to this means the block hash doesnt exist (perhaps its was rolled back)
+      counter = Math.max(...storedL2BlockNumbers) + 1;
+      break;
+      // throw new Error('Could not find blockHash in blockchain record');
       // break;
     }
   } while (onChainBlockData.blockHash !== block.blockHash);

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -379,6 +379,20 @@ describe('Testing the challenge http API', () => {
           web3.eth.abi.encodeEventSignature('Rollback(bytes32,uint256,uint256)'),
           web3.eth.abi.encodeParameter('bytes32', topicsBlockHashIncorrectRootInBlock),
         ]);
+        const res = await chai
+          .request(url)
+          .post('/transfer')
+          .send({
+            ercAddress,
+            tokenId,
+            recipientData: {
+              values: [value],
+              recipientZkpPublicKeys: [zkpPublicKey],
+            },
+            senderZkpPrivateKey: zkpPrivateKey,
+            fee,
+          });
+        await submitTransaction(res.body.txDataToSign, privateKey, shieldAddress, gas, fee);
       });
     });
 


### PR DESCRIPTION
This PR fixes a few things:

1. Issues with re-syncing brought about by changes made in `blockPropose` handling.
2. Fixes an issue in client where a duplicate transaction would incorrectly overwrite the `isOnChain` and `isNullifiedOnChain` fields of the initial (non-duplicate) commitment.
3. adds the `STATE` contract for `NewCurrentProposer` listener, `STATE` now emits an event that must be subscribed to.
4. adds a new endpoint (`/mempool`) - will be used in a follow up PR for rollbacks.
5. fixes the delete by `transactionType` which will now correctly delete transfers and withdrawals - previously nothing was being deleted. This change results in a change in `neg-http`.

A separate PR will be submitted for changes to the Rollback methodology.

