### PR TITLE
Fix Challenger storage

### DIFF
--- a/nightfall-optimist/src/event-handlers/challenge-commit.mjs
+++ b/nightfall-optimist/src/event-handlers/challenge-commit.mjs
@@ -7,7 +7,8 @@ async function committedToChallengeEventHandler(data) {
   logger.debug(
     `Received commmitted to challenge event, with hash ${commitHash} and sender ${sender}`,
   );
-  if (!isChallengerAddressMine(sender)) return; // it's not us - nothing to do
+  const challengerIsMe = await isChallengerAddressMine(sender);
+  if (!challengerIsMe) return; // it's not us - nothing to do
   logger.info(`Our challenge commitment has been mined, sending reveal`);
   const { txDataToSign } = await getCommit(commitHash);
   if (txDataToSign === null) throw new Error('Commit hash not found in database');

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -45,7 +45,7 @@ the front-runner).
 export async function addChallengerAddress(address) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
-  logger.debug(`Saving proposer address ${address}`);
+  logger.debug(`Saving challenger address ${address}`);
   const data = { challenger: address };
   return db.collection(METADATA_COLLECTION).insertOne(data);
 }
@@ -58,7 +58,7 @@ the address.
 export async function removeChallengerAddress(address) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
-  logger.debug(`Saving proposer address ${address}`);
+  logger.debug(`Removing challenger address ${address}`);
   const data = { challenger: address };
   return db.collection(METADATA_COLLECTION).deleteOne(data);
 }

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -226,11 +226,11 @@ describe('Testing the challenge http API', () => {
 
   describe('Basic Challenger tests', () => {
     it('should add a Challenger address', async () => {
-      const myAddress = (await getAccounts())[1];
+      const myAddress = (await getAccounts())[0];
       const res = await chai
         .request(optimistUrl)
         .post('/challenger/add')
-        .send({ challenger: myAddress });
+        .send({ address: myAddress });
       expect(res.body.ok).to.equal(1);
     });
   });


### PR DESCRIPTION
#138 makes use of two optimist instances for the test (although one is just listening). This actually uncovers a bug (unrelated to the PR) in the way that challenger addresses are stored and retrieved.

1.  In `challenge-commit.mjs` the retrieval + check code is not awaited, this causes the `if` condition to always evaluate to true (as promises are not falsy). Therefore, both `optimist` instances considers themselves to be the challenger that sent the on-chain challenge commit. This errors out in the in the second optimist instance.

2. The code in the test needs to be updated since `(await getAccounts())[1]` is actually undefined since the switch from `ganache` deterministic mnemonics to the new specified accounts way. The only reasons tests have worked in the past is likely due to point (1) and the always **true** evaluation.

To see the impact of this code change, run #138 before this PR and
- Inspect the logs for `optimist2`, which will display an error after receiving the `CommittedToChallenge` event
- Checking the `METADATA_COLLECTION` for `optimist1` which contain a `challenger: null` entry when it should contain a valid address

This PR is against #138 so that @ChaitanyaKonda  won't need to fix any merge conflicts.