### PR TITLE
feat: priority queues

### DIFF
--- a/nightfall-optimist/src/event-handlers/index.mjs
+++ b/nightfall-optimist/src/event-handlers/index.mjs
@@ -29,6 +29,12 @@ const eventHandlers = {
     CommittedToChallenge: removeCommittedToChallengeEventHandler,
     TransactionSubmitted: removeTransactionSubmittedEventHandler,
   },
+  priority: {
+    BlockProposed: 0,
+    TransactionSubmitted: 1,
+    Rollback: 0,
+    CommittedToChallenge: 0,
+  },
 };
 
 export {

--- a/nightfall-optimist/src/index.mjs
+++ b/nightfall-optimist/src/index.mjs
@@ -17,7 +17,7 @@ import {
 } from './services/block-assembler.mjs';
 import { setChallengeWebSocketConnection } from './services/challenges.mjs';
 import initialBlockSync from './services/state-sync.mjs';
-import buffer from './services/event-queue.mjs';
+import { queueManager } from './services/event-queue.mjs';
 
 const main = async () => {
   try {
@@ -35,7 +35,7 @@ const main = async () => {
     // we do not wait for the initial block sync for these event handlers
     // as we want to still listen to incoming events (just not make blocks)
     // subscribe to blockchain events
-    startEventQueue(buffer, eventHandlers);
+    startEventQueue(queueManager, eventHandlers);
     app.listen(80);
   } catch (err) {
     logger.error(err);

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -15,7 +15,7 @@ import {
 import Block from '../classes/block.mjs';
 import { Transaction } from '../classes/index.mjs';
 import { waitForContract } from '../event-handlers/subscribe.mjs';
-import { nextHigherPiorityQueueHasEmptied } from './event-queue.mjs';
+import { nextHigherPriorityQueueHasEmptied } from './event-queue.mjs';
 
 const { TRANSACTIONS_PER_BLOCK, STATE_CONTRACT_NAME } = config;
 const makeBlocks = true;
@@ -47,7 +47,7 @@ export async function conditionalMakeBlock(proposer) {
   logger.debug('Ready to make blocks');
   while (makeBlocks) {
     logger.silly('Block Assembler is waiting for transactions');
-    await nextHigherPiorityQueueHasEmptied(1); // i.e. the highest priority queue is empty
+    await nextHigherPriorityQueueHasEmptied(1); // i.e. the highest priority queue is empty
     // if we are the current proposer, and there are enough transactions waiting
     // to be processed, we can assemble a block and create a proposal
     // transaction. If not, we must wait until either we have enough (hooray)

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -15,6 +15,7 @@ import {
 import Block from '../classes/block.mjs';
 import { Transaction } from '../classes/index.mjs';
 import { waitForContract } from '../event-handlers/subscribe.mjs';
+import { nextHigherPiorityQueueHasEmptied } from './event-queue.mjs';
 
 const { TRANSACTIONS_PER_BLOCK, STATE_CONTRACT_NAME } = config;
 const makeBlocks = true;
@@ -46,6 +47,7 @@ export async function conditionalMakeBlock(proposer) {
   logger.debug('Ready to make blocks');
   while (makeBlocks) {
     logger.silly('Block Assembler is waiting for transactions');
+    await nextHigherPiorityQueueHasEmptied(1); // i.e. the highest priority queue is empty
     // if we are the current proposer, and there are enough transactions waiting
     // to be processed, we can assemble a block and create a proposal
     // transaction. If not, we must wait until either we have enough (hooray)

--- a/nightfall-optimist/src/services/event-queue.mjs
+++ b/nightfall-optimist/src/services/event-queue.mjs
@@ -31,7 +31,7 @@ This function will return a promise that resolves to true when the next highest
 priority queue is empty (priority goes in reverse order, prioity 0 is highest
 priority)
 */
-export function nextHigherPiorityQueueHasEmptied(priority) {
+export function nextHigherPriorityQueueHasEmptied(priority) {
   return new Promise(resolve => {
     const listener = () => resolve();
     if (priority === 0) resolve(); // resolve if we're the highest priority queue
@@ -61,14 +61,14 @@ export async function queueManager(eventObject, eventHandlers, ...args) {
     }
     logger.info(`Queueing event removal ${eventObject.event}`);
     queues[priority].push(async () => {
-      await nextHigherPiorityQueueHasEmptied(priority); // prevent eventHandlers running until the higher priority queue has emptied
+      await nextHigherPriorityQueueHasEmptied(priority); // prevent eventHandlers running until the higher priority queue has emptied
       eventHandlers.removers[eventObject.event](eventObject, args);
     });
     // otherwise queue the event for processing.
   } else {
     logger.info(`Queueing event ${eventObject.event}`);
     queues[priority].push(async () => {
-      await nextHigherPiorityQueueHasEmptied(priority); // prevent eventHandlers running until the higher priority queue has emptied
+      await nextHigherPriorityQueueHasEmptied(priority); // prevent eventHandlers running until the higher priority queue has emptied
       eventHandlers[eventObject.event](eventObject, args);
     });
   }

--- a/nightfall-optimist/src/services/event-queue.mjs
+++ b/nightfall-optimist/src/services/event-queue.mjs
@@ -22,15 +22,36 @@ import config from 'config';
 import logger from 'common-files/utils/logger.mjs';
 
 const { MAX_QUEUE } = config;
-const eventQueue = new Queue({ autostart: true, concurrency: 1 });
+const fastQueue = new Queue({ autostart: true, concurrency: 1 });
+const slowQueue = new Queue({ autostart: true, concurrency: 1 });
+const queues = [fastQueue, slowQueue];
 
-async function buffer(eventObject, eventHandlers, ...args) {
+/**
+This function will return a promise that resolves to true when the next highest
+priority queue is empty (priority goes in reverse order, prioity 0 is highest
+priority)
+*/
+export function nextHigherPiorityQueueHasEmptied(priority) {
+  return new Promise(resolve => {
+    const listener = () => resolve();
+    if (priority === 0) resolve(); // resolve if we're the highest priority queue
+    queues[priority - 1].once('end', listener); // or when the higher priority queue empties
+    if (queues[priority - 1].length === 0) {
+      queues[priority - 1].removeListener('end', listener);
+      resolve(); // or if it's already empty
+    }
+  });
+}
+
+export async function queueManager(eventObject, eventHandlers, ...args) {
   // handlers contains the functions needed to handle particular types of event,
   // including removal of events when a chain reorganisation happens
   if (!eventHandlers[eventObject.event]) {
     logger.debug(`Unknown event ${eventObject.event} ignored`);
     return;
   }
+  // pull up the priority for the event being handled (removers have identical priority)
+  const priority = eventHandlers.priority[eventObject.event];
   // if the event was removed then we have a chain reorg and need to reset our
   // layer 2 state accordingly.
   if (eventObject.removed) {
@@ -39,15 +60,19 @@ async function buffer(eventObject, eventHandlers, ...args) {
       return;
     }
     logger.info(`Queueing event removal ${eventObject.event}`);
-    eventQueue.push(() => eventHandlers.removers[eventObject.event](eventObject, args));
+    queues[priority].push(async () => {
+      await nextHigherPiorityQueueHasEmptied(priority); // prevent eventHandlers running until the higher priority queue has emptied
+      eventHandlers.removers[eventObject.event](eventObject, args);
+    });
     // otherwise queue the event for processing.
   } else {
     logger.info(`Queueing event ${eventObject.event}`);
-    eventQueue.push(() => eventHandlers[eventObject.event](eventObject, args));
+    queues[priority].push(async () => {
+      await nextHigherPiorityQueueHasEmptied(priority); // prevent eventHandlers running until the higher priority queue has emptied
+      eventHandlers[eventObject.event](eventObject, args);
+    });
   }
   // the queue shouldn't get too long if we're keeping up with the blockchain.
-  if (eventQueue.length > MAX_QUEUE)
+  if (queues[priority].length > MAX_QUEUE)
     logger.warn(`The event queue has more than ${MAX_QUEUE} events`);
 }
-
-export default buffer;


### PR DESCRIPTION
fixes #134 

This PR creates two queues for incoming blockchain events.  Events in the lower priority queue will only be processed if the higher priority queue is empty, otherwise the handler will await the higher priority queue emptying.  The code is generic and more queues can easily be added by putting Queue objects in the `queues` array.

TransactionSubmitted events are placed in the lower priority queue.  All other events are placed in the higher priority queue. To facilitate this, eventHandlers have an associated `priority`, with `priority = 0` being the highest.

The block assembler now monitors the highest priority queue and will only make blocks when it is empty.