### PR TITLE
add gtihub workflow to deploy on ropsten testnet and  run integration test

### DIFF
--- a/.github/workflows/check-PRs.yml
+++ b/.github/workflows/check-PRs.yml
@@ -37,6 +37,10 @@ jobs:
           sleep 1000
           npm test
 
+      - name: debug logs
+        if: always()
+        run: cat ganache-test.log
+
       - name: If integration test failed, shutdown the Containers
         if: failure()
         run: docker-compose -f docker-compose.yml -f docker-compose.ganache.yml down -v
@@ -70,6 +74,10 @@ jobs:
           sleep 1000
           npm run test-gas
 
+      - name: debug logs
+        if: always()
+        run: cat test-gas.log
+
       - name: If integration test failed, shutdown the Containers
         if: failure()
         run: docker-compose -f docker-compose.yml -f docker-compose.ganache.yml down -v
@@ -80,3 +88,56 @@ jobs:
         with:
           name: test-gas-logs
           path: ./test-gas.log
+
+  testnet-test:
+    runs-on: ubuntu-18.04
+    environment: TESTNET_DEPLOYMENT
+    env:
+      ETH_PRIVATE_KEY: ${{ secrets.ETH_PRIVATE_KEY }}
+      INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
+      INFURA_PROJECT_SECRET: ${{ secrets.INFURA_PROJECT_SECRET }}
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.17.0'
+
+      - name: balance before deployment and integration test
+        run: |
+          curl -u :$INFURA_PROJECT_SECRET https://ropsten.infura.io/v3/$INFURA_PROJECT_ID \
+          -X POST \
+          -H "Content-Type: application/json" \
+          -d '{"jsonrpc":"2.0","method":"eth_getBalance","params": ["0x29100E7E3dA6654BF63d9E7804ADe518aCc5AaA5", "latest"],"id":1}'
+
+      - name: Start Containers
+        run: |
+          docker-compose build
+          ./start-nightfall -t &> testnet-test.log &disown
+
+      - name: Run integration test
+        run: |
+          npm ci
+          sleep 1500
+          npm run testnet-test
+
+      - name: balance after deployment and integration test
+        run: |
+          curl  -u :$INFURA_PROJECT_SECRET https://ropsten.infura.io/v3/$INFURA_PROJECT_ID \
+          -X POST \
+          -H "Content-Type: application/json" \
+          -d '{"jsonrpc":"2.0","method":"eth_getBalance","params": ["0x29100E7E3dA6654BF63d9E7804ADe518aCc5AaA5", "latest"],"id":1}'
+
+      - name: debug logs
+        if: always()
+        run: cat testnet-test.log
+
+      - name: If integration test failed, shutdown the Containers
+        if: failure()
+        run: docker-compose down -v
+
+      - name: If integration test failed, upload logs files as artifacts
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: testnet-test-logs
+          path: ./testnet-test.log

--- a/common-files/utils/web3.mjs
+++ b/common-files/utils/web3.mjs
@@ -16,18 +16,10 @@ export default {
   connect() {
     if (this.web3) return this.web3.currentProvider;
 
-    logger.info('Blockchain Connecting ...');
+    logger.info('Blockchain Connecting ...', config.BLOCKCHAIN_TESTNET_URL);
     const provider = new Web3.providers.WebsocketProvider(
-      `ws://${config.BLOCKCHAIN_WS_HOST}:${config.BLOCKCHAIN_PORT}`,
-      {
-        timeout: 3600000,
-        reconnect: {
-          auto: true,
-          delay: 5000, // ms
-          maxAttempts: 120,
-          onTimeout: false,
-        },
-      }, // set a 10 minute timeout
+      config.BLOCKCHAIN_TESTNET_URL,
+      config.WEB3_RECONNET,
     );
 
     provider.on('error', err => logger.error(`web3 error: ${err}`));

--- a/common-files/utils/web3.mjs
+++ b/common-files/utils/web3.mjs
@@ -4,6 +4,8 @@ import Web3 from 'web3';
 import config from 'config';
 import logger from './logger.mjs';
 
+const { INFURA_PROJECT_SECRET } = process.env;
+
 export default {
   connection() {
     if (!this.web3) this.connect();
@@ -16,11 +18,24 @@ export default {
   connect() {
     if (this.web3) return this.web3.currentProvider;
 
-    logger.info('Blockchain Connecting ...', config.BLOCKCHAIN_TESTNET_URL);
-    const provider = new Web3.providers.WebsocketProvider(
-      config.BLOCKCHAIN_TESTNET_URL,
-      config.WEB3_RECONNET,
-    );
+    logger.info('Blockchain Connecting ...');
+
+    let provider;
+    if (config.ENABLE_TESTNET_DEPLOY) {
+      if (!INFURA_PROJECT_SECRET) throw Error('env INFURA_PROJECT_SECRET not set');
+
+      provider = new Web3.providers.WebsocketProvider(config.BLOCKCHAIN_TESTNET_URL, {
+        ...config.WEB3_RECONNET,
+        headers: {
+          authorization: `Basic ${Buffer.from(`:${INFURA_PROJECT_SECRET}`).toString('base64')}`,
+        },
+      });
+    } else {
+      provider = new Web3.providers.WebsocketProvider(
+        config.BLOCKCHAIN_TESTNET_URL,
+        config.WEB3_RECONNET,
+      );
+    }
 
     provider.on('error', err => logger.error(`web3 error: ${err}`));
     provider.on('connect', () => logger.info('Blockchain Connected ...'));
@@ -44,5 +59,24 @@ export default {
   },
   disconnect() {
     this.web3.currentProvider.connection.close();
+  },
+
+  // function only needed for testnet deployment
+  async submitRawTransaction(rawTransaction, contractAddress, value = 0) {
+    if (!rawTransaction) throw Error('No tx data to sign');
+    if (!contractAddress) throw Error('No contract address passed');
+    if (!config.WEB3_OPTIONS.from) throw Error('config WEB3_OPTIONS.from is not set');
+    if (!config.ETH_PRIVATE_KEY) throw Error('config ETH_PRIVATE_KEY not set');
+
+    const tx = {
+      to: contractAddress,
+      data: rawTransaction,
+      value,
+      gas: config.WEB3_OPTIONS.gas,
+      gasPrice: config.WEB3_OPTIONS.gasPrice,
+    };
+
+    const signed = await this.web3.eth.accounts.signTransaction(tx, config.ETH_PRIVATE_KEY);
+    return this.web3.eth.sendSignedTransaction(signed.rawTransaction);
   },
 };

--- a/config/default.js
+++ b/config/default.js
@@ -24,8 +24,12 @@ module.exports = {
   PROTOCOL: 'http://', // connect to zokrates microservice like this
   WEBSOCKET_PORT: process.env.WEBSOCKET_PORT || 8080,
   ZOKRATES_WORKER_HOST: process.env.ZOKRATES_WORKER_HOST || 'worker',
-  BLOCKCHAIN_WS_HOST: process.env.BLOCKCHAIN_WS_HOST || 'openethereum',
-  BLOCKCHAIN_PORT: process.env.BLOCKCHAIN_PORT || '8546',
+  BLOCKCHAIN_WS_HOST: process.env.BLOCKCHAIN_WS_HOST,
+  BLOCKCHAIN_PORT: process.env.BLOCKCHAIN_PORT,
+  BLOCKCHAIN_TESTNET_URL:
+    process.env.BLOCKCHAIN_TESTNET_URL ||
+    `ws://${process.env.BLOCKCHAIN_WS_HOST}:${process.env.BLOCKCHAIN_PORT}`,
+  ETH_MNEMONIC: process.env.ETH_MNEMONIC,
   TIMBER_HOST: process.env.TIMBER_HOST || 'timber',
   TIMBER_PORT: process.env.TIMBER_PORT || 80,
   OPTIMIST_HOST: process.env.OPTIMIST_HOST || 'optimist',
@@ -34,6 +38,15 @@ module.exports = {
     gas: process.env.GAS || 1000000,
     gasPrice: process.env.GAS_PRICE || '20000000000',
     from: process.env.FROM_ADDRESS || undefined,
+  },
+  WEB3_RECONNET: {
+    // Enable auto reconnection
+    reconnect: {
+      auto: true,
+      delay: 5000, // ms
+      maxAttempts: 5,
+      onTimeout: false,
+    },
   },
   PROVING_SCHEME: process.env.PROVING_SCHEME || 'gm17',
   BACKEND: process.env.BACKEND || 'libsnark',

--- a/config/default.js
+++ b/config/default.js
@@ -24,12 +24,11 @@ module.exports = {
   PROTOCOL: 'http://', // connect to zokrates microservice like this
   WEBSOCKET_PORT: process.env.WEBSOCKET_PORT || 8080,
   ZOKRATES_WORKER_HOST: process.env.ZOKRATES_WORKER_HOST || 'worker',
-  BLOCKCHAIN_WS_HOST: process.env.BLOCKCHAIN_WS_HOST,
-  BLOCKCHAIN_PORT: process.env.BLOCKCHAIN_PORT,
   BLOCKCHAIN_TESTNET_URL:
     process.env.BLOCKCHAIN_TESTNET_URL ||
     `ws://${process.env.BLOCKCHAIN_WS_HOST}:${process.env.BLOCKCHAIN_PORT}`,
-  ETH_MNEMONIC: process.env.ETH_MNEMONIC,
+  ENABLE_TESTNET_DEPLOY: process.env.ENABLE_TESTNET_DEPLOY === 'true',
+  ETH_PRIVATE_KEY: process.env.ETH_PRIVATE_KEY,
   TIMBER_HOST: process.env.TIMBER_HOST || 'timber',
   TIMBER_PORT: process.env.TIMBER_PORT || 80,
   OPTIMIST_HOST: process.env.OPTIMIST_HOST || 'optimist',
@@ -40,11 +39,16 @@ module.exports = {
     from: process.env.FROM_ADDRESS || undefined,
   },
   WEB3_RECONNET: {
-    // Enable auto reconnection
+    clientConfig: {
+      // Useful to keep a connection alive
+      keepalive: true,
+      keepaliveInterval: 60000,
+    },
+    timeout: 3600000,
     reconnect: {
       auto: true,
       delay: 5000, // ms
-      maxAttempts: 5,
+      maxAttempts: 120,
       onTimeout: false,
     },
   },
@@ -62,7 +66,7 @@ module.exports = {
   ], // used to encode/decode proposeBlock signature
   SUBMIT_TRANSACTION_TYPES:
     '(uint64,uint64,uint8,uint8,bytes32,bytes32,bytes32,bytes32,bytes32[2],bytes32[2],bytes32[8],uint[4])',
-  RETRIES: process.env.AUTOSTART_RETRIES || 50,
+  RETRIES: Number(process.env.AUTOSTART_RETRIES) || 50,
   NODE_HASHLENGTH: 32,
   ZERO: '0x0000000000000000000000000000000000000000000000000000000000000000',
   HASH_TYPE: 'mimc',

--- a/config/timber.js
+++ b/config/timber.js
@@ -74,7 +74,9 @@ module.exports = {
   web3: {
     host: process.env.BLOCKCHAIN_WS_HOST,
     port: process.env.BLOCKCHAIN_PORT,
-    // not used - remove after testing shows it's not needed:
+    url:
+      process.env.BLOCKCHAIN_TESTNET_URL ||
+      `ws://${process.env.BLOCKCHAIN_WS_HOST}:${process.env.BLOCKCHAIN_PORT}`,
     options: {
       defaultAccount: '0x0',
       defaultBlock: '0', // e.g. the genesis block our blockchain
@@ -84,6 +86,14 @@ module.exports = {
       transactionConfirmationBlocks: 15,
       transactionPollingTimeout: 480,
       // transactionSigner: new CustomTransactionSigner()
+
+      // Enable auto reconnection
+      reconnect: {
+        auto: true,
+        delay: 5000, // ms
+        maxAttempts: 5,
+        onTimeout: false,
+      },
     },
   },
   LOG_LEVEL: process.env.LOG_LEVEL || 'info',

--- a/config/timber.js
+++ b/config/timber.js
@@ -30,6 +30,7 @@ module.exports = {
 
   UPDATE_FREQUENCY: 100, // TODO: recalculate the tree every 'x' leaves - NOT USED YET
   BULK_WRITE_BUFFER_SIZE: 1000, // number of documents to add to a buffer before bulk-writing them to the db
+  ENABLE_TESTNET_DEPLOY: process.env.ENABLE_TESTNET_DEPLOY === 'true',
 
   // contracts to filter:
   contracts: {
@@ -72,12 +73,11 @@ module.exports = {
 
   // web3:
   web3: {
-    host: process.env.BLOCKCHAIN_WS_HOST,
-    port: process.env.BLOCKCHAIN_PORT,
     url:
       process.env.BLOCKCHAIN_TESTNET_URL ||
       `ws://${process.env.BLOCKCHAIN_WS_HOST}:${process.env.BLOCKCHAIN_PORT}`,
     options: {
+      // some of options are not in use - remove after testing shows it's not needed:
       defaultAccount: '0x0',
       defaultBlock: '0', // e.g. the genesis block our blockchain
       defaultGas: 100000,
@@ -86,12 +86,16 @@ module.exports = {
       transactionConfirmationBlocks: 15,
       transactionPollingTimeout: 480,
       // transactionSigner: new CustomTransactionSigner()
-
-      // Enable auto reconnection
+      clientConfig: {
+        // Useful to keep a connection alive
+        keepalive: true,
+        keepaliveInterval: 60000,
+      },
+      timeout: 3600000,
       reconnect: {
         auto: true,
         delay: 5000, // ms
-        maxAttempts: 5,
+        maxAttempts: 120,
         onTimeout: false,
       },
     },

--- a/docker-compose.testnet.yml
+++ b/docker-compose.testnet.yml
@@ -1,39 +1,65 @@
 version: '3.5'
-# Use this script for running up nightfall_3 in 'rinkeby' mode with local
+# Use this script for running up nightfall_3 in 'ropsten' mode with local
 # Use it as an override file for docker-compose.yml
 # See the readme for more information.
 services:
-
-  client1: 
+  client1:
     environment:
-      BLOCKCHAIN_TESTNET_URL: "wss://rinkeby.infura.io/ws/v3/0652859c595f4f429c3e4b83c8ff28d2"
+      BLOCKCHAIN_TESTNET_URL: 'wss://ropsten.infura.io/ws/v3/${INFURA_PROJECT_ID}'
+      ENABLE_TESTNET_DEPLOY: 'true'
+      AUTOSTART_RETRIES: 300
+      FROM_ADDRESS: '0x29100E7E3dA6654BF63d9E7804ADe518aCc5AaA5'
+      INFURA_PROJECT_SECRET: $INFURA_PROJECT_SECRET
 
   client2:
     environment:
-      BLOCKCHAIN_TESTNET_URL: "wss://rinkeby.infura.io/ws/v3/0652859c595f4f429c3e4b83c8ff28d2"
+      BLOCKCHAIN_TESTNET_URL: 'wss://ropsten.infura.io/ws/v3/${INFURA_PROJECT_ID}'
+      ENABLE_TESTNET_DEPLOY: 'true'
+      AUTOSTART_RETRIES: 300
+      FROM_ADDRESS: '0x29100E7E3dA6654BF63d9E7804ADe518aCc5AaA5'
+      INFURA_PROJECT_SECRET: $INFURA_PROJECT_SECRET
 
   deployer:
     environment:
-      LOG_LEVEL: debug
       # ETH_NETWORK sets the network selected by Truffle from truffle-config.js
       # startup routines will wait for a blockchain client to be reachable on this network
-      ETH_NETWORK: rinkeby
-      BLOCKCHAIN_TESTNET_URL: "wss://rinkeby.infura.io/ws/v3/0652859c595f4f429c3e4b83c8ff28d2"
-      ETH_MNEMONIC: $ETH_MNEMONIC
+      ETH_NETWORK: ropsten
+      BLOCKCHAIN_TESTNET_URL: 'wss://:${INFURA_PROJECT_SECRET}@ropsten.infura.io/ws/v3/${INFURA_PROJECT_ID}'
+      ENABLE_TESTNET_DEPLOY: 'true'
+      AUTOSTART_RETRIES: 300
+      FROM_ADDRESS: '0x29100E7E3dA6654BF63d9E7804ADe518aCc5AaA5'
+      ETH_PRIVATE_KEY: $ETH_PRIVATE_KEY
+      INFURA_PROJECT_SECRET: $INFURA_PROJECT_SECRET
 
   # Timber service, configured for nightfall
   timber1:
     environment:
-      BLOCKCHAIN_TESTNET_URL: "wss://rinkeby.infura.io/ws/v3/0652859c595f4f429c3e4b83c8ff28d2"
+      BLOCKCHAIN_TESTNET_URL: 'wss://ropsten.infura.io/ws/v3/${INFURA_PROJECT_ID}'
+      ENABLE_TESTNET_DEPLOY: 'true'
+      AUTOSTART_RETRIES: 300
+      FROM_ADDRESS: '0x29100E7E3dA6654BF63d9E7804ADe518aCc5AaA5'
+      INFURA_PROJECT_SECRET: $INFURA_PROJECT_SECRET
 
   optimist1:
     environment:
-      BLOCKCHAIN_TESTNET_URL: "wss://rinkeby.infura.io/ws/v3/0652859c595f4f429c3e4b83c8ff28d2"
+      BLOCKCHAIN_TESTNET_URL: 'wss://ropsten.infura.io/ws/v3/${INFURA_PROJECT_ID}'
+      ENABLE_TESTNET_DEPLOY: 'true'
+      AUTOSTART_RETRIES: 300
+      FROM_ADDRESS: '0x29100E7E3dA6654BF63d9E7804ADe518aCc5AaA5'
+      INFURA_PROJECT_SECRET: $INFURA_PROJECT_SECRET
 
   timber2:
     environment:
-      BLOCKCHAIN_TESTNET_URL: "wss://rinkeby.infura.io/ws/v3/0652859c595f4f429c3e4b83c8ff28d2"
+      BLOCKCHAIN_TESTNET_URL: 'wss://ropsten.infura.io/ws/v3/${INFURA_PROJECT_ID}'
+      ENABLE_TESTNET_DEPLOY: 'true'
+      AUTOSTART_RETRIES: 300
+      FROM_ADDRESS: '0x29100E7E3dA6654BF63d9E7804ADe518aCc5AaA5'
+      INFURA_PROJECT_SECRET: $INFURA_PROJECT_SECRET
 
   optimist2:
     environment:
-      BLOCKCHAIN_TESTNET_URL: "wss://rinkeby.infura.io/ws/v3/0652859c595f4f429c3e4b83c8ff28d2"
+      BLOCKCHAIN_TESTNET_URL: 'wss://ropsten.infura.io/ws/v3/${INFURA_PROJECT_ID}'
+      ENABLE_TESTNET_DEPLOY: 'true'
+      AUTOSTART_RETRIES: 300
+      FROM_ADDRESS: '0x29100E7E3dA6654BF63d9E7804ADe518aCc5AaA5'
+      INFURA_PROJECT_SECRET: $INFURA_PROJECT_SECRET

--- a/docker-compose.testnet.yml
+++ b/docker-compose.testnet.yml
@@ -1,0 +1,39 @@
+version: '3.5'
+# Use this script for running up nightfall_3 in 'rinkeby' mode with local
+# Use it as an override file for docker-compose.yml
+# See the readme for more information.
+services:
+
+  client1: 
+    environment:
+      BLOCKCHAIN_TESTNET_URL: "wss://rinkeby.infura.io/ws/v3/0652859c595f4f429c3e4b83c8ff28d2"
+
+  client2:
+    environment:
+      BLOCKCHAIN_TESTNET_URL: "wss://rinkeby.infura.io/ws/v3/0652859c595f4f429c3e4b83c8ff28d2"
+
+  deployer:
+    environment:
+      LOG_LEVEL: debug
+      # ETH_NETWORK sets the network selected by Truffle from truffle-config.js
+      # startup routines will wait for a blockchain client to be reachable on this network
+      ETH_NETWORK: rinkeby
+      BLOCKCHAIN_TESTNET_URL: "wss://rinkeby.infura.io/ws/v3/0652859c595f4f429c3e4b83c8ff28d2"
+      ETH_MNEMONIC: $ETH_MNEMONIC
+
+  # Timber service, configured for nightfall
+  timber1:
+    environment:
+      BLOCKCHAIN_TESTNET_URL: "wss://rinkeby.infura.io/ws/v3/0652859c595f4f429c3e4b83c8ff28d2"
+
+  optimist1:
+    environment:
+      BLOCKCHAIN_TESTNET_URL: "wss://rinkeby.infura.io/ws/v3/0652859c595f4f429c3e4b83c8ff28d2"
+
+  timber2:
+    environment:
+      BLOCKCHAIN_TESTNET_URL: "wss://rinkeby.infura.io/ws/v3/0652859c595f4f429c3e4b83c8ff28d2"
+
+  optimist2:
+    environment:
+      BLOCKCHAIN_TESTNET_URL: "wss://rinkeby.infura.io/ws/v3/0652859c595f4f429c3e4b83c8ff28d2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,7 +202,7 @@ services:
       MONGO_PORT: 27017
       MONGO_NAME: merkle_tree
       HASH_TYPE: mimc
-      LOG_LEVEL: info
+      LOG_LEVEL: debug
       AUTOSTART: enabled
 
   # Timber service, configured for nightfall
@@ -310,7 +310,7 @@ services:
       HASH_TYPE: mimc
       LOG_LEVEL: debug
       IS_CHALLENGER: 'true'
-      TRANSACTIONS_PER_BLOCK: 2
+      TRANSACTIONS_PER_BLOCK: ${TRANSACTIONS_PER_BLOCK:-2}
       TIMBER_HOST: timber1
       TIMBER_PORT: 80
     command: ['npm', 'run', 'dev']
@@ -341,13 +341,13 @@ services:
         source: ./config/default.js
         target: /app/config/default.js
     environment:
-      WEBSOCKET_PORT: 8084
+      WEBSOCKET_PORT: 8080
       BLOCKCHAIN_WS_HOST: blockchain1
       BLOCKCHAIN_PORT: 8546
       HASH_TYPE: mimc
       LOG_LEVEL: debug
       IS_CHALLENGER: 'true'
-      TRANSACTIONS_PER_BLOCK: 2
+      TRANSACTIONS_PER_BLOCK: ${TRANSACTIONS_PER_BLOCK:-2}
       TIMBER_HOST: timber2
       TIMBER_PORT: 80
     command: ['npm', 'run', 'dev']

--- a/nightfall-client/docker-entrypoint.sh
+++ b/nightfall-client/docker-entrypoint.sh
@@ -2,8 +2,16 @@
 mongod --dbpath /app/mongodb/ --fork --logpath /var/log/mongodb/mongod.log --bind_ip_all
 while ! nc -z localhost 27017; do sleep 3; done
 echo 'mongodb started'
-# wait until there's a blockchain client up
-while ! nc -z ${BLOCKCHAIN_WS_HOST} ${BLOCKCHAIN_PORT}; do sleep 3; done
+
+# check if testnet url exist: this means there is no
+# local blockchain running instead we are trying to to connect
+# testnet network via infura
+if [ -z "${BLOCKCHAIN_TESTNET_URL}" ]
+then
+  # wait until there's a blockchain client up
+  while ! nc -z ${BLOCKCHAIN_WS_HOST} ${BLOCKCHAIN_PORT}; do sleep 3; done
+fi
+
 # wait until there's a zokrates worker host up
 while ! nc -z ${ZOKRATES_WORKER_HOST} 80; do sleep 3; done
 

--- a/nightfall-deployer/contracts/Config.sol
+++ b/nightfall-deployer/contracts/Config.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.0;
 
 contract Config {
-  uint constant REGISTRATION_BOND = 10 ether; // TODO owner can update
-  uint constant BLOCK_STAKE = 1 ether;
+  uint constant REGISTRATION_BOND = 10 wei; // TODO owner can update
+  uint constant BLOCK_STAKE = 1 wei;
   uint constant ROTATE_PROPOSER_BLOCKS = 4;
   uint constant COOLING_OFF_PERIOD = 1 weeks;
   bytes32 constant ZERO = bytes32(0);

--- a/nightfall-deployer/entrypoint.sh
+++ b/nightfall-deployer/entrypoint.sh
@@ -1,9 +1,16 @@
 #! /bin/bash
 set -o errexit
-set -o nounset
 set -o pipefail
-# wait until there's a blockchain client up
-while ! nc -z ${BLOCKCHAIN_WS_HOST} ${BLOCKCHAIN_PORT}; do sleep 3; done
+
+# check if testnet url exist: this means there is no
+# local blockchain running instead we are trying to to connect
+# testnet network via infura
+if [ -z "${BLOCKCHAIN_TESTNET_URL}" ]
+then
+  # wait until there's a blockchain client up
+  while ! nc -z ${BLOCKCHAIN_WS_HOST} ${BLOCKCHAIN_PORT}; do sleep 3; done
+fi
+
 npx truffle migrate --network=${ETH_NETWORK} --reset
 
 #sleep 10

--- a/nightfall-deployer/package-lock.json
+++ b/nightfall-deployer/package-lock.json
@@ -171,7 +171,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
       "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-      "optional": true,
       "requires": {
         "@babel/highlight": "^7.14.5"
       }
@@ -179,8 +178,7 @@
     "@babel/compat-data": {
       "version": "7.14.9",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.9.tgz",
-      "integrity": "sha512-p3QjZmMGHDGdpcwEYYWu7i7oJShJvtgMjJeb0W95PPhSm++3lm8YXYOh45Y6iCN9PkZLTZ7CIX5nFrp7pw7TXw==",
-      "optional": true
+      "integrity": "sha512-p3QjZmMGHDGdpcwEYYWu7i7oJShJvtgMjJeb0W95PPhSm++3lm8YXYOh45Y6iCN9PkZLTZ7CIX5nFrp7pw7TXw=="
     },
     "@babel/core": {
       "version": "7.14.8",
@@ -306,7 +304,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
       "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
-      "optional": true,
       "requires": {
         "@babel/compat-data": "^7.14.5",
         "@babel/helper-validator-option": "^7.14.5",
@@ -317,8 +314,7 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "optional": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -334,6 +330,129 @@
         "@babel/helper-optimise-call-expression": "^7.14.5",
         "@babel/helper-replace-supers": "^7.14.5",
         "@babel/helper-split-export-declaration": "^7.14.5"
+      }
+    },
+    "@babel/helper-define-polyfill-provider": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
+      "integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/traverse": "^7.13.0",
+        "debug": "^4.1.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.14.2",
+        "semver": "^6.1.2"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+          "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+          "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.15.4",
+            "@babel/template": "^7.15.4",
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+          "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+          "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+          "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
+          "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+          "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+          "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.4",
+            "@babel/helper-function-name": "^7.15.4",
+            "@babel/helper-hoist-variables": "^7.15.4",
+            "@babel/helper-split-export-declaration": "^7.15.4",
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "@babel/helper-function-name": {
@@ -426,7 +545,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
       "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
-      "optional": true,
       "requires": {
         "@babel/types": "^7.14.5"
       },
@@ -435,7 +553,6 @@
           "version": "7.14.9",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
           "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
-          "optional": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
@@ -518,8 +635,7 @@
     "@babel/helper-plugin-utils": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
-      "optional": true
+      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
     },
     "@babel/helper-replace-supers": {
       "version": "7.14.5",
@@ -634,14 +750,12 @@
     "@babel/helper-validator-identifier": {
       "version": "7.14.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
-      "optional": true
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
     },
     "@babel/helper-validator-option": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
-      "optional": true
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
     },
     "@babel/helpers": {
       "version": "7.14.8",
@@ -693,7 +807,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
       "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-      "optional": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.5",
         "chalk": "^2.0.0",
@@ -943,6 +1056,28 @@
             "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
           }
+        }
+      }
+    },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.15.0.tgz",
+      "integrity": "sha512-sfHYkLGjhzWTq6xsuQ01oEsUYjkHRux9fW1iUA68dC7Qd8BS1Unq4aZ8itmQp95zUzIcyR2EbNMTzAicFj+guw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "babel-plugin-polyfill-corejs2": "^0.2.2",
+        "babel-plugin-polyfill-corejs3": "^0.2.2",
+        "babel-plugin-polyfill-regenerator": "^0.2.2",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
@@ -2361,7 +2496,7 @@
         "sync-fetch": "0.3.0",
         "tslib": "~2.2.0",
         "valid-url": "1.0.9",
-        "ws": "7.5.3"
+        "ws": "7.4.5"
       },
       "dependencies": {
         "@graphql-tools/delegate": {
@@ -3492,6 +3627,45 @@
         "ora": "^3.4.0"
       }
     },
+    "@truffle/hdwallet-provider": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.5.0.tgz",
+      "integrity": "sha512-nWgOBRT3ZCX7VAFVrDrWLvX405J502WlP5azmnWbM5r3fqDKUJlBdtHZTCGeiDKAT6twtpTUj6tO8mKmrjF8PA==",
+      "dev": true,
+      "requires": {
+        "@trufflesuite/web3-provider-engine": "15.0.13-1",
+        "eth-sig-util": "^3.0.1",
+        "ethereum-cryptography": "^0.1.3",
+        "ethereum-protocol": "^1.0.1",
+        "ethereumjs-common": "^1.5.0",
+        "ethereumjs-tx": "^2.1.2",
+        "ethereumjs-util": "^6.1.0",
+        "ethereumjs-wallet": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "ethereumjs-util": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.3"
+          }
+        }
+      }
+    },
     "@truffle/interface-adapter": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.5.3.tgz",
@@ -3609,6 +3783,85 @@
         }
       }
     },
+    "@truffle/preserve-to-filecoin": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@truffle/preserve-to-filecoin/-/preserve-to-filecoin-0.2.4.tgz",
+      "integrity": "sha512-kUzvSUCfpH0gcLxOM8eaYy5dPuJYh/wBpjU5bEkCcrx1HQWr73fR3slS8cO5PNqaxkDvm8RDlh7Lha2JTLp4rw==",
+      "optional": true,
+      "requires": {
+        "@truffle/preserve": "^0.2.4",
+        "cids": "^1.1.5",
+        "delay": "^5.0.0",
+        "filecoin.js": "^0.0.5-alpha"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "1.1.9",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.9.tgz",
+          "integrity": "sha512-l11hWRfugIcbGuTZwAM5PwpjPPjyb6UZOGwlHSnOBV5o07XhQ4gNpBN67FbODvpjyHtd+0Xs6KNvUcGBiDRsdg==",
+          "optional": true,
+          "requires": {
+            "multibase": "^4.0.1",
+            "multicodec": "^3.0.1",
+            "multihashes": "^4.0.1",
+            "uint8arrays": "^3.0.0"
+          }
+        },
+        "multibase": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
+          "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
+          "optional": true,
+          "requires": {
+            "@multiformats/base-x": "^4.0.1"
+          }
+        },
+        "multicodec": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.2.1.tgz",
+          "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
+          "optional": true,
+          "requires": {
+            "uint8arrays": "^3.0.0",
+            "varint": "^6.0.0"
+          }
+        },
+        "multihashes": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
+          "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
+          "optional": true,
+          "requires": {
+            "multibase": "^4.0.1",
+            "uint8arrays": "^3.0.0",
+            "varint": "^5.0.2"
+          },
+          "dependencies": {
+            "varint": {
+              "version": "5.0.2",
+              "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+              "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
+              "optional": true
+            }
+          }
+        },
+        "uint8arrays": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
+          "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+          "optional": true,
+          "requires": {
+            "multiformats": "^9.4.2"
+          }
+        },
+        "varint": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+          "optional": true
+        }
+      }
+    },
     "@truffle/preserve-to-ipfs": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@truffle/preserve-to-ipfs/-/preserve-to-ipfs-0.2.4.tgz",
@@ -3642,6 +3895,311 @@
         "json-pointer": "^0.6.0",
         "node-interval-tree": "^1.3.3",
         "web3-utils": "1.5.0"
+      }
+    },
+    "@trufflesuite/eth-json-rpc-filters": {
+      "version": "4.1.2-1",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/eth-json-rpc-filters/-/eth-json-rpc-filters-4.1.2-1.tgz",
+      "integrity": "sha512-/MChvC5dw2ck9NU1cZmdovCz2VKbOeIyR4tcxDvA5sT+NaL0rA2/R5U0yI7zsbo1zD+pgqav77rQHTzpUdDNJQ==",
+      "dev": true,
+      "requires": {
+        "@trufflesuite/eth-json-rpc-middleware": "^4.4.2-0",
+        "await-semaphore": "^0.1.3",
+        "eth-query": "^2.1.2",
+        "json-rpc-engine": "^5.1.3",
+        "lodash.flatmap": "^4.5.0",
+        "safe-event-emitter": "^1.0.1"
+      }
+    },
+    "@trufflesuite/eth-json-rpc-infura": {
+      "version": "4.0.3-0",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/eth-json-rpc-infura/-/eth-json-rpc-infura-4.0.3-0.tgz",
+      "integrity": "sha512-xaUanOmo0YLqRsL0SfXpFienhdw5bpQ1WEXxMTRi57az4lwpZBv4tFUDvcerdwJrxX9wQqNmgUgd1BrR01dumw==",
+      "dev": true,
+      "requires": {
+        "@trufflesuite/eth-json-rpc-middleware": "^4.4.2-1",
+        "cross-fetch": "^2.1.1",
+        "eth-json-rpc-errors": "^1.0.1",
+        "json-rpc-engine": "^5.1.3"
+      },
+      "dependencies": {
+        "cross-fetch": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.5.tgz",
+          "integrity": "sha512-xqYAhQb4NhCJSRym03dwxpP1bYXpK3y7UN83Bo2WFi3x1Zmzn0SL/6xGoPr+gpt4WmNrgCCX3HPysvOwFOW36w==",
+          "dev": true,
+          "requires": {
+            "node-fetch": "2.6.1",
+            "whatwg-fetch": "2.0.4"
+          }
+        },
+        "eth-json-rpc-errors": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-1.1.1.tgz",
+          "integrity": "sha512-WT5shJ5KfNqHi9jOZD+ID8I1kuYWNrigtZat7GOQkvwo99f8SzAVaEcWhJUv656WiZOAg3P1RiJQANtUmDmbIg==",
+          "dev": true,
+          "requires": {
+            "fast-safe-stringify": "^2.0.6"
+          }
+        }
+      }
+    },
+    "@trufflesuite/eth-json-rpc-middleware": {
+      "version": "4.4.2-1",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/eth-json-rpc-middleware/-/eth-json-rpc-middleware-4.4.2-1.tgz",
+      "integrity": "sha512-iEy9H8ja7/8aYES5HfrepGBKU9n/Y4OabBJEklVd/zIBlhCCBAWBqkIZgXt11nBXO/rYAeKwYuE3puH3ByYnLA==",
+      "dev": true,
+      "requires": {
+        "@trufflesuite/eth-sig-util": "^1.4.2",
+        "btoa": "^1.2.1",
+        "clone": "^2.1.1",
+        "eth-json-rpc-errors": "^1.0.1",
+        "eth-query": "^2.1.2",
+        "ethereumjs-block": "^1.6.0",
+        "ethereumjs-tx": "^1.3.7",
+        "ethereumjs-util": "^5.1.2",
+        "ethereumjs-vm": "^2.6.0",
+        "fetch-ponyfill": "^4.0.0",
+        "json-rpc-engine": "^5.1.3",
+        "json-stable-stringify": "^1.0.1",
+        "pify": "^3.0.0",
+        "safe-event-emitter": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+          "dev": true
+        },
+        "eth-json-rpc-errors": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-1.1.1.tgz",
+          "integrity": "sha512-WT5shJ5KfNqHi9jOZD+ID8I1kuYWNrigtZat7GOQkvwo99f8SzAVaEcWhJUv656WiZOAg3P1RiJQANtUmDmbIg==",
+          "dev": true,
+          "requires": {
+            "fast-safe-stringify": "^2.0.6"
+          }
+        },
+        "ethereum-common": {
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
+          "dev": true
+        },
+        "ethereumjs-tx": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+          "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+          "dev": true,
+          "requires": {
+            "ethereum-common": "^0.0.18",
+            "ethereumjs-util": "^5.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        }
+      }
+    },
+    "@trufflesuite/eth-sig-util": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
+      "integrity": "sha512-+GyfN6b0LNW77hbQlH3ufZ/1eCON7mMrGym6tdYf7xiNw9Vv3jBO72bmmos1EId2NgBvPMhmYYm6DSLQFTmzrA==",
+      "dev": true,
+      "requires": {
+        "ethereumjs-abi": "^0.6.8",
+        "ethereumjs-util": "^5.1.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        }
+      }
+    },
+    "@trufflesuite/web3-provider-engine": {
+      "version": "15.0.13-1",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/web3-provider-engine/-/web3-provider-engine-15.0.13-1.tgz",
+      "integrity": "sha512-6u3x/iIN5fyj8pib5QTUDmIOUiwAGhaqdSTXdqCu6v9zo2BEwdCqgEJd1uXDh3DBmPRDfiZ/ge8oUPy7LerpHg==",
+      "dev": true,
+      "requires": {
+        "@trufflesuite/eth-json-rpc-filters": "^4.1.2-1",
+        "@trufflesuite/eth-json-rpc-infura": "^4.0.3-0",
+        "@trufflesuite/eth-json-rpc-middleware": "^4.4.2-1",
+        "@trufflesuite/eth-sig-util": "^1.4.2",
+        "async": "^2.5.0",
+        "backoff": "^2.5.0",
+        "clone": "^2.0.0",
+        "cross-fetch": "^2.1.0",
+        "eth-block-tracker": "^4.4.2",
+        "eth-json-rpc-errors": "^2.0.2",
+        "ethereumjs-block": "^1.2.2",
+        "ethereumjs-tx": "^1.2.0",
+        "ethereumjs-util": "^5.1.5",
+        "ethereumjs-vm": "^2.3.4",
+        "json-stable-stringify": "^1.0.1",
+        "promise-to-callback": "^1.0.0",
+        "readable-stream": "^2.2.9",
+        "request": "^2.85.0",
+        "semaphore": "^1.0.3",
+        "ws": "^5.1.1",
+        "xhr": "^2.2.0",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+          "dev": true
+        },
+        "cross-fetch": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.5.tgz",
+          "integrity": "sha512-xqYAhQb4NhCJSRym03dwxpP1bYXpK3y7UN83Bo2WFi3x1Zmzn0SL/6xGoPr+gpt4WmNrgCCX3HPysvOwFOW36w==",
+          "dev": true,
+          "requires": {
+            "node-fetch": "2.6.1",
+            "whatwg-fetch": "2.0.4"
+          }
+        },
+        "ethereum-common": {
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
+          "dev": true
+        },
+        "ethereumjs-tx": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+          "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+          "dev": true,
+          "requires": {
+            "ethereum-common": "^0.0.18",
+            "ethereumjs-util": "^5.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
+          }
+        },
+        "ws": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
+          "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
       }
     },
     "@types/accepts": {
@@ -3974,7 +4532,6 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
       "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-      "optional": true,
       "requires": {
         "xtend": "~4.0.0"
       }
@@ -4563,6 +5120,26 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
+    "async-eventemitter": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
+      "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
+      "dev": true,
+      "requires": {
+        "async": "^2.4.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        }
+      }
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -4598,6 +5175,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
       "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA=="
+    },
+    "await-semaphore": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/await-semaphore/-/await-semaphore-0.1.3.tgz",
+      "integrity": "sha512-d1W2aNSYcz/sxYO4pMGX9vq65qOTu0P800epMud+6cYYX0QcT7zyqcxec3VWzpgvdXo57UWmVbZpLMjX2m1I7Q==",
+      "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -4711,6 +5294,44 @@
       "optional": true,
       "requires": {
         "object.assign": "^4.1.0"
+      }
+    },
+    "babel-plugin-polyfill-corejs2": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.2.tgz",
+      "integrity": "sha512-kISrENsJ0z5dNPq5eRvcctITNHYXWOA4DUZRFYCz3jYCcvTb/A546LIddmoGNMVYg2U38OyFeNosQwI9ENTqIQ==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.13.11",
+        "@babel/helper-define-polyfill-provider": "^0.2.2",
+        "semver": "^6.1.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-polyfill-corejs3": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.4.tgz",
+      "integrity": "sha512-z3HnJE5TY/j4EFEa/qpQMSbcUJZ5JQi+3UFjXzn6pQCmIKc5Ug5j98SuYyH+m4xQnvKlMDIW4plLfgyVnd0IcQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.2.2",
+        "core-js-compat": "^3.14.0"
+      }
+    },
+    "babel-plugin-polyfill-regenerator": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.2.tgz",
+      "integrity": "sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.2.2"
       }
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -4829,6 +5450,15 @@
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
       "optional": true
+    },
+    "backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "dev": true,
+      "requires": {
+        "precond": "0.2"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -5183,7 +5813,6 @@
       "version": "4.16.7",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
       "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
-      "optional": true,
       "requires": {
         "caniuse-lite": "^1.0.30001248",
         "colorette": "^1.2.2",
@@ -5218,6 +5847,12 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
+    },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "dev": true
     },
     "btoa-lite": {
       "version": "1.0.0",
@@ -5342,8 +5977,7 @@
     "caniuse-lite": {
       "version": "1.0.30001248",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz",
-      "integrity": "sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw==",
-      "optional": true
+      "integrity": "sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -5363,7 +5997,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "optional": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -5393,6 +6026,15 @@
         "title-case": "^2.1.0",
         "upper-case": "^1.1.1",
         "upper-case-first": "^1.1.0"
+      }
+    },
+    "checkpoint-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
+      "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
+      "dev": true,
+      "requires": {
+        "functional-red-black-tree": "^1.0.1"
       }
     },
     "cheerio": {
@@ -5639,8 +6281,7 @@
     "colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-      "optional": true
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
     },
     "colors": {
       "version": "1.4.0",
@@ -5693,6 +6334,7 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
       "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+      "optional": true,
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "~2.0.0",
@@ -5703,6 +6345,7 @@
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -5715,7 +6358,8 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "optional": true
         }
       }
     },
@@ -5822,6 +6466,61 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+    },
+    "core-js-compat": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.17.3.tgz",
+      "integrity": "sha512-+in61CKYs4hQERiADCJsdgewpdl/X0GhEX77pjKgbeibXviIt2oxEjTc8O2fqHX8mDdBrDvX8MYD/RYsBv4OiA==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.17.0",
+        "semver": "7.0.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.17.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
+          "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001254",
+            "colorette": "^1.3.0",
+            "electron-to-chromium": "^1.3.830",
+            "escalade": "^3.1.1",
+            "node-releases": "^1.1.75"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001256",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001256.tgz",
+          "integrity": "sha512-QirrvMLmB4txNnxiaG/xbm6FSzv9LqOZ3Jp9VtCYb3oPIfCHpr/oGn38pFq0udwlkctvXQgPthaXqJ76DaYGnA==",
+          "dev": true
+        },
+        "colorette": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+          "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.836",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.836.tgz",
+          "integrity": "sha512-Ney3pHOJBWkG/AqYjrW0hr2AUCsao+2uvq9HUlRP8OlpSdk/zOHOUJP7eu0icDvePC9DlgffuelP4TnOJmMRUg==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.75",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+          "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+          "dev": true
+        }
+      }
     },
     "core-js-pure": {
       "version": "3.16.0",
@@ -6410,8 +7109,7 @@
     "electron-to-chromium": {
       "version": "1.3.795",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.795.tgz",
-      "integrity": "sha512-4TPxrLf9Fzsi4rVgTlDm+ubxoXm3/TN67/LGHx/a4UkVubKILa6L26O6eTnHewixG/knzU9L3lLmfL39eElwlQ==",
-      "optional": true
+      "integrity": "sha512-4TPxrLf9Fzsi4rVgTlDm+ubxoXm3/TN67/LGHx/a4UkVubKILa6L26O6eTnHewixG/knzU9L3lLmfL39eElwlQ=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -6459,7 +7157,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "optional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
       },
@@ -6468,7 +7165,6 @@
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -6534,7 +7230,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
       "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-      "optional": true,
       "requires": {
         "prr": "~1.0.1"
       }
@@ -6647,8 +7342,7 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "optional": true
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -6686,7 +7380,7 @@
         "escape-html": "1.0.3",
         "fs-extra": "5.0.0",
         "ice-cap": "0.0.4",
-        "marked": "0.6.2",
+        "marked": "0.3.19",
         "minimist": "1.2.0",
         "taffydb": "2.7.3"
       },
@@ -6729,6 +7423,20 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "eth-block-tracker": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-4.4.3.tgz",
+      "integrity": "sha512-A8tG4Z4iNg4mw5tP1Vung9N9IjgMNqpiMoJ/FouSFwNCGHv2X0mmOYwtQOJzki6XN7r7Tyo01S29p7b224I4jw==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-transform-runtime": "^7.5.5",
+        "@babel/runtime": "^7.5.5",
+        "eth-query": "^2.1.0",
+        "json-rpc-random-id": "^1.0.1",
+        "pify": "^3.0.0",
+        "safe-event-emitter": "^1.0.1"
+      }
+    },
     "eth-ens-namehash": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
@@ -6736,6 +7444,15 @@
       "requires": {
         "idna-uts46-hx": "^2.3.1",
         "js-sha3": "^0.5.7"
+      }
+    },
+    "eth-json-rpc-errors": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-2.0.2.tgz",
+      "integrity": "sha512-uBCRM2w2ewusRHGxN8JhcuOb2RN3ueAOYH/0BhqdFmQkZx5lj5+fLKTz0mIVOzd4FG5/kUksCzCD7eTEim6gaA==",
+      "dev": true,
+      "requires": {
+        "fast-safe-stringify": "^2.0.6"
       }
     },
     "eth-lib": {
@@ -6758,6 +7475,66 @@
         }
       }
     },
+    "eth-query": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
+      "integrity": "sha1-1nQdkAAQa1FRDHLbktY2VFam2l4=",
+      "dev": true,
+      "requires": {
+        "json-rpc-random-id": "^1.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "eth-rpc-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-3.0.0.tgz",
+      "integrity": "sha512-iPPNHPrLwUlR9xCSYm7HHQjWBasor3+KZfRvwEWxMz3ca0yqnlBeJrnyphkGIXZ4J7AMAaOLmwy4AWhnxOiLxg==",
+      "dev": true,
+      "requires": {
+        "fast-safe-stringify": "^2.0.6"
+      }
+    },
+    "eth-sig-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-3.0.1.tgz",
+      "integrity": "sha512-0Us50HiGGvZgjtWTyAI/+qTzYPMLy5Q451D0Xy68bxq1QMWdoOddDwGvsqcFT27uohKgalM9z/yxplyt+mY2iQ==",
+      "dev": true,
+      "requires": {
+        "ethereumjs-abi": "^0.6.8",
+        "ethereumjs-util": "^5.1.1",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+          "dev": true
+        }
+      }
+    },
     "ethereum-bloom-filters": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
@@ -6772,6 +7549,12 @@
           "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
         }
       }
+    },
+    "ethereum-common": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+      "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA==",
+      "dev": true
     },
     "ethereum-cryptography": {
       "version": "0.1.3",
@@ -6816,6 +7599,181 @@
         }
       }
     },
+    "ethereum-protocol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ethereum-protocol/-/ethereum-protocol-1.0.1.tgz",
+      "integrity": "sha512-3KLX1mHuEsBW0dKG+c6EOJS1NBNqdCICvZW9sInmZTt5aY0oxmHVggYRE0lJu1tcnMD1K+AKHdLi6U43Awm1Vg==",
+      "dev": true
+    },
+    "ethereumjs-abi": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
+      "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.11.8",
+        "ethereumjs-util": "^6.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "ethereumjs-util": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.3"
+          }
+        }
+      }
+    },
+    "ethereumjs-account": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
+      "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
+      "dev": true,
+      "requires": {
+        "ethereumjs-util": "^5.0.0",
+        "rlp": "^2.0.0",
+        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        }
+      }
+    },
+    "ethereumjs-block": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+      "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+      "dev": true,
+      "requires": {
+        "async": "^2.0.1",
+        "ethereum-common": "0.2.0",
+        "ethereumjs-tx": "^1.2.2",
+        "ethereumjs-util": "^5.0.0",
+        "merkle-patricia-tree": "^2.1.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "ethereumjs-tx": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+          "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+          "dev": true,
+          "requires": {
+            "ethereum-common": "^0.0.18",
+            "ethereumjs-util": "^5.0.0"
+          },
+          "dependencies": {
+            "ethereum-common": {
+              "version": "0.0.18",
+              "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+              "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
+              "dev": true
+            }
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        }
+      }
+    },
+    "ethereumjs-common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
+      "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA==",
+      "dev": true
+    },
+    "ethereumjs-tx": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+      "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
+      "dev": true,
+      "requires": {
+        "ethereumjs-common": "^1.5.0",
+        "ethereumjs-util": "^6.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "ethereumjs-util": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.3"
+          }
+        }
+      }
+    },
     "ethereumjs-util": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
@@ -6836,6 +7794,123 @@
           "requires": {
             "@types/node": "*"
           }
+        }
+      }
+    },
+    "ethereumjs-vm": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz",
+      "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
+      "dev": true,
+      "requires": {
+        "async": "^2.1.2",
+        "async-eventemitter": "^0.2.2",
+        "ethereumjs-account": "^2.0.3",
+        "ethereumjs-block": "~2.2.0",
+        "ethereumjs-common": "^1.1.0",
+        "ethereumjs-util": "^6.0.0",
+        "fake-merkle-patricia-tree": "^1.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "merkle-patricia-tree": "^2.3.2",
+        "rustbn.js": "~0.2.0",
+        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "ethereumjs-block": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
+          "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
+          "dev": true,
+          "requires": {
+            "async": "^2.0.1",
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-tx": "^2.1.1",
+            "ethereumjs-util": "^5.0.0",
+            "merkle-patricia-tree": "^2.1.2"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "^0.1.3",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
+              }
+            }
+          }
+        },
+        "ethereumjs-util": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.3"
+          }
+        }
+      }
+    },
+    "ethereumjs-wallet": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-1.0.1.tgz",
+      "integrity": "sha512-3Z5g1hG1das0JWU6cQ9HWWTY2nt9nXCcwj7eXVNAHKbo00XAZO8+NHlwdgXDWrL0SXVQMvTWN8Q/82DRH/JhPw==",
+      "dev": true,
+      "requires": {
+        "aes-js": "^3.1.1",
+        "bs58check": "^2.1.2",
+        "ethereum-cryptography": "^0.1.3",
+        "ethereumjs-util": "^7.0.2",
+        "randombytes": "^2.0.6",
+        "scrypt-js": "^3.0.1",
+        "utf8": "^3.0.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "aes-js": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+          "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
+          "dev": true
+        },
+        "scrypt-js": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -6909,8 +7984,7 @@
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "optional": true
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -7052,6 +8126,15 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fake-merkle-patricia-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
+      "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
+      "dev": true,
+      "requires": {
+        "checkpoint-store": "^1.1.0"
+      }
     },
     "faker": {
       "version": "5.5.3",
@@ -7232,6 +8315,27 @@
       "requires": {
         "es6-denodeify": "^0.1.1",
         "tough-cookie": "^2.3.1"
+      }
+    },
+    "fetch-ponyfill": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz",
+      "integrity": "sha1-rjzl9zLGReq4fkroeTQUcJsjmJM=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "~1.7.1"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "file-uri-to-path": {
@@ -7479,8 +8583,7 @@
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "optional": true
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gauge": {
       "version": "2.7.4",
@@ -7588,7 +8691,7 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "optional": true,
       "requires": {
-        "glob-parent": "~5.1.0",
+        "glob-parent": "^2.0.0",
         "is-glob": "^2.0.0"
       },
       "dependencies": {
@@ -7596,8 +8699,26 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
           "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "optional": true,
           "requires": {
             "is-glob": "^4.0.1"
+          },
+          "dependencies": {
+            "is-extglob": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+              "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+              "optional": true
+            },
+            "is-glob": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+              "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+              "optional": true,
+              "requires": {
+                "is-extglob": "^2.1.1"
+              }
+            }
           }
         },
         "is-extglob": {
@@ -7621,8 +8742,20 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "optional": true,
       "requires": {
         "is-glob": "^4.0.1"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "optional": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        }
       }
     },
     "glob-stream": {
@@ -7633,7 +8766,7 @@
       "requires": {
         "extend": "^3.0.0",
         "glob": "^5.0.3",
-        "glob-parent": "~5.1.0",
+        "glob-parent": "^3.0.0",
         "micromatch": "^2.3.7",
         "ordered-read-streams": "^0.3.0",
         "through2": "^0.6.0",
@@ -7689,8 +8822,7 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "optional": true
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globalthis": {
       "version": "1.0.2",
@@ -7893,8 +9025,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "optional": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbol-support-x": {
       "version": "1.4.2",
@@ -8158,8 +9289,7 @@
     "immediate": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
-      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
-      "optional": true
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
     },
     "immutable": {
       "version": "3.7.6",
@@ -9082,7 +10212,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
       "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-      "optional": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -9129,6 +10258,12 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
       "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
     },
+    "is-fn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
+      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw=",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -9146,15 +10281,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.9.tgz",
       "integrity": "sha512-ZJ34p1uvIfptHCN7sFTjGibB9/oBg17sHqzDLfuwhvmN/qLVvIQXRQ8licZQ35WJ8KuEQt/etnnzQFI9C9Ue/A=="
-    },
-    "is-glob": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-      "optional": true,
-      "requires": {
-        "is-extglob": "^2.1.0"
-      }
     },
     "is-hex-prefixed": {
       "version": "1.0.0",
@@ -9555,8 +10681,7 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "optional": true
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-buffer": {
       "version": "3.0.0",
@@ -9570,6 +10695,22 @@
       "requires": {
         "foreach": "^2.0.4"
       }
+    },
+    "json-rpc-engine": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.4.0.tgz",
+      "integrity": "sha512-rAffKbPoNDjuRnXkecTjnsE3xLLrb00rEkdgalINhaYVYIxDwWtvYBr9UFbhTvPB1B2qUOLoFd/cV6f4Q7mh7g==",
+      "dev": true,
+      "requires": {
+        "eth-rpc-errors": "^3.0.0",
+        "safe-event-emitter": "^1.0.1"
+      }
+    },
+    "json-rpc-random-id": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
+      "integrity": "sha1-uknZat7RRE27jaPSA3SKy7zeyMg=",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -9903,6 +11044,57 @@
         "end-stream": "~0.1.0"
       }
     },
+    "level-ws": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
+      "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~1.0.15",
+        "xtend": "~2.1.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "dev": true,
+          "requires": {
+            "object-keys": "~0.4.0"
+          }
+        }
+      }
+    },
     "leveldown": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.0.2.tgz",
@@ -10088,10 +11280,22 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
     "lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+    },
+    "lodash.flatmap": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
+      "integrity": "sha1-74y/QI9uSCaGYzRTBcaswLd4cC4=",
+      "dev": true
     },
     "lodash.flatten": {
       "version": "4.4.0",
@@ -10273,8 +11477,7 @@
     "ltgt": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
-      "optional": true
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
     },
     "make-dir": {
       "version": "1.3.0",
@@ -10321,7 +11524,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
       "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
-      "optional": true,
       "requires": {
         "abstract-leveldown": "~2.7.1",
         "functional-red-black-tree": "^1.0.1",
@@ -10334,8 +11536,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "optional": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -10413,6 +11614,187 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "optional": true
+    },
+    "merkle-patricia-tree": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
+      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
+      "dev": true,
+      "requires": {
+        "async": "^1.4.2",
+        "ethereumjs-util": "^5.0.0",
+        "level-ws": "0.0.0",
+        "levelup": "^1.2.1",
+        "memdown": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "rlp": "^2.0.0",
+        "semaphore": ">=1.0.1"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+          "dev": true,
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        },
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "deferred-leveldown": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+          "dev": true,
+          "requires": {
+            "abstract-leveldown": "~2.6.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "level-codec": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
+          "dev": true
+        },
+        "level-errors": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+          "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+          "dev": true,
+          "requires": {
+            "errno": "~0.1.1"
+          }
+        },
+        "level-iterator-stream": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+          "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "level-errors": "^1.0.3",
+            "readable-stream": "^1.0.33",
+            "xtend": "^4.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.14",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            }
+          }
+        },
+        "levelup": {
+          "version": "1.3.9",
+          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
+          "dev": true,
+          "requires": {
+            "deferred-leveldown": "~1.2.1",
+            "level-codec": "~7.0.0",
+            "level-errors": "~1.0.3",
+            "level-iterator-stream": "~1.3.0",
+            "prr": "~1.0.1",
+            "semver": "~5.4.1",
+            "xtend": "~4.0.0"
+          }
+        },
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
     },
     "meros": {
       "version": "1.1.4",
@@ -10900,7 +12282,7 @@
       "optional": true,
       "requires": {
         "chalk": "1.1.3",
-        "concat-stream": "1.5.2",
+        "concat-stream": "1.5.1",
         "lodash.template": "4.2.4",
         "map-stream": "0.0.6",
         "tildify": "1.2.0",
@@ -11280,8 +12662,7 @@
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "optional": true
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
       "version": "0.10.0",
@@ -11340,8 +12721,7 @@
     "node-releases": {
       "version": "1.1.73",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
-      "optional": true
+      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg=="
     },
     "nofilter": {
       "version": "1.0.4",
@@ -11862,12 +13242,6 @@
         "no-case": "^2.2.0"
       }
     },
-    "path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "optional": true
-    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -11881,8 +13255,7 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "optional": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -12024,8 +13397,7 @@
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "optional": true
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -12658,6 +14030,12 @@
         }
       }
     },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw=",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -12698,6 +14076,16 @@
       "optional": true,
       "requires": {
         "asap": "~2.0.3"
+      }
+    },
+    "promise-to-callback": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
+      "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
+      "dev": true,
+      "requires": {
+        "is-fn": "^1.0.0",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "promise.allsettled": {
@@ -12793,8 +14181,7 @@
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "optional": true
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "psl": {
       "version": "1.8.0",
@@ -13469,7 +14856,6 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "optional": true,
       "requires": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -13633,6 +15019,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "rustbn.js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
+      "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==",
+      "dev": true
+    },
     "rxjs": {
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
@@ -13654,6 +15046,15 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safe-event-emitter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-event-emitter/-/safe-event-emitter-1.0.1.tgz",
+      "integrity": "sha512-e1wFe99A91XYYxoQbcq2ZJUWurxEyP8vfz7A7vuUe1s95q8r5ebraVaA1BukYJcpM6V16ugWoD9vngi8Ccu5fg==",
+      "dev": true,
+      "requires": {
+        "events": "^3.0.0"
+      }
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -13711,6 +15112,12 @@
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
       "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
       "optional": true
+    },
+    "semaphore": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
+      "dev": true
     },
     "semver": {
       "version": "5.7.1",
@@ -13804,6 +15211,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "dev": true
     },
     "setimmediate": {
       "version": "1.0.4",
@@ -14311,7 +15724,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "optional": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -14601,8 +16013,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "optional": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-json-schema": {
       "version": "0.2.5",
@@ -14678,6 +16089,7 @@
         "@truffle/debugger": "^9.1.8",
         "@truffle/preserve-fs": "^0.2.4",
         "@truffle/preserve-to-buckets": "^0.2.4",
+        "@truffle/preserve-to-filecoin": "^0.2.4",
         "@truffle/preserve-to-ipfs": "^0.2.4",
         "app-module-path": "^2.2.0",
         "mocha": "8.1.2",
@@ -14908,8 +16320,7 @@
     "tweetnacl-util": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
-      "optional": true
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
     },
     "type": {
       "version": "1.2.0",
@@ -15686,6 +17097,12 @@
         "sqlite3": "^4.0.0",
         "tiny-queue": "^0.2.1"
       }
+    },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+      "dev": true
     },
     "whatwg-url-compat": {
       "version": "0.6.5",

--- a/nightfall-deployer/package.json
+++ b/nightfall-deployer/package.json
@@ -32,6 +32,7 @@
     "winston": "^3.3.3"
   },
   "devDependencies": {
+    "@truffle/hdwallet-provider": "^1.5.0",
     "truffle-contract-size": "^2.0.1"
   }
 }

--- a/nightfall-deployer/src/contract-setup.mjs
+++ b/nightfall-deployer/src/contract-setup.mjs
@@ -3,12 +3,37 @@ module to initialise the proposers, challenges and shield contracts with the
 address of the contract that holds global state (State.sol)
 */
 
+import config from 'config';
 import logger from 'common-files/utils/logger.mjs';
-import { waitForContract } from 'common-files/utils/contract.mjs';
+import Web3 from 'common-files/utils/web3.mjs';
+import { waitForContract, getContractAddress } from 'common-files/utils/contract.mjs';
 
 async function setupCircuits() {
   const stateInstance = await waitForContract('State');
   logger.debug(`address of State contract is ${stateInstance.options.address}`);
+
+  // when deploying on testnet
+  // do serial registration to predict nonce
+  if (config.ENABLE_TESTNET_DEPLOY) {
+    await Web3.submitRawTransaction(
+      (await waitForContract('Proposers')).methods
+        .setStateContract(stateInstance.options.address)
+        .encodeABI(),
+      await getContractAddress('Proposers'),
+    );
+    await Web3.submitRawTransaction(
+      (await waitForContract('Shield')).methods
+        .setStateContract(stateInstance.options.address)
+        .encodeABI(),
+      await getContractAddress('Shield'),
+    );
+    return Web3.submitRawTransaction(
+      (await waitForContract('Challenges')).methods
+        .setStateContract(stateInstance.options.address)
+        .encodeABI(),
+      await getContractAddress('Challenges'),
+    );
+  }
   // the following code runs the registrations in parallel
   return Promise.all([
     (await waitForContract('Proposers')).methods

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -18,7 +18,9 @@
  *
  */
 
-// const HDWalletProvider = require('@truffle/hdwallet-provider');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const HDWalletProvider = require('@truffle/hdwallet-provider');
+const config = require('config');
 // const infuraKey = "fj4jll3k.....";
 //
 // const fs = require('fs');
@@ -79,6 +81,11 @@ module.exports = {
       network_id: 4378921, // Any network (default: none)
       gas: 8000000,
       websockets: true,
+    },
+
+    rinkeby: {
+      provider: () => new HDWalletProvider(config.ETH_MNEMONIC, config.BLOCKCHAIN_TESTNET_URL),
+      network_id: 4,
     },
 
     // Another network with more advanced options...

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -83,9 +83,10 @@ module.exports = {
       websockets: true,
     },
 
-    rinkeby: {
-      provider: () => new HDWalletProvider(config.ETH_MNEMONIC, config.BLOCKCHAIN_TESTNET_URL),
-      network_id: 4,
+    ropsten: {
+      provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_TESTNET_URL),
+      network_id: 3,
+      networkCheckTimeout: 10000000,
     },
 
     // Another network with more advanced options...

--- a/nightfall-optimist/docker-entrypoint.sh
+++ b/nightfall-optimist/docker-entrypoint.sh
@@ -3,7 +3,14 @@
 mongod --dbpath /app/mongodb/ --fork --logpath /var/log/mongodb/mongod.log --bind_ip_all
 while ! nc -z localhost 27017; do sleep 3; done
 echo 'mongodb started'
-# wait until there's a blockchain client up
-while ! nc -z ${BLOCKCHAIN_WS_HOST} ${BLOCKCHAIN_PORT}; do sleep 3; done
+
+# check if testnet url exist: this means there is no
+# local blockchain running instead we are trying to to connect
+# testnet network via infura
+if [ -z "${BLOCKCHAIN_TESTNET_URL}" ]
+then
+  # wait until there's a blockchain client up
+  while ! nc -z ${BLOCKCHAIN_WS_HOST} ${BLOCKCHAIN_PORT}; do sleep 3; done
+fi
 
 exec "$@"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./nightfall-client/src/index.mjs",
   "scripts": {
     "test": "mocha --timeout 0 --bail test/http.mjs test/neg-http.mjs",
+    "testnet-test": "ENABLE_TESTNET_DEPLOY=true FROM_ADDRESS=0x29100E7E3dA6654BF63d9E7804ADe518aCc5AaA5 BLOCKCHAIN_TESTNET_URL=wss://ropsten.infura.io/ws/v3/INFURA_PROJECT_ID mocha --timeout 0 --bail test/http.mjs test/neg-http.mjs",
     "test-gas": "mocha --timeout 0 --bail test/tx-gas.mjs",
     "test-chain-reorg": "mocha --timeout 0 --bail test/chain-reorg.mjs",
     "lint": "eslint . --ext js,mjs && find-unused-exports",

--- a/start-nightfall
+++ b/start-nightfall
@@ -11,7 +11,7 @@ usage()
   echo "  -l or --localhost; to connect to an already running blockchain on ws://localhost:8546"
   echo "  -s or --stubs; runs with circuits stubbed out (faster but no checking of ZKP code) - use with either -g or -l"
   echo "  -h or --help; to print this message"
-  echo "  -t or --testnet; to connect rinkeby testnet"
+  echo "  -t or --testnet; to connect infura ropsten testnet"
 }
 
 # select a Geth or Ganache client
@@ -25,7 +25,7 @@ while [ -n "$1" ]; do
                               ;;
       -l | --localhost )      FILE="-f docker-compose.yml -f docker-compose.host.docker.internal.yml"
                               ;;
-      -t | --testnet )        FILE="-f docker-compose.testnet.yml"
+      -t | --testnet )        FILE="-f docker-compose.yml -f docker-compose.testnet.yml"
                               ;;
       -h | --help )           usage
                               ;;

--- a/start-nightfall
+++ b/start-nightfall
@@ -11,6 +11,7 @@ usage()
   echo "  -l or --localhost; to connect to an already running blockchain on ws://localhost:8546"
   echo "  -s or --stubs; runs with circuits stubbed out (faster but no checking of ZKP code) - use with either -g or -l"
   echo "  -h or --help; to print this message"
+  echo "  -t or --testnet; to connect rinkeby testnet"
 }
 
 # select a Geth or Ganache client
@@ -23,6 +24,8 @@ while [ -n "$1" ]; do
       -g | --ganache )        FILE="-f docker-compose.yml -f docker-compose.ganache.yml"
                               ;;
       -l | --localhost )      FILE="-f docker-compose.yml -f docker-compose.host.docker.internal.yml"
+                              ;;
+      -t | --testnet )        FILE="-f docker-compose.testnet.yml"
                               ;;
       -h | --help )           usage
                               ;;

--- a/test/chain-reorg.mjs
+++ b/test/chain-reorg.mjs
@@ -47,7 +47,7 @@ describe('Testing the http API', () => {
   // this is also accounts[0]
   // this is what we pay the proposer for incorporating a transaction
   const fee = 1;
-  const BLOCK_STAKE = 1000000000000000000; // 1 ether
+  const BLOCK_STAKE = 1; // 1 wei
   const txPerBlock = 2;
   const eventLogs = [];
 
@@ -244,7 +244,7 @@ describe('Testing the http API', () => {
       txDataToSign = res.body.txDataToSign;
       expect(txDataToSign).to.be.a('string');
       // we have to pay 10 ETH to be registered
-      const bond = 10000000000000000000;
+      const bond = 10;
       const gasCosts = 5000000000000000;
       const startBalance = await getBalance(myAddress);
       // now we need to sign the transaction and send it to the blockchain

--- a/test/tx-gas.mjs
+++ b/test/tx-gas.mjs
@@ -46,7 +46,7 @@ describe('Testing the http API', () => {
   // this is the openethereum test account (but could be anything)
   // this is what we pay the proposer for incorporating a transaction
   const fee = 1;
-  const BLOCK_STAKE = 1000000000000000000; // 1 ether
+  const BLOCK_STAKE = 1; // 1 wei
   const TRANSACTIONS_PER_BLOCK = 32;
 
   before(async () => {
@@ -135,7 +135,7 @@ describe('Testing the http API', () => {
       txDataToSign = res.body.txDataToSign;
       expect(txDataToSign).to.be.a('string');
       // we have to pay 10 ETH to be registered
-      const bond = 10000000000000000000;
+      const bond = 10;
       const gasCosts = 5000000000000000;
       const startBalance = await getBalance(myAddress);
       // now we need to sign the transaction and send it to the blockchain

--- a/timber/entrypoint.sh
+++ b/timber/entrypoint.sh
@@ -1,9 +1,15 @@
 #! /bin/bash
 set -o errexit
-set -o nounset
 set -o pipefail
-# wait until there's a blockchain client up
-while ! nc -z ${BLOCKCHAIN_WS_HOST} ${BLOCKCHAIN_PORT}; do sleep 3; done
+
+# check if testnet url exist: this means there is no
+# local blockchain running instead we are trying to to connect
+# testnet network via infura
+if [ -z "${BLOCKCHAIN_TESTNET_URL}" ]
+then
+  # wait until there's a blockchain client up
+  while ! nc -z ${BLOCKCHAIN_WS_HOST} ${BLOCKCHAIN_PORT}; do sleep 3; done
+fi
 
 #sleep 10
 

--- a/timber/src/auto-start.mjs
+++ b/timber/src/auto-start.mjs
@@ -19,7 +19,7 @@ const autoStart = async () => {
     // Timber has the ability to infer one. Otherwise Timber will fall over. If
     // the build artefacts don't exist yet then we need to wait.
     // Stop eslint complaining because we DO want delays in this loop
-    let retries = process.env.AUTOSTART_RETRIES || 50;
+    let retries = Number(process.env.AUTOSTART_RETRIES) || 50;
     while (!data.contractAddress) {
       try {
         // eslint-disable-next-line no-await-in-loop

--- a/timber/src/web3.mjs
+++ b/timber/src/web3.mjs
@@ -8,6 +8,8 @@ import Web3 from 'web3';
 import config from 'config';
 import logger from './logger.mjs';
 
+const { INFURA_PROJECT_SECRET } = process.env;
+
 export default {
   connection() {
     return this.web3;
@@ -19,15 +21,25 @@ export default {
   connect() {
     if (this.web3) return this.web3;
 
-    logger.info(`Blockchain Connecting ..config.web3.url...${config.web3.url}`);
-    const provider = new Web3.providers.WebsocketProvider(config.web3.url, config.web3.options);
+    logger.info('Blockchain Connecting ...');
+
+    let provider;
+    if (config.ENABLE_TESTNET_DEPLOY) {
+      if (!INFURA_PROJECT_SECRET) throw Error('env INFURA_PROJECT_SECRET not set');
+
+      provider = new Web3.providers.WebsocketProvider(config.web3.url, {
+        ...config.web3.options,
+        headers: {
+          authorization: `Basic ${Buffer.from(`:${INFURA_PROJECT_SECRET}`).toString('base64')}`,
+        },
+      });
+    } else {
+      provider = new Web3.providers.WebsocketProvider(config.web3.url, config.web3.options);
+    }
 
     provider.on('error', err => logger.error(err));
     provider.on('connect', () => logger.info('Blockchain Connected ...'));
-    provider.on('end', () => {
-      logger.error('Blockchain Disconnected');
-      logger.info(this);
-    });
+    provider.on('end', () => logger.error('Blockchain Disconnected'));
 
     this.web3 = new Web3(provider);
 

--- a/timber/src/web3.mjs
+++ b/timber/src/web3.mjs
@@ -19,23 +19,15 @@ export default {
   connect() {
     if (this.web3) return this.web3;
 
-    logger.info('Blockchain Connecting ...');
-    const provider = new Web3.providers.WebsocketProvider(
-      `ws://${config.web3.host}:${config.web3.port}`,
-      {
-        timeout: 3600000,
-        reconnect: {
-          auto: true,
-          delay: 5000, // ms
-          maxAttempts: 120,
-          onTimeout: false,
-        },
-      }, // set a 10 minute timeout
-    );
+    logger.info(`Blockchain Connecting ..config.web3.url...${config.web3.url}`);
+    const provider = new Web3.providers.WebsocketProvider(config.web3.url, config.web3.options);
 
     provider.on('error', err => logger.error(err));
     provider.on('connect', () => logger.info('Blockchain Connected ...'));
-    provider.on('end', () => logger.error('Blockchain Disconnected'));
+    provider.on('end', () => {
+      logger.error('Blockchain Disconnected');
+      logger.info(this);
+    });
 
     this.web3 = new Web3(provider);
 


### PR DESCRIPTION
This PR add a github action workflow which will test all PR to master branch by deploying code to infura testnet(ropsten) and run integration test (test/http.mjs and test/neg-http.mjs).

fixes #183 

this PR does few changes to make continues integration works (deploy at ropsten network).
1. lowers `block_stake` and `bond`,  `1 eth` and `10 eth` to `1 wei` and `10 wei` respectively.
2. added basic auth logic to web3 connection by passing `INFURA_PROJECT_SECET` env (this enable a basic security feature as infura set transaction limit per day)


NOTE: Infura testnet deployment `./start-nightfall -t` cannot be tested locally (unless fews changes are made) , because it has dependency on fews secret environment variables
1.  `ETH_PRIVATE_KEY`
2. `INFURA_PROJECT_ID`
3. `INFURA_PROJECT_SECRET`

changes to make Infura testnet deployment and then integration test to work:-
1. update FROM_ADDRESS in `./docker-compose.testnet.yml` and in `./package.json` with your own EOA for which have balance in rospten network.
2. set environment variable `ETH_PRIVATE_KEY` to your EOA's private key.
3 set env `INFURA_PROJECT_ID` and `INFURA_PROJECT_SECRET` values from your own infura project or use one which github action workflow is using (slack me for the these values :) )

also this PR fixes github action workflow which run `npm run test-gas` by updating `docker-compose.yml` to expect value for TRANSACTIONS_PER_BLOCK from environment variable, if not set take default value "2".

