### PR TITLE
Calculate leafCount for incorrect root challenge on-chain

### DIFF
--- a/nightfall-deployer/contracts/Challenges.sol
+++ b/nightfall-deployer/contracts/Challenges.sol
@@ -54,7 +54,6 @@ contract Challenges is Stateful, Key_Registry, Config {
     Block memory blockL2,
     uint256 blockNumberL2,
     Transaction[] memory transactions,
-    uint256 commitmentIndex, // the index *in the Merkle Tree* of the commitment that we are providing a SiblingPath for.
     bytes32 salt
   ) external {
     checkCommit(msg.data, salt);
@@ -67,8 +66,7 @@ contract Challenges is Stateful, Key_Registry, Config {
       priorBlockTransactions,
       frontierPriorBlock,
       blockL2,
-      transactions,
-      commitmentIndex
+      transactions
     );
     challengeAccepted(blockL2, blockNumberL2);
   }

--- a/nightfall-deployer/contracts/ChallengesUtil.sol
+++ b/nightfall-deployer/contracts/ChallengesUtil.sol
@@ -26,8 +26,7 @@ library ChallengesUtil {
         Structures.Transaction[] memory priorBlockTransactions, // the transactions in the prior block
         bytes32[33] calldata frontierPriorBlock, // frontier path before prior block is added. The same frontier used in calculating root when prior block is added
         Structures.Block memory blockL2,
-        Structures.Transaction[] memory transactions,
-        uint256 commitmentIndex // the index *in the Merkle Tree* of the commitment that we are providing a SiblingPath for.
+        Structures.Transaction[] memory transactions
     ) public pure {
         // next check the sibling path is valid and get the Frontier
         bool valid;
@@ -39,6 +38,7 @@ library ChallengesUtil {
             priorBlockL2.root
         );
         require(valid, 'The sibling path is invalid');
+        uint256 commitmentIndex = priorBlockL2.leafCount + Utils.filterCommitments(priorBlockTransactions).length;
         // At last, we can check if the root itself is correct!
         (bytes32 root, , ) =
             MerkleTree_Stateless.insertLeaves(

--- a/nightfall-optimist/src/services/challenges.mjs
+++ b/nightfall-optimist/src/services/challenges.mjs
@@ -76,12 +76,6 @@ export async function createChallenge(block, transactions, err) {
         const priorBlockTransactions = await getTransactionsByTransactionHashes(
           priorBlock.transactionHashes,
         );
-        const priorBlockCommitmentsCount = priorBlockTransactions.reduce(
-          (acc, priorBlockTransaction) => {
-            return acc + priorBlockTransaction.commitments.length;
-          },
-          0,
-        );
 
         const priorBlockHistory = await getTreeHistory(priorBlock.root);
 
@@ -94,7 +88,6 @@ export async function createChallenge(block, transactions, err) {
             Block.buildSolidityStruct(block),
             block.blockNumberL2,
             transactions.map(t => Transaction.buildSolidityStruct(t)),
-            priorBlockHistory.leafIndex + priorBlockCommitmentsCount, // priorBlockHistory.leafIndex + number of commitments  in prior block
             salt,
           )
           .encodeABI();


### PR DESCRIPTION
This PR changes `challengeNewRootCorrect` so that `commitmentIndex` is not passed in as a parameter but instead calculated on-chain using the `leafCount` of the `priorBlock` and the `nCommitments` of the next block.

This prevents fraudulent challenges of this type from being incorrectly accepted  as a challenger may intentionally use the wrong `commitmentIndex` to create trivial root mismatches.