### PR TITLE
Adds client resync

### DIFF
--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -41,7 +41,7 @@ async function blockProposedEventHandler(data, keys = [ZERO, ZERO]) {
       // this client and stored during deposit transaction creation. If so, only update that commitment is on chain
       // If not this commitment need not be stored or updated by other clients
       if ((await countCommitments(transaction.commitments)) > 0) {
-        await markOnChain(nonZeroCommitments, blockNumberL2);
+        await markOnChain(nonZeroCommitments, blockNumberL2, data.blockNumber);
       }
       // if transaction is single transfer or double transfer
     } else if (transaction.transactionType === '1' || transaction.transactionType === '2') {
@@ -52,8 +52,8 @@ async function blockProposedEventHandler(data, keys = [ZERO, ZERO]) {
       // nothing needs to be stored
       if ((await countCommitments(transaction.commitments)) > 0) {
         await Promise.all([
-          markOnChain(nonZeroCommitments, blockNumberL2),
-          markNullifiedOnChain(nonZeroNullifiers, blockNumberL2),
+          markOnChain(nonZeroCommitments, blockNumberL2, data.blockNumber),
+          markNullifiedOnChain(nonZeroNullifiers, blockNumberL2, data.blockNumber),
         ]);
       } else {
         // decompress the secrets first and then we will decrypt the secrets from this
@@ -68,7 +68,7 @@ async function blockProposedEventHandler(data, keys = [ZERO, ZERO]) {
           else {
             // store commitment if the new commitment in this transaction is intended for this client
             await storeCommitment(commitment, nsk);
-            await markOnChain(nonZeroCommitments, blockNumberL2);
+            await markOnChain(nonZeroCommitments, blockNumberL2, data.blockNumber);
           }
         } catch (err) {
           logger.info(err);
@@ -81,7 +81,7 @@ async function blockProposedEventHandler(data, keys = [ZERO, ZERO]) {
       // this client and stored during withdraw transaction creation. If so, only update that nullifier is on chain
       // If not this nullifier need not be stored or updated by other clients
       if ((await countNullifiers(transaction.nullifiers)) > 0) {
-        await markNullifiedOnChain(nonZeroNullifiers, blockNumberL2);
+        await markNullifiedOnChain(nonZeroNullifiers, blockNumberL2, data.blockNumber);
       }
     } else logger.error('Transaction type is invalid. Transaction type is', transaction.Type);
   });

--- a/nightfall-client/src/index.mjs
+++ b/nightfall-client/src/index.mjs
@@ -4,7 +4,6 @@ import mongo from 'common-files/utils/mongo.mjs';
 import app from './app.mjs';
 import rabbitmq from './utils/rabbitmq.mjs';
 import queues from './queues/index.mjs';
-import { subscribeToRollbackEventHandler, rollbackEventHandler } from './event-handlers/index.mjs';
 
 const main = async () => {
   try {
@@ -12,7 +11,6 @@ const main = async () => {
       await rabbitmq.connect();
       queues();
     }
-    subscribeToRollbackEventHandler(rollbackEventHandler);
     await mongo.connection(config.MONGO_URL); // get a db connection
     app.listen(80);
   } catch (err) {

--- a/nightfall-client/src/routes/incomingViewingKey.mjs
+++ b/nightfall-client/src/routes/incomingViewingKey.mjs
@@ -8,7 +8,10 @@ import logger from 'common-files/utils/logger.mjs';
 import {
   subscribeToBlockProposedEvent,
   blockProposedEventHandler,
+  subscribeToRollbackEventHandler,
+  rollbackEventHandler,
 } from '../event-handlers/index.mjs';
+import { initialClientSync } from '../services/state-sync.mjs';
 
 const router = express.Router();
 
@@ -16,7 +19,10 @@ router.post('/', async (req, res, next) => {
   logger.debug(`Incoming Viewing Key endpoint received POST ${JSON.stringify(req.body, null, 2)}`);
   try {
     const { ivk, nsk } = generalise(req.body);
-    subscribeToBlockProposedEvent(blockProposedEventHandler, ivk.bigInt, nsk.bigInt);
+    initialClientSync().then(() => {
+      subscribeToBlockProposedEvent(blockProposedEventHandler, ivk.bigInt, nsk.bigInt);
+      subscribeToRollbackEventHandler(rollbackEventHandler);
+    });
     res.json({ status: 'success' });
   } catch (err) {
     logger.error(err);

--- a/nightfall-client/src/services/state-sync.mjs
+++ b/nightfall-client/src/services/state-sync.mjs
@@ -1,0 +1,58 @@
+/**
+Resync code so that restarted client instances are able to read past events and update
+their local commitments databsae.
+*/
+
+import config from 'config';
+import logger from 'common-files/utils/logger.mjs';
+import { getContractInstance } from 'common-files/utils/contract.mjs';
+import mongo from 'common-files/utils/mongo.mjs';
+import blockProposedEventHandler from '../event-handlers/block-proposed.mjs';
+import rollbackEventHandler from '../event-handlers/rollback.mjs';
+
+const { MONGO_URL, COMMITMENTS_DB, COMMITMENTS_COLLECTION, STATE_CONTRACT_NAME } = config;
+
+const syncState = async (fromBlock = 'earliest', toBlock = 'latest', eventFilter = 'allEvents') => {
+  const stateContractInstance = await getContractInstance(STATE_CONTRACT_NAME); // Rollback, BlockProposed
+
+  const pastStateEvents = await stateContractInstance.getPastEvents(eventFilter, {
+    fromBlock,
+    toBlock,
+  });
+  logger.info(`pastStateEvents: ${JSON.stringify(pastStateEvents)}`);
+
+  for (let i = 0; i < pastStateEvents.length; i++) {
+    switch (pastStateEvents[i].event) {
+      case 'BlockProposed':
+        // eslint-disable-next-line no-await-in-loop
+        await blockProposedEventHandler(pastStateEvents[i]);
+        break;
+      case 'Rollback':
+        // eslint-disable-next-line no-await-in-loop
+        await rollbackEventHandler(pastStateEvents[i]);
+        break;
+      default:
+        break;
+    }
+  }
+};
+
+const genGetCommitments = async (query = {}, proj = {}) => {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(COMMITMENTS_DB);
+  return db.collection(COMMITMENTS_COLLECTION).find(query, proj).toArray();
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export const initialClientSync = async () => {
+  const allCommitments = await genGetCommitments();
+  if (allCommitments.length === 0) return {};
+
+  const commitmentBlockNumbers = allCommitments.map(a => a.blockNumber).filter(n => n >= 0);
+  logger.info(`commitmentBlockNumbers: ${commitmentBlockNumbers}`);
+  const firstSeenBlockNumber = Math.min(...commitmentBlockNumbers);
+  logger.info(`firstSeenBlockNumber: ${firstSeenBlockNumber}`);
+  // fistSeenBlockNumber can be infinity if the commitmentBlockNumbers array is empty
+  if (firstSeenBlockNumber === Infinity) return syncState();
+  return syncState(firstSeenBlockNumber);
+};


### PR DESCRIPTION
This PR adds functionality for a restarted client instance to perform a re-sync. This enables them to update their local databases based on past events.

It does this using a newly added `blockNumber` that is associated with each commitments <> nullifier pair.  To be safe when re-syncing, we begin scanning the main chain from the smallest `blockNumber` we have stored in our local database. This guarantees we are able to sync events that we may miss that are relevant to us.

This closes #135 