### PR TITLE
feat: use of stubs selectable in startup script

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -53,7 +53,7 @@ module.exports = {
   NODE_HASHLENGTH: 32,
   ZERO: '0x0000000000000000000000000000000000000000000000000000000000000000',
   HASH_TYPE: 'mimc',
-  USE_STUBS: process.env.USE_STUBS === 'false',
+  USE_STUBS: process.env.USE_STUBS === 'true',
   VK_IDS: { deposit: 0, single_transfer: 1, double_transfer: 2, withdraw: 3 }, // used as an enum to mirror the Shield contracts enum for vk types. The keys of this object must correspond to a 'folderpath' (the .zok file without the '.zok' bit)
 
   // the various parameters needed to describe the Babyjubjub curve that we use for El-Gamal

--- a/docker-compose.stubs.yml
+++ b/docker-compose.stubs.yml
@@ -1,0 +1,14 @@
+version: '3.5'
+# Use this script for making nightfall_3 use stubs.
+services:
+    client1:
+      environment:
+        USE_STUBS: 'true' # make sure this flag is the same as in deployer service
+
+    client2:
+      environment:
+        USE_STUBS: 'true' # make sure this flag is the same as in deployer service
+
+    deployer:
+      environment:
+        USE_STUBS: 'true' # make sure this flag is the same as in deployer service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       ENABLE_QUEUE: 1
       OPTIMIST_HOST: optimist1
       OPTIMIST_PORT: 80
-      USE_STUBS: 'true' # make sure this flag is the same as in deployer service
+      USE_STUBS: 'false' # make sure this flag is the same as in deployer service
     command: ['npm', 'run', 'dev']
 
   client2:
@@ -93,7 +93,7 @@ services:
       ENABLE_QUEUE: 1
       OPTIMIST_HOST: optimist2
       OPTIMIST_PORT: 80
-      USE_STUBS: 'true' # make sure this flag is the same as in deployer service
+      USE_STUBS: 'false' # make sure this flag is the same as in deployer service
     command: ['npm', 'run', 'dev']
 
   worker:
@@ -167,7 +167,7 @@ services:
       ZOKRATES_WORKER_HOST: worker
       # TIMBER_HOST: timber1
       # TIMBER_PORT: 80
-      USE_STUBS: 'true'
+      USE_STUBS: 'false'
 
   # Timber service, configured for nightfall
   timber1:

--- a/start-nightfall
+++ b/start-nightfall
@@ -2,38 +2,46 @@
 
 VOLUME_LIST=$(docker volume ls -q)
 FILE=
+STUBS=
 
 usage()
 {
   echo "Usage:"
   echo "  -g or --ganache; for a ganache simulator"
   echo "  -l or --localhost; to connect to an already running blockchain on ws://localhost:8546"
+  echo "  -s or --stubs; runs with circuits stubbed out (faster but no checking of ZKP code) - use with either -g or -l"
   echo "  -h or --help; to print this message"
 }
 
 # select a Geth or Ganache client
-if [ "$1" == "" ]; then
+if [ -z "$1" ]; then
   usage
   exit 1
 fi
-while [ "$1" != "" ]; do
+while [ -n "$1" ]; do
   case $1 in
-      -g | --ganache )        FILE="-f docker-compose.ganache.yml"
+      -g | --ganache )        FILE="-f docker-compose.yml -f docker-compose.ganache.yml"
                               ;;
-      -l | --localhost )      FILE="-f docker-compose.host.docker.internal.yml"
+      -l | --localhost )      FILE="-f docker-compose.yml -f docker-compose.host.docker.internal.yml"
                               ;;
       -h | --help )           usage
+                              ;;
+      -s | --stubs )          STUBS="-f docker-compose.stubs.yml"
                               ;;
       * )                     usage
                               exit 1
     esac
   shift
 done
-
+# FILE should always be set.  Asking for -s on its own makes no sense
+if [ -z "$FILE" ]; then
+  usage
+  exit 1
+fi
 # shut down cleanly in the event of a cntl-c etc. We don't want to leave containers running
-trap "docker-compose -f docker-compose.yml $FILE down --remove-orphans -t 1; exit 1" SIGHUP SIGINT SIGTERM
+trap "docker-compose $FILE $STUBS down --remove-orphans -t 1; exit 1" SIGHUP SIGINT SIGTERM
 
-docker-compose -f docker-compose.yml $FILE down --remove-orphans
+docker-compose -f docker-compose.yml $FILE $STUBS  down --remove-orphans
 
 # if-else block checks - volume exist and then removes it.
 if [[ $(echo $VOLUME_LIST | grep nightfall_3_timber-database-volume1) ]]; then
@@ -96,4 +104,4 @@ if [[ -d "$DIR" ]]; then
   rm -dr common-files/node_modules
 fi
 #docker-compose -f docker-compose.yml $FILE up -d deployer
-docker-compose -f docker-compose.yml $FILE up
+docker-compose $FILE $STUBS  up


### PR DESCRIPTION
fixes #153
This PR tidies up the selection of stubbed circuits by adding another argument to the `./start-nightfall` script.  Now, besides the existing (`-l`, `-h`, `-g`) arguments, you can additionally include `-s` (e.g. `-s -g`).  If you do this, your instance of nightfall will run with stubbed circuit files.  If you miss out `-s` the default behaviour will be to not use stubs.