### PR TITLE
Create nightfall_3 version of timber

### DIFF
--- a/common-files/classes/timber.mjs
+++ b/common-files/classes/timber.mjs
@@ -97,8 +97,12 @@ const _checkMembership = (leafVal, tree, path, f, acc) => {
 
 /**
 @class
-Creates a timber library instance.
-@param {Array<string>} leaves - Leaves that should be inserted into timber
+Creates a timber library instance. The constructor is designed to enable the recreation of a timber instance
+@param {string} root - Root of the timber tree
+@param {object} tree  - Tree object to use
+@param {Array<string>} frontier - frontier of this tree
+@param {number} leafCount - number of leaves in the tree
+
 */
 class Timber {
   root = ZERO;
@@ -109,8 +113,14 @@ class Timber {
 
   leafCount = 0;
 
-  constructor(leaves = []) {
-    return this.insertLeaves(leaves);
+  constructor(root = ZERO, tree = Leaf(ZERO), frontier = [], leafCount = 0) {
+    if (root === ZERO || tree === Leaf(ZERO) || frontier.length === 0 || leafCount === 0)
+      return this;
+    this.root = root;
+    this.tree = tree;
+    this.frontier = frontier;
+    this.leafCount = leafCount;
+    return this;
   }
 
   /**

--- a/common-files/classes/timber.mjs
+++ b/common-files/classes/timber.mjs
@@ -129,7 +129,7 @@ class Timber {
 
   leafCount = 0;
 
-  constructor(root = 0, tree = Leaf(0), frontier = [], leafCount = 0) {
+  constructor(root = 0, frontier = [], leafCount = 0, tree = Leaf(0)) {
     if (root === 0 || tree === Leaf(0) || frontier.length === 0 || leafCount === 0) return this;
     this.root = root;
     this.tree = tree;
@@ -494,10 +494,7 @@ class Timber {
     for (let j = timber.frontier.length; j < TIMBER_HEIGHT; j++) {
       root = utils.concatenateThenHash(root, '0');
     }
-    const t = new Timber();
-    t.root = root;
-    t.frontier = finalFrontier;
-    t.leafCount = timber.leafCount + leaves.length;
+    const t = new Timber(root, finalFrontier, timber.leafCount + leaves.length);
     return t;
   }
 

--- a/common-files/classes/timber.mjs
+++ b/common-files/classes/timber.mjs
@@ -1,0 +1,353 @@
+/* eslint import/no-extraneous-dependencies: "off" */
+/* ignore unused exports */
+
+/**
+A class for timber-like merkle trees.
+*/
+
+import config from 'config';
+import utils from '../utils/crypto/merkle-tree/utils.mjs';
+
+const { TIMBER_HEIGHT, ZERO } = config;
+export const TIMBER_WIDTH = 2 ** TIMBER_HEIGHT;
+
+/** 
+Helper functions for use in the Timber class, defined here before use
+*/
+
+// This helps to create a branch object
+const Branch = (leftTree, rightTree) => ({
+  tag: 'branch',
+  left: leftTree,
+  right: rightTree,
+});
+
+// This helps to create a leaf object
+const Leaf = leafVal => ({
+  tag: 'leaf',
+  value: leafVal,
+});
+
+/**
+This function is called recursively to traverse down the tree using the known insertion path
+@function _insertLeaf
+@param {string} leafVal - The commitment hash to be inserted into the tree
+@param {object} tree - The tree where leafVal will be inserted
+@param {string} path - The path down tree that leafVal will be inserted into 
+@returns {object} An updated tree post-insertion
+*/
+const _insertLeaf = (leafVal, tree, path) => {
+  // The base case is when we have reached the end of the path, we return the the leafVal as a Leaf Object
+  if (path.length === 0) return Leaf(leafVal);
+  switch (tree.tag) {
+    // If we are at a branch, we use the next element in path to decide if we go down the left or right subtree.
+    case 'branch':
+      return path[0] === '0'
+        ? Branch(_insertLeaf(leafVal, tree.left, path.slice(1)), tree.right)
+        : Branch(tree.left, _insertLeaf(leafVal, tree.right, path.slice(1)));
+    // If we are at a leaf AND path.length > 0, we need to expand the undeveloped subtree
+    // We then use the next element in path to decided which subtree to traverse
+    case 'leaf':
+      return path[0] === '0'
+        ? Branch(_insertLeaf(leafVal, Leaf(ZERO), path.slice(1)), Leaf(ZERO))
+        : Branch(Leaf(ZERO), _insertLeaf(leafVal, Leaf(ZERO), path.slice(1)));
+    default:
+      return tree;
+  }
+};
+
+/**
+This function is called recursively to traverse down the tree to find check set membership
+@function _checkMembership
+@param {string} leafVal - The commitment hash that is being checked
+@param {object} tree - The tree that will be checked
+@param {string} path - The path down tree that leafVal is stored
+@param {function} f - This is the function that reduces the unexplored subtree (e.g. hash) in the membership check
+@param {Array<object>} acc - This is the array that contains the membership proof
+@returns {Array<object>} An array containing the membership proof
+*/
+const _checkMembership = (leafVal, tree, path, f, acc) => {
+  switch (tree.tag) {
+    case 'branch':
+      // If recurse left (i.e. '0'), we apply the function f to the right subtree  and vice versa
+      // We also store the direction that f was applied (i.e. 'right' in the above case).
+      return path[0] === '0'
+        ? _checkMembership(
+            leafVal,
+            tree.left,
+            path.slice(1),
+            f,
+            [{ dir: 'right', value: f(tree.right) }].concat(acc),
+          )
+        : _checkMembership(
+            leafVal,
+            tree.right,
+            path.slice(1),
+            f,
+            [{ dir: 'left', value: f(tree.left) }].concat(acc),
+          );
+
+    case 'leaf':
+      // If we arrive at a leaf, we check if the value at the leaf matches the element we are looking for.
+      return tree.value !== leafVal ? { isMember: false, path: [] } : { isMember: true, path: acc };
+    default:
+      return { isMember: false, path: [] };
+  }
+};
+
+/**
+@class
+Creates a timber library instance.
+@param {Array<string>} leaves - Leaves that should be inserted into timber
+*/
+class Timber {
+  root = ZERO;
+
+  tree = Leaf(ZERO);
+
+  frontier = [];
+
+  leafCount = 0;
+
+  constructor(leaves = []) {
+    return this.insertLeaves(leaves);
+  }
+
+  /**
+  @method
+  This helpfully traverse the tree to apply the function to all leaves.
+  @param {function} f - A function that operates on strings stored in Leaf values
+  @param {object} tree - The tree to be traversed
+  @returns {object} - The tree with f applied to all leaves
+  */
+  static mapTree(f, tree) {
+    switch (tree.tag) {
+      case 'branch':
+        return Branch(this.mapTree(f, tree.left), this.mapTree(f, tree.right));
+      case 'leaf':
+        return Leaf(f(tree.value));
+      default:
+        return tree;
+    }
+  }
+
+  /**
+  @method
+  This is like mapTree except the values are accumulated to the root
+  @param {function} f - A binary (as in two parameters) function that operates on strings stored in Leaf values
+  @param {object} tree - The tree to be traversed
+  @returns {string} The result of the accumulations as due to f
+  */
+  static reduceTree(f, tree) {
+    switch (tree.tag) {
+      case 'branch':
+        return f(this.reduceTree(f, tree.left), this.reduceTree(f, tree.right));
+      case 'leaf':
+        return tree.value;
+      default:
+        return tree;
+    }
+  }
+
+  /**
+  @method
+  This hashes the tree
+  @param {object} tree - The tree that will be hashed
+  @returns {string} The hash result;
+  */
+  static hashTree(tree) {
+    return Timber.reduceTree(utils.concatenateThenHash, tree);
+  }
+
+  /**
+  @method
+  This moves our "focus" from the current node down to a subtree
+  @param {object} tree - The tree where our focus is currently at the root of
+  @param {string} dir - The element '0' or '1' that decides if we go left or right.
+  @returns {object} The subtree where our focus is currently at the root of.
+  */
+  static moveDown(tree, dir) {
+    if (Number(dir) > 1 || Number(dir) < 0) throw new Error('Invalid Dir');
+    switch (tree.tag) {
+      case 'branch':
+        return dir === '0' ? tree.left : tree.right;
+      default:
+        return tree;
+    }
+  }
+
+  /**
+  @method
+  This gets the path from a leafValue to the root.
+  @param {string} leafValue - The leafValue to get the path of.
+  @param {string} index - The index that the leafValue is located at.
+  @returns {Array<object>} The merkle path for leafValue.
+  */
+  getMerklePath(leafValue, index = -1) {
+    // eslint-disable-next-line no-param-reassign
+    if (index === -1) index = this.toArray().findIndex(comm => comm === leafValue);
+    if (index > this.leafCount || index < 0) throw new Error('Index is outside valid leaf count');
+    const indexBinary = Number(index).toString(2).padStart(TIMBER_HEIGHT, '0');
+    return _checkMembership(leafValue, this.tree, indexBinary, Timber.hashTree, []);
+  }
+
+  /**
+  @method
+  This verifies a merkle path for a given leafValue
+  @param {string} leafValue - The leafValue to get the path of.
+  @param {string} root - The root that the merkle proof should verify to.
+  @param {Array<object>} proofPath - The output from getMerklePath.
+  @returns {boolean} If a path is true or false.
+  */
+  static verifyMerklePath(leafValue, root, proofPath) {
+    const calcRoot = proofPath.path.reduce((acc, curr) => {
+      if (curr.dir === 'right') return utils.concatenateThenHash(acc, curr.value);
+      return utils.concatenateThenHash(curr.value, acc);
+    }, leafValue);
+    return calcRoot === root;
+  }
+
+  /**
+  @method
+  This calculates the frontier for a tree
+  @param {object} tree - The tree where our focus is currently at the root of
+  @param {string} index - The index that the leafValue is located at.
+  @returns {Array<object>} The merkle path for leafValue.
+  */
+  static calcFrontier(tree, leafCount) {
+    // If the tree is full the Frontier is trivially all the rightmost elements.
+    if (leafCount === TIMBER_WIDTH) {
+      const lastElementIndex = Number(TIMBER_WIDTH - 1)
+        .toString(2)
+        .split('');
+
+      // eslint-disable-next-line prettier/prettier, no-return-assign, no-param-reassign
+      return  [Timber.hashTree(tree)].concat(lastElementIndex.map((a => e => a = Timber.hashTree(Timber.moveDown(a, e)))(tree)));
+      // The above line is moves our pointer down the tree, hashing and storing the value after each step.
+    }
+    const lastIdx = leafCount - 1;
+    const frontierCount = Math.floor(Math.log2(leafCount)) + 1;
+    const lastIdxBin = Number(lastIdx).toString(2).padStart(TIMBER_HEIGHT, '0');
+    // Move our focus to the subtree that contains the frontier elements
+    const frontierTreeRoot = lastIdxBin
+      .slice(0, TIMBER_HEIGHT - frontierCount)
+      .split('')
+      .reduce((acc, curr) => Timber.moveDown(acc, curr), tree);
+
+    const subTreePath = lastIdxBin.slice(-frontierCount);
+    const frontierPoints = []; // This will be an array of arrays that contain the path to each frontier point.
+    for (let i = 1; i <= subTreePath.length; i++) {
+      // We use i = 1 here because we never consider the first element and always look one element ahead
+      // this aesthetically saves repeated i + 1
+      const lastPathDir = subTreePath[i]; // The last direction to the (i-1)-th frontier point
+      if (lastPathDir === '0') {
+        // If our sequence ends in a 0, then we invert the path to arrive at the predecessor node.
+        frontierPoints.push(
+          subTreePath
+            .slice(0, i)
+            .split('')
+            .map(s => (s === '0' ? '1' : '0')),
+        );
+      } else frontierPoints.push(subTreePath.slice(0, i).split(''));
+    }
+    // We move our focus from the current tree to each frontier point, resulting in a array of subtrees.
+    // The roots of these subtrees are the frontier points, so we hash each of the subtrees.
+    return frontierPoints.map(fp =>
+      Timber.hashTree(fp.reduce((acc, curr) => Timber.moveDown(acc, curr), frontierTreeRoot)),
+    );
+  }
+
+  /**
+  @method
+  Inserts a single leaf into the tree
+  @param {string} leafValue - The commitment that will be inserted.
+  @returns {object} Updated timber instance.
+  */
+  insertLeaf(leafValue) {
+    if (this.leafCount === TIMBER_WIDTH) throw new Error('Tree is Full');
+    // New Leaf will be added at index leafCount - the leafCount is always one more than the index.
+    const nextIndex = Number(this.leafCount).toString(2).padStart(TIMBER_HEIGHT, '0');
+
+    const inputTree = this.tree;
+    this.tree = _insertLeaf(leafValue, inputTree, nextIndex);
+    this.leafCount += 1;
+    this.root = Timber.hashTree(this.tree);
+    this.frontier = Timber.calcFrontier(this.tree, this.leafCount);
+    return this;
+  }
+
+  /**
+  @method
+  Inserts multiple  leaves into the tree
+  @param {Array<string>} leafValues - The commitments that will be inserted.
+  @returns {object} Updated timber instance.
+  */
+  insertLeaves(leafValues) {
+    if (this.leafCount + leafValues.length > TIMBER_WIDTH)
+      throw new Error('Cannot insert leaves as tree is/will be full');
+
+    const idxValuePairs = [...Array(leafValues.length).keys()].map((a, i) => {
+      const nodeIndex = Number(this.leafCount + a)
+        .toString(2)
+        .padStart(TIMBER_HEIGHT, '0');
+      return [nodeIndex, leafValues[i]];
+    });
+    const inputTree = this.tree;
+    this.tree = idxValuePairs.reduce((acc, curr) => _insertLeaf(curr[1], acc, curr[0]), inputTree);
+    this.leafCount += leafValues.length;
+    this.root = Timber.hashTree(this.tree);
+    this.frontier = Timber.calcFrontier(this.tree, this.leafCount);
+    return this;
+  }
+
+  /**
+  @method
+  This helpfully deletes the right subtree along a given path.
+  @param {object} tree - The tree that deletion will be performed over.
+  @param {string} pathToLeaf - The path along which every right subtree will be deleted.
+  @returns {object} A tree after deletion
+  */
+  static pruneRightSubTree(tree, pathToLeaf) {
+    switch (tree.tag) {
+      case 'branch':
+        return pathToLeaf[0] === '0'
+          ? Branch(this.pruneRightSubTree(tree.left, pathToLeaf.slice(1)), Leaf(ZERO)) // Going left, delete the right tree
+          : Branch(tree.left, this.pruneRightSubTree(tree.right, pathToLeaf.slice(1))); // Going right, but leave the left tree intact
+      case 'leaf':
+        return tree;
+      default:
+        return tree;
+    }
+  }
+
+  /**
+  @method
+  Rolls a tree back to a given leafcount
+  @param {number} leafCount - The leafcount to which the tree should be rolled back to.
+  @returns {object} - Updated timber instance.
+  */
+  rollback(leafCount) {
+    if (leafCount > this.leafCount) throw new Error('Cannot rollback tree to desired leafcount');
+    if (leafCount === this.leafCount) return this;
+    if (leafCount === 0) return new Timber();
+    const pathToNewLastElement = Number(leafCount - 1)
+      .toString(2)
+      .padStart(TIMBER_HEIGHT, '0');
+    this.tree = Timber.pruneRightSubTree(this.tree, pathToNewLastElement);
+    this.root = Timber.hashTree(this.tree);
+    this.leafCount = leafCount;
+    this.frontier = Timber.calcFrontier(this.tree, this.leafCount);
+    return this;
+  }
+
+  /**
+  @method
+  Converts a tree to a array, this will include the zero elements.
+  @returns {Array<string>} - Array of all the leaves in the tree including zero elements.
+  */
+  toArray() {
+    return Timber.reduceTree((a, b) => [].concat([a, b]).flat(), this.tree);
+  }
+}
+
+export default Timber;

--- a/common-files/classes/timber.mjs
+++ b/common-files/classes/timber.mjs
@@ -104,11 +104,11 @@ const _checkMembership = (leafVal, tree, path, f, acc) => {
  */
 const combineFrontiers = (arr1, arr2) => {
   if (arr1.length > arr2.length) {
-    const fromArr1 = arr1.slice(0, arr1.length - arr2.length);
-    return fromArr1.concat(arr2);
+    const fromArr1 = arr1.slice(arr2.length);
+    return arr2.concat(fromArr1);
   }
-  const fromArr2 = arr2.slice(0, arr2.length - arr1.length);
-  return fromArr2.concat(arr1);
+  const fromArr2 = arr2.slice(arr1.length);
+  return arr1.concat(fromArr2);
 };
 
 /**
@@ -282,9 +282,11 @@ class Timber {
       '0'.padStart(a + 1, '1'),
     );
 
-    const leftTreeFrontierPoints = [Timber.hashTree(frontierTreeRoot.left)].concat(
-      leftSubTreeDirs.map(fp => Timber.hashTree(Timber.moveDown(frontierTreeRoot.left, fp))),
-    );
+    const leftTreeFrontierPoints = [Timber.hashTree(frontierTreeRoot.left)]
+      .concat(
+        leftSubTreeDirs.map(fp => Timber.hashTree(Timber.moveDown(frontierTreeRoot.left, fp))),
+      )
+      .reverse();
 
     // const newHeight = height - numFrontierPoints > 0 ? numFrontierPoints - 1 : height - 1;
     const newHeight = numFrontierPoints - 1;

--- a/common-files/classes/timber.mjs
+++ b/common-files/classes/timber.mjs
@@ -366,7 +366,6 @@ class Timber {
   rollback(leafCount) {
     if (leafCount > this.leafCount) throw new Error('Cannot rollback tree to desired leafcount');
     if (leafCount === this.leafCount) return this;
-    if (leafCount === 0) return new Timber();
     const pathToNewLastElement = Number(leafCount - 1)
       .toString(2)
       .padStart(TIMBER_HEIGHT, '0');

--- a/config/default.js
+++ b/config/default.js
@@ -72,6 +72,7 @@ module.exports = {
   HASH_TYPE: 'mimc',
   USE_STUBS: process.env.USE_STUBS === 'true',
   VK_IDS: { deposit: 0, single_transfer: 1, double_transfer: 2, withdraw: 3 }, // used as an enum to mirror the Shield contracts enum for vk types. The keys of this object must correspond to a 'folderpath' (the .zok file without the '.zok' bit)
+  TIMBER_HEIGHT: 32,
 
   // the various parameters needed to describe the Babyjubjub curve that we use for El-Gamal
   // BABYJUBJUB

--- a/package-lock.json
+++ b/package-lock.json
@@ -3860,6 +3860,15 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "fast-check": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-2.18.0.tgz",
+      "integrity": "sha512-7KKUw0wtAJOVrJ1DgmFILd9EmeqMLGtfe5HoEtkYZfYIxohm6Zy7zPq1Zl8t6tPL8A3e86YZrheyGg2m5j8cLA==",
+      "dev": true,
+      "requires": {
+        "pure-rand": "^5.0.0"
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6300,6 +6309,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "pure-rand": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-5.0.0.tgz",
+      "integrity": "sha512-lD2/y78q+7HqBx2SaT6OT4UcwtvXNRfEpzYEzl0EQ+9gZq2Qi3fa0HDnYPeqQwhlHJFBUhT7AO3mLU3+8bynHA==",
       "dev": true
     },
     "q": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "config": "^3.3.1",
     "eslint": "^7.25.0",
     "eslint-config-codfish": "^10.0.0",
+    "fast-check": "^2.18.0",
     "find-unused-exports": "^2.0.0",
     "general-number": "^1.0.1",
     "husky": "^6.0.0",

--- a/test/timber.test.mjs
+++ b/test/timber.test.mjs
@@ -1,0 +1,60 @@
+import config from 'config';
+import chai from 'chai';
+import Timber from '../common-files/classes/timber.mjs';
+import utils from '../common-files/utils/crypto/merkle-tree/utils.mjs';
+
+const { expect } = chai;
+const { TIMBER_HEIGHT, ZERO } = config;
+
+const genLeafValues = n => {
+  const arrayOfVals = [...Array(n).keys()].map(s => s + 1);
+  const maxPad = Math.ceil(Math.log10(n)) + 1;
+  const paddedVals = arrayOfVals.map(a => `0x${a.toString().padStart(maxPad, '0')}`);
+  return paddedVals;
+};
+
+describe('Test Local timber', () => {
+  let generatedValues;
+  let timber;
+  beforeEach(() => {
+    generatedValues = genLeafValues(50);
+    timber = new Timber();
+    timber.insertLeaves(generatedValues);
+  });
+  describe('Check Tree Operations', () => {
+    it('Check all leaves inserted ', () => {
+      const timberArray = timber.toArray();
+      expect(timberArray.filter(t => t !== ZERO)).to.eql(generatedValues);
+    });
+    it('Check hashing of root', () => {
+      let arr = generatedValues;
+      for (let i = 0; i < TIMBER_HEIGHT; i++) {
+        arr = arr.length % 2 === 0 ? arr : [...arr, ZERO];
+        // eslint-disable-next-line no-loop-func
+        arr = arr.reduce((all, one, idx) => {
+          const ch = Math.floor(idx / 2);
+          // eslint-disable-next-line no-param-reassign
+          all[ch] = [].concat(all[ch] || [], one);
+          return all;
+        }, []);
+        arr = arr.map(a => utils.concatenateThenHash(...a));
+      }
+      expect(arr[0]).to.equal(timber.root);
+    });
+    it('Check leafCount', () => {
+      expect(generatedValues.length).to.equal(timber.leafCount);
+    });
+    it('Check Merkle Proof', () => {
+      const randomIndex = Math.floor(Math.random() * generatedValues.length);
+      const leafValue = generatedValues[randomIndex];
+      const merklePath = timber.getMerklePath(leafValue);
+      expect(Timber.verifyMerklePath(leafValue, timber.root, merklePath)).to.be.equal(true);
+    });
+    it('Check Rollback', () => {
+      const rollbackLeafTo = Math.floor(Math.random() * generatedValues.length);
+      const newTimber = new Timber();
+      newTimber.insertLeaves(generatedValues.slice(0, rollbackLeafTo));
+      expect(timber.rollback(rollbackLeafTo)).to.eql(newTimber);
+    });
+  });
+});

--- a/test/timber.test.mjs
+++ b/test/timber.test.mjs
@@ -4,7 +4,7 @@ import Timber from '../common-files/classes/timber.mjs';
 import utils from '../common-files/utils/crypto/merkle-tree/utils.mjs';
 
 const { expect } = chai;
-const { TIMBER_HEIGHT, ZERO } = config;
+const { TIMBER_HEIGHT } = config;
 
 const genLeafValues = n => {
   const arrayOfVals = [...Array(n).keys()].map(s => s + 1);
@@ -24,12 +24,12 @@ describe('Test Local timber', () => {
   describe('Check Tree Operations', () => {
     it('Check all leaves inserted ', () => {
       const timberArray = timber.toArray();
-      expect(timberArray.filter(t => t !== ZERO)).to.eql(generatedValues);
+      expect(timberArray.filter(t => t !== 0)).to.eql(generatedValues);
     });
     it('Check hashing of root', () => {
       let arr = generatedValues;
       for (let i = 0; i < TIMBER_HEIGHT; i++) {
-        arr = arr.length % 2 === 0 ? arr : [...arr, ZERO];
+        arr = arr.length % 2 === 0 ? arr : [...arr, 0];
         // eslint-disable-next-line no-loop-func
         arr = arr.reduce((all, one, idx) => {
           const ch = Math.floor(idx / 2);

--- a/test/timber.test.mjs
+++ b/test/timber.test.mjs
@@ -1,60 +1,129 @@
 import config from 'config';
 import chai from 'chai';
+import fc from 'fast-check';
 import Timber from '../common-files/classes/timber.mjs';
 import utils from '../common-files/utils/crypto/merkle-tree/utils.mjs';
 
 const { expect } = chai;
 const { TIMBER_HEIGHT } = config;
 
-const genLeafValues = n => {
-  const arrayOfVals = [...Array(n).keys()].map(s => s + 1);
+const genLeafValues = (n, start = 0) => {
+  const arrayOfVals = [...Array(n).keys()].map(s => s + (start + 1));
   const maxPad = Math.ceil(Math.log10(n)) + 1;
   const paddedVals = arrayOfVals.map(a => `0x${a.toString().padStart(maxPad, '0')}`);
   return paddedVals;
 };
 
+const MAX_ARRAY = 100;
+
+const randomLeaves = fc.hexaString({ minLength: 2, maxLength: 2 }).map(h => `0x${h}`);
+
 describe('Test Local timber', () => {
-  let generatedValues;
-  let timber;
-  beforeEach(() => {
-    generatedValues = genLeafValues(50);
-    timber = new Timber();
-    timber.insertLeaves(generatedValues);
-  });
+  // let generatedValues;
+  // let timber;
+  // beforeEach(() => {
+  //   generatedValues = genLeafValues(3);
+  //   timber = new Timber();
+  //   timber.insertLeaves(generatedValues);
+  // });
   describe('Check Tree Operations', () => {
-    it('Check all leaves inserted ', () => {
-      const timberArray = timber.toArray();
-      expect(timberArray.filter(t => t !== 0)).to.eql(generatedValues);
-    });
-    it('Check hashing of root', () => {
-      let arr = generatedValues;
-      for (let i = 0; i < TIMBER_HEIGHT; i++) {
-        arr = arr.length % 2 === 0 ? arr : [...arr, 0];
-        // eslint-disable-next-line no-loop-func
-        arr = arr.reduce((all, one, idx) => {
-          const ch = Math.floor(idx / 2);
-          // eslint-disable-next-line no-param-reassign
-          all[ch] = [].concat(all[ch] || [], one);
-          return all;
-        }, []);
-        arr = arr.map(a => utils.concatenateThenHash(...a));
-      }
-      expect(arr[0]).to.equal(timber.root);
-    });
-    it('Check leafCount', () => {
-      expect(generatedValues.length).to.equal(timber.leafCount);
-    });
-    it('Check Merkle Proof', () => {
-      const randomIndex = Math.floor(Math.random() * generatedValues.length);
-      const leafValue = generatedValues[randomIndex];
-      const merklePath = timber.getMerklePath(leafValue);
-      expect(Timber.verifyMerklePath(leafValue, timber.root, merklePath)).to.be.equal(true);
-    });
-    it('Check Rollback', () => {
-      const rollbackLeafTo = Math.floor(Math.random() * generatedValues.length);
-      const newTimber = new Timber();
-      newTimber.insertLeaves(generatedValues.slice(0, rollbackLeafTo));
-      expect(timber.rollback(rollbackLeafTo)).to.eql(newTimber);
+    // it('Check all leaves inserted ', () => {
+    //   fc.assert(
+    //     fc.property(randomLeaves, leaves => {
+    //       const timber = new Timber();
+    //       timber.insertLeaves(leaves);
+    //       expect(timber.toArray().filter(t => t !== 0)).to.eql(leaves);
+    //       expect(timber.leafCount).to.equal(leaves.length);
+    //     }),
+    //     { numRuns: 10 },
+    //   );
+    // });
+    // it('Check hashing of root', () => {
+    //   fc.assert(
+    //     fc.property(randomLeaves, leaves => {
+    //       let leavesArr = leaves;
+    //       const timber = new Timber();
+    //       timber.insertLeaves(leavesArr);
+    //       for (let i = 0; i < TIMBER_HEIGHT; i++) {
+    //         leavesArr = leavesArr.length % 2 === 0 ? leavesArr : [...leavesArr, 0];
+    //         // eslint-disable-next-line no-loop-func
+    //         leavesArr = leavesArr.reduce((all, one, idx) => {
+    //           const ch = Math.floor(idx / 2);
+    //           // eslint-disable-next-line no-param-reassign
+    //           all[ch] = [].concat(all[ch] || [], one);
+    //           return all;
+    //         }, []);
+    //         leavesArr = leavesArr.map(a => utils.concatenateThenHash(...a));
+    //       }
+    //       expect(leavesArr[0]).to.equal(timber.root);
+    //     }),
+    //     { numRuns: 10 },
+    //   );
+    // });
+    // it('Check Merkle Proof', () => {
+    //   fc.assert(
+    //     fc.property(randomLeaves, fc.nat(MAX_ARRAY - 1), (leaves, randomIndex) => {
+    //       const timber = new Timber();
+    //       timber.insertLeaves(leaves);
+    //       const leafValue = leaves[randomIndex];
+    //       const merklePath = timber.getMerklePath(leafValue);
+    //       expect(Timber.verifyMerklePath(leafValue, timber.root, merklePath)).to.be.equal(true);
+    //     }),
+    //     { numRuns: 10 },
+    //   );
+    // });
+    // it('Check Rollback', () => {
+    //   fc.assert(
+    //     fc.property(randomLeaves, fc.nat(MAX_ARRAY - 1), (leaves, rollbackLeaf) => {
+    //       const timber = new Timber();
+    //       timber.insertLeaves(leaves);
+    //       const newTimber = new Timber();
+    //       newTimber.insertLeaves(leaves.slice(0, rollbackLeaf));
+    //       expect(timber.rollback(rollbackLeaf)).to.eql(newTimber);
+    //     }),
+    //     { numRuns: 10 },
+    //   );
+    // });
+    it('Check even updateFrontier', () => {
+      let count = 0;
+      fc.assert(
+        fc.property(
+          fc.array(randomLeaves, { minLength: 1, maxLength: MAX_ARRAY }),
+          fc.array(randomLeaves, { minLength: 1, maxLength: 32 }),
+          (leaves, addedLeaves) => {
+            console.log(`randomLeaves: ${leaves.length}`);
+            console.log(`AddedLeaves: ${addedLeaves.length}`);
+            const timber = new Timber();
+            timber.insertLeaves(leaves);
+            const newFrontier = Timber.updateFrontier(timber, addedLeaves);
+            timber.insertLeaves(addedLeaves);
+            expect(newFrontier.frontier).to.eql(timber.frontier);
+            expect(newFrontier.leafCount).to.equal(timber.leafCount);
+            console.log(`count: ${count}`);
+            count++;
+          },
+        ),
+        { numRuns: 100 },
+      );
+      // const extraLeaves = genLeafValues(2, 3);
+      // const newFrontier = Timber.updateFrontier(timber, extraLeaves);
+      // // console.log(`newFrontier: ${newFrontier.frontier}`);
+      // timber.insertLeaves(extraLeaves);
+      // // console.log(`timber.insertLeaves: ${timber.frontier}`);
+      // expect(newFrontier.frontier).to.eql(timber.frontier);
+      // expect(newFrontier.leafCount).to.equal(timber.leafCount);
     });
   });
 });
+
+// const t = new Timber();
+// const leafVals = genLeafValues(2);
+// t.insertLeaves(leafVals);
+// const extraLeaves = genLeafValues(4, 2);
+// const newFrontier = Timber.updateFrontier(t, extraLeaves);
+// t.insertLeaves(extraLeaves)
+// // const newT = Timber.updateFrontier(t, ['0x03']);
+// console.log(newFrontier.frontier);
+// console.log(t.frontier);
+// console.log(newFrontier.leafCount);
+// console.log(t.leafCount);


### PR DESCRIPTION
This PR is part of of the eventual solution to #185. Due to the size of the changes when integrating into `optimist`, this PR only contains the core `timber` library and test, and does not replace any existing code in `nightfall_3`. 

The code is extensively documented in a jsdoc style. At a high-level, the `timber` class provides merkle-tree operations (insertion, setMembership, rollbacks) on a timber-like tree (i.e. has a concept of a frontier). 

The tree itself is a recursively defined data structure that only stores leaf values. At each point in the tree, a node is either a `Branch(leftTree, rightTree)` or `Leaf(value)`, where `leftTree` and `rightTree` themselves are either `Branches` or `Leaves`.

Tests are available and can be run using `npx mocha --timeout 0 --bail test/timber.test.mjs`.

There is room for performance optimisation (e.g. using the existing frontier during insertion to minimise re-calculations of the root and future frontier), but that will be addressed after integration.