### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This will test the application, creating transactions and assembling them into l
 
 ### Measuring Block Gas used
 
-In reality, a value of two transactions per block, although convenient for testing, wouldn't make very efficient use of Optimism.  A more realistic value is 32 transactions per layer 2 block. This value can be configured by the environment variable `TRANSACTIONS_PER_BLOCK` in the docker-compose.yml file (part of the `optimist` service). This is important for the Block Gas measurement, which requires a value of 32 to be set.
+In reality, a value of two transactions per block, although convenient for testing, wouldn't make very efficient use of Optimism.  A more realistic value is 32 transactions per layer 2 block. This value can be configured by the environment variable `TRANSACTIONS_PER_BLOCK` in the `docker-compose.yml` file (part of the `optimist` service). This is important for the Block Gas measurement, which requires a value of 32 to be set.
 
 To measure the Block Gas used per transaction, first edit the `TRANSACTIONS_PER_BLOCK` variable as above (don't forget to change it back after), restart nightfall_3, and run:
 ```sh

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 Nightfall_3 is an application for transferring ERC20, ERC721 and ERC1155 applications under Zero Knowledge.  It abstracts away any need to deal directly with ZKP artefacts and provides a simple token-transfer API.  When used correctly, it will hide the recipient and the token being transferred.
 
-Nightfall_3 uses optimistic rollups to counter the high gas costs of direct ZKP transactions. It can complete a ZKP transfer for approximately 10 kGas (this will soon be reduced to 8 kGas with a pending update).  This compares with 700 kGas for the original Nightfall application. As a Layer 2 solution with on-chain data availability, Nightfall_3 can perform a  private transfer for less than half the cost of a public ERCx transfer whilst maintaining the security and consensus assumptions from the Ethereum Mainnet.
+Nightfall_3 uses optimistic rollups to counter the high gas costs of direct ZKP transactions. It can complete a ZKP transfer for approximately 10 kGas.  This compares with 700 kGas for the original Nightfall application. As a Layer 2 solution with on-chain data availability, Nightfall_3 can perform a private transfer for less than half the cost of a public ERCx transfer whilst maintaining the security and consensus assumptions from the Ethereum Mainnet.
 
 ## Setup
 
 ### Prerequisites
 
-This application runs in docker containers so you will need Docker installed and you must allocate 14 GB of RAM and 4 GB of swap to the Docker containers.  Most problems are caused by the containers not having access to enough memory.  We also recommend allocating at least 4 cores to Docker.
+This application runs in docker containers so you will need Docker installed and you must allocate 14 GB of RAM and 4 GB of swap to the Docker containers.  Most problems are caused by the containers not having access to enough memory.  We also recommend allocating at least 4 cores to Docker if you are running in a virtual linux environment (e.g. on a Mac).
 
 You will need a local copy of `node` and `npm` to run the tests and `git` to clone the repository.  We have tested with versions 14.15.1 and 6.14.13 of `node` and `npm`, respectively.
 
@@ -22,14 +22,8 @@ The application will run happily on a MacBook pro and most Linux implementations
 
 Clone this GitHub repository, then `cd` into it:
 
-You need to run a setup script the first time that you use nightfall_3.  This will install all of the dependencies. We use GitHub packages to store our NPM packages and so you will have to create a Personal Access [Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token), to pull these. It's just the way GitHub works. Call it GPR_TOKEN:
+You need to run a setup script the first time that you use nightfall_3.  This will install all of the dependencies.
 
-```sh
-export GPR_TOKEN=<my_personal_access_token_string>
-```
-You can put the above line in your `~/.bash_profile` file if you wish (and you are using bash!).
-
-After that, run the setup script
 ```sh
 ./setup-nightfall
 ```
@@ -38,9 +32,9 @@ After that, run the setup script
 
 If running for first time, do the setup as above and then run this script:
 ```sh
-./start-nightfall [-e | -g]
+./start-nightfall -l | -g [-s]
 ```
-This will bring up the application.  You can run it either with a Ganache blockchain simulator or a real Geth private network.  Use -g for Ganache and -e for Geth.  We recommend using Ganache first to check everything works, because it's considerably faster. 
+This will bring up the application.  You can run it either with a Ganache blockchain simulator or a real blockchain client which exposes a websocket connection on localHost:8546.  See below for more details on how to do the latter as there are some additional considerations.  Use -g for Ganache and -l for localhost.  We recommend using Ganache first to check everything works, because it's considerably faster.  Additionally, you can use the -s flag.  If you do that, Nightfall_3 will run with stubbed ZKP circuits, which generate proofs that always verify.  That's useful for development work because tests will run much faster but clearly you should run without stubs, as a final check.
 
 Startup will take a minute or so, depending on your machine. You'll see lots of warnings as it runs up from the `optimist` and `timber` containers.  That's entirely fine, they're just waiting for the other services that they need to start up. You should see no errors however.  If you do, something has broken.
 
@@ -58,7 +52,7 @@ Open a separate terminal window, cd to the nightfall_3 repo and run
 ```sh
 npm test
 ```
-This will test the application, creating transactions and assembling them into layer 2 blocks.  By default the application is configured to put only two transactions into a layer 2 block.  This is to make the standard tests fast.  They won't currently run with any other value because they have to know when the application should have created a block in order to test it properly.  
+This will test the application, creating transactions and assembling them into layer 2 blocks.  By default the application is configured to put only two transactions into a layer 2 block.  This is to make the standard tests fast.  
 
 ### Measuring Block Gas used
 
@@ -69,10 +63,26 @@ To measure the Block Gas used per transaction, first edit the `TRANSACTIONS_PER_
 npm run test-gas
 ```
 
-### A note on the ZKP circuits
+### Test chain reorganisations
 
-The computation of proofs associated with the transfer of commitments can take a few minutes.  If you are developing and testing your code, this can become quite a bottle-neck for your productivity. Accordingly, we've provided a set of stub proofs that always verify. *These are the default*.  They are much faster to use for when you aren't working directly on the circuits (but of course don't provide any assurance of correctness of a computation).  You can choose whether to use the real or stubbed proofs via the environment variable `USE_STUBS` in the `deployer` service in the `docker-compose.yml` file.
+In Layer 2 solutions, Layer 2 state is held off-chain but created by a series of Layer 1 transactions (e.g. the proposal of a Layer 2 block).  In the case of Nightfall_3 these Layer 2 state updates are signalled by blockchain Events being 'broadcast'.  Thus, all Layer 2 solutions must be able to correct their Layer 2 state when it becomes invalidated by a Layer 1 chain reorganisation.  This is actually quite hard to test because it requires one to be able to generate a chain reorganisation to order.
+To facilitate such a test, we create a private Geth-based blockchain (details of how to run this up are below) consisting of two clients, two miners and a bootnode.  We can then freeze half of the nodes by pausing their containers and creating transaction on the un-paused nodes to create a 'split-brain'.  Inverting the process to put different transactions on the other part of the network will create a chain fork and, when all the nodes are brought back on line, a chain reorganisation will occur.  Currently test coverage is fairly limited because there are a number of sub-classes of chain fork that have to be simulated. We continue to work on these.  These tests are run, once the private Geth blockchain is started, with:
 
+```sh
+npm test-chain-reorg
+```
+
+### Using a Geth private blockchain
+
+The script `./geth-standalone` will run up a private blockchain consisting of a bootnode, two client nodes and two miners.  This is required for testing chain reorganisations (Ganache does not simulate a chain-reorg) but can be used for other tests or general running.  It's slower than using Ganache but it does provide a more real-life test. Note also that the private chain exposes a client on `host.docker.internal:8546`.  On a Mac this will map to `localhost` but it won't work on any other machine. If you aren't on a Mac then edit `nightfall-deployer/truffle-config.js` to point to the IP of your `localhost` or use the docker-compose line `external_servers` to inject a hostname into the containers host file (see the Github workflows for further clues about how to do that).
+
+To use the private blockchain:
+
+- Run up the private chain with `./geth-standalone -s`
+- Start terminal logging with `./geth-standalone -l` and wait for the DAG build to complete
+- Start Nightfall in another terminal with the `-l` option (`./start-nightfall -l`) and, optionally, the `-s` option if you want stubbed circuits.
+
+That's it.  You can shut down the geth blockchain with `./geth-standalone -d` or pause/unpause it with `-p`, `-u`.
 
 # Acknowledgements
 


### PR DESCRIPTION
fixes #152 
Small updates to the readme - the instructions for use had become a little out of date and a user would probably fail to launch Nightfall_3 successfully.