### PR TITLE
Add block stakes as part of challenge reward

### DIFF
--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -41,11 +41,13 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
 
   // function to enable a proposer to get paid for proposing a block
   function requestBlockPayment(Block memory b, uint blockNumberL2, Transaction[] memory ts) external {
+    bytes32 blockHash = Utils.hashBlock(b, ts);
     state.isBlockReal(b, ts, blockNumberL2);
     // check that the block has been finalised
     uint time = state.getBlockData(blockNumberL2).time;
     require(time + COOLING_OFF_PERIOD < block.timestamp, 'It is too soon to get paid for this block');
     require(b.proposer == msg.sender, 'You are not the proposer of this block');
+    require(state.isBlockStakeWithdrawn(blockHash) == false, 'The block stake for this block is already claimed');
     // add up how much the proposer is owed.
     uint payment;
     for (uint i = 0; i < ts.length; i++) {

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -18,6 +18,7 @@ contract State is Structures, Config {
   mapping(address => uint) public pendingWithdrawals;
   mapping(address => LinkedAddress) public proposers;
   mapping(address => TimeLockedBond) public bondAccounts;
+  mapping(bytes32 => bool) public claimedBlockStakes;
   LinkedAddress public currentProposer; // who can propose a new shield state
   uint public proposerStartBlock; // L1 block where currentProposer became current
   // local state variables
@@ -185,17 +186,25 @@ contract State is Structures, Config {
     return bondAccounts[addr];
   }
 
-  function rewardChallenger(address challengerAddr, address proposer) public onlyRegistered {
+  function rewardChallenger(address challengerAddr, address proposer, uint256 numRemoved) public onlyRegistered {
     removeProposer(proposer);
     TimeLockedBond memory bond = bondAccounts[proposer];
     bondAccounts[proposer] = TimeLockedBond(0,0);
-    pendingWithdrawals[challengerAddr] += bond.amount;
+    pendingWithdrawals[challengerAddr] += bond.amount + numRemoved * BLOCK_STAKE;
   }
 
   function updateBondAccountTime(address addr, uint time) public onlyRegistered {
     TimeLockedBond memory bond = bondAccounts[addr];
     bond.time = time;
     bondAccounts[addr] = bond;
+  }
+
+  function isBlockStakeWithdrawn(bytes32 blockHash) public view returns (bool){
+    return claimedBlockStakes[blockHash];
+  }
+
+  function setBlockStakeWithdrawn(bytes32 blockHash) public onlyRegistered {
+    claimedBlockStakes[blockHash] = true;
   }
 
 }


### PR DESCRIPTION
This PR closes #112 and does two things:
1. Adds tracking of claimed block stakes to ensure they can only be claimed once per block.
2. Increases challenger rewards by also crediting the challenger with the sum of all the block stakes from blocks pruned by a successful challenge.

Change (2) seeks to modify the behaviour of the proposers and challengers as follows:

- **Challengers:** Provides a financial incentive to submit fraud proofs even if the bond of a bad proposer has already been claimed. While it may appear that a challenger is incentivised to let blocks be built ontop of a bad block (increasing the potential payout) - they are in a race with other challengers and delaying a challenge submission may result in missing out entirely on a reward.
- **Proposers:** This provides increased financial disincentive to build on top of bad blocks. While building on top of a bad block is not risk-free given the gas cost to propose, this provides an effective floor (should gas price fall) on the risk. 

Minimising the likelihood of deep (i.e. not on the tip of the L2 chain) bad blocks is important as all transactions in a bad block at the tip (except for the invalid transactions that cause it to be bad) are guaranteed to be valid. This:

1. Allows for a simpler and more optimal path to be taken in the `rollback-handlers`.
2. Minimises fee lost by honest transactors due to dropped transfers
**Note that fees are only truly lost if a transfer needs to be dropped because it is invalid after the rollback (e.g. commitments dropped from the tree, historicBlockRoot invalid)**
