### PR TITLE
Hari/l2blocks ordering

### DIFF
--- a/nightfall-optimist/src/routes/block.mjs
+++ b/nightfall-optimist/src/routes/block.mjs
@@ -67,4 +67,14 @@ router.get('/root/:root', async (req, res, next) => {
   }
 });
 
+router.get('/reset-localblock', async (req,res, next) => {
+  logger.debug('block endpoint received get');
+  try {
+    await Block.rollback();
+    res.json({resetstatus: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
 export default router;

--- a/nightfall-optimist/src/routes/block.mjs
+++ b/nightfall-optimist/src/routes/block.mjs
@@ -4,6 +4,7 @@ Routes for checking that a block is valid.
 import express from 'express';
 import logger from 'common-files/utils/logger.mjs';
 import checkBlock from '../services/check-block.mjs';
+import Block from '../classes/block.mjs';
 import {
   getBlockByTransactionHash,
   getBlockByRoot,
@@ -67,11 +68,11 @@ router.get('/root/:root', async (req, res, next) => {
   }
 });
 
-router.get('/reset-localblock', async (req,res, next) => {
+router.get('/reset-localblock', async (req, res, next) => {
   logger.debug('block endpoint received get');
   try {
     await Block.rollback();
-    res.json({resetstatus: true });
+    res.json({ resetstatus: true });
   } catch (err) {
     next(err);
   }

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -45,6 +45,10 @@ should not be called from anywhere else because we only want one instance ever.
 */
 export async function conditionalMakeBlock(proposer) {
   logger.debug('Ready to make blocks');
+  //reset local optimist values before every first L2 block mined in cycle
+  //This will make proposer name L2 blocknumber as next one to the onchain number
+  //which helps in maintaining the blockorder in case of any previous proposer failure
+  Block.rollback();
   while (makeBlocks) {
     logger.silly('Block Assembler is waiting for transactions');
     await nextHigherPriorityQueueHasEmptied(1); // i.e. the highest priority queue is empty

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -45,10 +45,6 @@ should not be called from anywhere else because we only want one instance ever.
 */
 export async function conditionalMakeBlock(proposer) {
   logger.debug('Ready to make blocks');
-  //reset local optimist values before every first L2 block mined in cycle
-  //This will make proposer name L2 blocknumber as next one to the onchain number
-  //which helps in maintaining the blockorder in case of any previous proposer failure
-  Block.rollback();
   while (makeBlocks) {
     logger.silly('Block Assembler is waiting for transactions');
     await nextHigherPriorityQueueHasEmptied(1); // i.e. the highest priority queue is empty


### PR DESCRIPTION
This fixes issue #164  .

Created a new route  `/reset-localblock'`  in `nightfall-optimist > src > routes > block.mjs ` 

## Resetting LocalL2BlockNumber

***Request Type***:    GET
***Name***: /reset-localblock
***Input***:           -
***Returns***:     On Success  {"resetstatus":true}

This sets 
`  localLeafCount = 0
    localBlockNumberL2 = 0
    localRoot = 0
    localPreviousBlockHash = ZERO`
  
This method requires proposer to manually call the route to reset L2 block. This should be called only when proposer is not currentProposer as there could be a conflict in local values whilst building new blocks.  The process can be automated instead of an API by using scheduler/ queuing procedure.