### PR TITLE
Race condition between commit challenge and reveal challenge

### DIFF
--- a/nightfall-optimist/src/services/challenges.mjs
+++ b/nightfall-optimist/src/services/challenges.mjs
@@ -47,8 +47,8 @@ async function commitToChallenge(txDataToSign) {
       2,
     )}`,
   );
+  await saveCommit(commitHash, txDataToSign);
   ws.send(JSON.stringify({ type: 'commit', txDataToSign: commitToSign }));
-  saveCommit(commitHash, txDataToSign);
 }
 
 export async function revealChallenge(txDataToSign) {


### PR DESCRIPTION
When a challenge is recognised by a Challenger, a commit to challenge is done first by calling `commitToChallenge` on chain. Only after this is done, do we reveal the challenge on chain. During `commitToChallenge` we save the commitment in Challenger's DB. During reveal the challenge stage, we get this commitment from the database. Incredibly, commitToChallenge tx is received by the blockchain and the event is even received by the event listener in Challenger's optimist before this commitment is even saved in Challenger's DB. We resolved this issue by awaiting the DB write and only after this sending the `commitToChallenge` on chain. 