### PR TITLE
Fix duplicateTransactions challenge

### DIFF
--- a/nightfall-deployer/contracts/Challenges.sol
+++ b/nightfall-deployer/contracts/Challenges.sol
@@ -88,6 +88,10 @@ contract Challenges is Stateful, Key_Registry, Config {
     // first, check we have real, in-train, contiguous blocks
     state.isBlockReal(block1, transactions1, block1NumberL2);
     state.isBlockReal(block2, transactions2, block2NumberL2);
+    // If the duplicate exists in the same block, the index cannot be the same
+    if(block1NumberL2 == block1NumberL2)
+      require(transactionIndex1 != transactionIndex2, 'Cannot be the same index');
+
     require(
       Utils.hashTransaction(transactions1[transactionIndex1]) ==
       Utils.hashTransaction(transactions2[transactionIndex2]),

--- a/nightfall-deployer/contracts/Challenges.sol
+++ b/nightfall-deployer/contracts/Challenges.sol
@@ -89,7 +89,7 @@ contract Challenges is Stateful, Key_Registry, Config {
     state.isBlockReal(block1, transactions1, block1NumberL2);
     state.isBlockReal(block2, transactions2, block2NumberL2);
     // If the duplicate exists in the same block, the index cannot be the same
-    if(block1NumberL2 == block1NumberL2)
+    if(block1NumberL2 == block2NumberL2)
       require(transactionIndex1 != transactionIndex2, 'Cannot be the same index');
 
     require(

--- a/nightfall-optimist/src/routes/block.mjs
+++ b/nightfall-optimist/src/routes/block.mjs
@@ -30,7 +30,7 @@ router.get('/transaction-hash/:transactionHash', async (req, res, next) => {
     const { transactionHash } = req.params;
     logger.debug(`searching for block containing transaction hash ${transactionHash}`);
     // get data to return
-    const block = await getBlockByTransactionHash(transactionHash);
+    const [block] = await getBlockByTransactionHash(transactionHash);
     if (block !== null) {
       const transactions = await getTransactionsByTransactionHashes(block.transactionHashes);
       const index = block.transactionHashes.indexOf(transactionHash);

--- a/nightfall-optimist/src/services/challenges.mjs
+++ b/nightfall-optimist/src/services/challenges.mjs
@@ -106,8 +106,9 @@ export async function createChallenge(block, transactions, err) {
           err.metadata;
 
         // Get the block that contains the duplicate of the transaction
-        const block2 = await getBlockByTransactionHash(transactionHash1);
-        // Find the index of the duplication transaction in this block
+        const [block2] = (await getBlockByTransactionHash(transactionHash1)).filter(
+          b => b.blockHash !== block.blockHash,
+        );
         const transactions2 = await getTransactionsByTransactionHashes(block2.transactionHashes);
         const transactionIndex2 = transactions2
           .map(t => t.transactionHash)

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -96,7 +96,7 @@ export async function getBlockByTransactionHash(transactionHash) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   const query = { transactionHashes: transactionHash };
-  return db.collection(SUBMITTED_BLOCKS_COLLECTION).findOne(query);
+  return db.collection(SUBMITTED_BLOCKS_COLLECTION).find(query).toArray();
 }
 
 export async function numberOfBlockWithTransactionHash(transactionHash) {
@@ -294,13 +294,6 @@ export async function deleteTransferAndWithdraw(transactionHashes) {
     transactionHash: { $in: transactionHashes },
     transactionType: { $in: ['1', '2', '3'] },
   };
-  return db.collection(TRANSACTIONS_COLLECTION).deleteMany(query);
-}
-
-export async function deleteTransactionsByTransactionHashes(transactionHashes) {
-  const connection = await mongo.connection(MONGO_URL);
-  const db = connection.db(OPTIMIST_DB);
-  const query = { transactionHash: { $in: transactionHashes } };
   return db.collection(TRANSACTIONS_COLLECTION).deleteMany(query);
 }
 


### PR DESCRIPTION
### Safer access pattern
Building a challenge for a `duplicateTransaction` uses an unsafe access pattern via `getBlockByTransactionHash` and `findOne`. `findOne` uses an unreliable "natural ordering" to return the blocks and is not suitable if a call might return two items.

The bad block containing the duplicate is saved before this challenge code runs, therefore there will be two blocks in the collection that could be returned from this call. This means there is a 50:50 chance that the wrong block is returned from this call.

In this case, the wrong block is defined as the bad block itself. This would lead to the challenge using the bad block twice as inputs to the on-chain challenge, rather than the bad block and an earlier valid block that contains the first time the duplicate was used.

### Fix issue with duplicate challenge
One of the reasons this hasn't caused an issue before (despite the 50:50 odds) is that the on-chain `challengeNoDuplicateTransaction` does not guard against using the same block as both inputs. This meant that any block was arbitrarily challengeable.