### PR TITLE
Add proposer event handling to queue

### DIFF
--- a/nightfall-optimist/src/event-handlers/index.mjs
+++ b/nightfall-optimist/src/event-handlers/index.mjs
@@ -1,7 +1,5 @@
 import {
   startEventQueue,
-  subscribeToNewCurrentProposer,
-  subscribeToRemovedNewCurrentProposer,
   subscribeToBlockAssembledWebSocketConnection,
   subscribeToChallengeWebSocketConnection,
 } from './subscribe.mjs';
@@ -23,27 +21,26 @@ const eventHandlers = {
   TransactionSubmitted: transactionSubmittedEventHandler,
   Rollback: rollbackEventHandler,
   CommittedToChallenge: committedToChallengeEventHandler,
+  NewCurrentProposer: newCurrentProposerEventHandler,
   removers: {
     // Rollback: removeRollbackEventHandler,
     BlockProposed: removeBlockProposedEventHandler,
     CommittedToChallenge: removeCommittedToChallengeEventHandler,
     TransactionSubmitted: removeTransactionSubmittedEventHandler,
+    NewCurrentProposer: removeNewCurrentProposerEventHandler,
   },
   priority: {
     BlockProposed: 0,
     TransactionSubmitted: 1,
     Rollback: 0,
     CommittedToChallenge: 0,
+    NewCurrentProposer: 0,
   },
 };
 
 export {
   startEventQueue,
-  subscribeToNewCurrentProposer,
-  subscribeToRemovedNewCurrentProposer,
   subscribeToBlockAssembledWebSocketConnection,
   subscribeToChallengeWebSocketConnection,
-  newCurrentProposerEventHandler,
-  removeNewCurrentProposerEventHandler,
   eventHandlers,
 };

--- a/nightfall-optimist/src/index.mjs
+++ b/nightfall-optimist/src/index.mjs
@@ -2,12 +2,8 @@ import logger from 'common-files/utils/logger.mjs';
 import app from './app.mjs';
 import {
   startEventQueue,
-  subscribeToNewCurrentProposer,
-  subscribeToRemovedNewCurrentProposer,
   subscribeToBlockAssembledWebSocketConnection,
   subscribeToChallengeWebSocketConnection,
-  newCurrentProposerEventHandler,
-  removeNewCurrentProposerEventHandler,
   eventHandlers,
 } from './event-handlers/index.mjs';
 import Proposer from './classes/proposer.mjs';
@@ -28,14 +24,9 @@ const main = async () => {
     // try to sync any missing blockchain state
     // only then start making blocks and listening to new proposers
     initialBlockSync(proposer).then(() => {
-      subscribeToNewCurrentProposer(newCurrentProposerEventHandler, proposer);
-      subscribeToRemovedNewCurrentProposer(removeNewCurrentProposerEventHandler, proposer);
+      startEventQueue(queueManager, eventHandlers, proposer);
       conditionalMakeBlock(proposer);
     });
-    // we do not wait for the initial block sync for these event handlers
-    // as we want to still listen to incoming events (just not make blocks)
-    // subscribe to blockchain events
-    startEventQueue(queueManager, eventHandlers);
     app.listen(80);
   } catch (err) {
     logger.error(err);

--- a/nightfall-optimist/src/services/event-queue.mjs
+++ b/nightfall-optimist/src/services/event-queue.mjs
@@ -43,7 +43,9 @@ export function nextHigherPriorityQueueHasEmptied(priority) {
   });
 }
 
-export async function queueManager(eventObject, eventHandlers, ...args) {
+export async function queueManager(eventObject, eventArgs) {
+  // First element of eventArgs must be the eventHandlers object
+  const [eventHandlers, ...args] = eventArgs;
   // handlers contains the functions needed to handle particular types of event,
   // including removal of events when a chain reorganisation happens
   if (!eventHandlers[eventObject.event]) {


### PR DESCRIPTION
This PR adds `NewCurrentProposer` handling (and removal) to the internal `optimist` processing queue. It also includes a small refactor of `startEventQueue`.

This is part of a bigger set of refactors enabling #173 and subsequently #139 to be completed.





