### PR TITLE
Bond and block stake update

### DIFF
--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -41,9 +41,9 @@ class Nf3 {
 
   defaultFee = 10;
 
-  PROPOSER_BOND = 10000000000000000000;
+  PROPOSER_BOND = 10;
 
-  BLOCK_STAKE = 1000000000000000000; // 1 ether
+  BLOCK_STAKE = 1;
 
   constructor(
     clientBaseUrl,


### PR DESCRIPTION
As an interim measure for testnet testing, the bond and block stakes have been reduced to 10 wei and 1 wei respectively.

This updates the cli values to reflect this and so that `./proposer` will register correctly.