### PR TITLE
Westlad/instant withdrawals  and bug fixes Pt 1

### DIFF
--- a/cli/src/challenger.mjs
+++ b/cli/src/challenger.mjs
@@ -1,5 +1,5 @@
 /**
-Module that runs up as a combined proposer and challenger
+Module that runs up as a challenger
 */
 import { Command } from 'commander/esm.mjs';
 import clear from 'clear';

--- a/cli/src/liquidity-provider.mjs
+++ b/cli/src/liquidity-provider.mjs
@@ -1,0 +1,44 @@
+/**
+Modules that acts as a 'liquidity provider'. This makes advance payments for
+users who request an instant withdrawal. Note that it's a simple implementation
+fand does not do any validity checks before it provides the advance. Do not use
+this in production.
+*/
+
+import { Command } from 'commander/esm.mjs';
+import clear from 'clear';
+import Nf3 from '../lib/nf3.mjs';
+
+const defaultKey = '0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69e';
+const program = new Command();
+program.option('-k, --key', 'Ethereum signing key', defaultKey);
+program.option('-h', '--help', 'Help');
+if (program.opts().help) console.log('-k | --key input an Ethereum signing key to use');
+const advanceWithdrawalEthereumSigningKey = program.opts().key || defaultKey;
+
+/**
+Does the preliminary setup and starts listening on the websocket
+*/
+async function startProvider() {
+  clear();
+  console.log('Starting Liquidity Provider...');
+  const nf3 = new Nf3(
+    'http://localhost:8080',
+    'http://localhost:8081',
+    'ws://localhost:8082',
+    'ws://localhost:8546',
+    advanceWithdrawalEthereumSigningKey,
+  );
+  await nf3.init();
+  if (await nf3.healthcheck('optimist')) console.log('Healthcheck passed');
+  else throw new Error('Healthcheck failed');
+  // set up a listener to service requests for an instant withdrawal
+  const emitter = await nf3.getInstantWithdrawalRequestedEmitter();
+  emitter.on('data', async (withdrawTransactionHash, paidBy, amount) => {
+    await nf3.advanceInstantWithdrawal(withdrawTransactionHash);
+    console.log(`Serviced instant-withdrawal request from ${paidBy}, with fee ${amount}`);
+  });
+  console.log('Listening for incoming events');
+}
+
+startProvider();

--- a/cli/src/proposer.mjs
+++ b/cli/src/proposer.mjs
@@ -1,5 +1,5 @@
 /**
-Module that runs up as a combined proposer and challenger
+Module that runs up as a proposer
 */
 import { Command } from 'commander/esm.mjs';
 import clear from 'clear';

--- a/common-files/classes/transaction.mjs
+++ b/common-files/classes/transaction.mjs
@@ -28,7 +28,7 @@ function keccak(preimage) {
     ...preimage.commitments.map(ch => ({ t: 'bytes32', v: ch })),
     ...preimage.nullifiers.map(nh => ({ t: 'bytes32', v: nh })),
     ...preimage.compressedSecrets.map(es => ({ t: 'bytes32', v: es })),
-    ...preimage.proof.map(p => ({ t: 'uint', v: p })),
+    ...compressProof(preimage.proof).map(p => ({ t: 'uint', v: p })),
   );
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,7 +202,7 @@ services:
       MONGO_PORT: 27017
       MONGO_NAME: merkle_tree
       HASH_TYPE: mimc
-      LOG_LEVEL: debug
+      LOG_LEVEL: info
       AUTOSTART: enabled
 
   # Timber service, configured for nightfall

--- a/liquidity-provider
+++ b/liquidity-provider
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+/usr/bin/env node cli/src/liquidity-provider.mjs

--- a/nightfall-deployer/contracts/Proposers.sol
+++ b/nightfall-deployer/contracts/Proposers.sol
@@ -30,7 +30,7 @@ contract Proposers is Stateful, Structures, Config {
 
   //add the proposer to the circular linked list
   function registerProposer() external payable {
-    require(REGISTRATION_BOND == msg.value, 'The registration payment is incorrect');
+    require(REGISTRATION_BOND <= msg.value, 'The registration payment is incorrect');
     payable(address(state)).transfer(REGISTRATION_BOND);
     state.setBondAccount(msg.sender,REGISTRATION_BOND);
     LinkedAddress memory currentProposer = state.getCurrentProposer();

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -137,6 +137,7 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
     require(msg.sender == currentOwner, 'You are not the current owner of this withdrawal');
     advancedFeeWithdrawals[withdrawTransactionHash] = msg.value;
     payable(address(state)).transfer(msg.value);
+    emit InstantWithdrawalRequested(withdrawTransactionHash, msg.sender, msg.value);
   }
 
   function payOut(Transaction memory t, address recipientAddress) internal {

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -57,7 +57,7 @@ contract State is Structures, Config {
     require(b.blockNumberL2 == blockHashes.length, 'The block is out of order'); // this will fail if a tx is re-mined out of order due to a chain reorg.
     bytes32 previousBlockHash;
     if (blockHashes.length != 0) require(b.previousBlockHash == blockHashes[blockHashes.length - 1].blockHash, 'The block is flawed or out of order'); // this will fail if a tx is re-mined out of order due to a chain reorg.
-    require(BLOCK_STAKE == msg.value, 'The stake payment is incorrect');
+    require(BLOCK_STAKE <= msg.value, 'The stake payment is incorrect');
     require(b.proposer == msg.sender, 'The proposer address is not the sender');
     // We need to set the blockHash on chain here, because there is no way to
     // convince a challenge function of the (in)correctness by an offchain

--- a/nightfall-deployer/contracts/Structures.sol
+++ b/nightfall-deployer/contracts/Structures.sol
@@ -21,6 +21,8 @@ contract Structures {
 
     event CommittedToChallenge(bytes32 commitHash, address sender);
 
+    event InstantWithdrawalRequested(bytes32 withdrawTransactionHash, address paidBy, uint amount);
+
     /**
   These events are what the merkle-tree microservice's filters will listen for.
   */

--- a/nightfall-deployer/contracts/Utils.sol
+++ b/nightfall-deployer/contracts/Utils.sol
@@ -22,6 +22,7 @@ library Utils {
         t.recipientAddress,
         t.commitments,
         t.nullifiers,
+        t.compressedSecrets,
         t.proof
       )
     );

--- a/nightfall-optimist/src/event-handlers/index.mjs
+++ b/nightfall-optimist/src/event-handlers/index.mjs
@@ -2,12 +2,14 @@ import {
   startEventQueue,
   subscribeToBlockAssembledWebSocketConnection,
   subscribeToChallengeWebSocketConnection,
+  subscribeToInstantWithDrawalWebSocketConnection,
 } from './subscribe.mjs';
 import blockProposedEventHandler from './block-proposed.mjs';
 import newCurrentProposerEventHandler from './new-current-proposer.mjs';
 import transactionSubmittedEventHandler from './transaction-submitted.mjs';
 import rollbackEventHandler from './rollback.mjs';
 import committedToChallengeEventHandler from './challenge-commit.mjs';
+import instantWithdrawalRequestedEventHandler from './instant-withdrawal.mjs';
 import {
   // removeRollbackEventHandler,
   removeBlockProposedEventHandler,
@@ -22,6 +24,7 @@ const eventHandlers = {
   Rollback: rollbackEventHandler,
   CommittedToChallenge: committedToChallengeEventHandler,
   NewCurrentProposer: newCurrentProposerEventHandler,
+  InstantWithdrawalRequested: instantWithdrawalRequestedEventHandler,
   removers: {
     // Rollback: removeRollbackEventHandler,
     BlockProposed: removeBlockProposedEventHandler,
@@ -35,6 +38,7 @@ const eventHandlers = {
     Rollback: 0,
     CommittedToChallenge: 0,
     NewCurrentProposer: 0,
+    InstantWithdrawalRequested: 1,
   },
 };
 
@@ -42,5 +46,7 @@ export {
   startEventQueue,
   subscribeToBlockAssembledWebSocketConnection,
   subscribeToChallengeWebSocketConnection,
+  subscribeToInstantWithDrawalWebSocketConnection,
+  instantWithdrawalRequestedEventHandler,
   eventHandlers,
 };

--- a/nightfall-optimist/src/event-handlers/index.mjs
+++ b/nightfall-optimist/src/event-handlers/index.mjs
@@ -47,6 +47,5 @@ export {
   subscribeToBlockAssembledWebSocketConnection,
   subscribeToChallengeWebSocketConnection,
   subscribeToInstantWithDrawalWebSocketConnection,
-  instantWithdrawalRequestedEventHandler,
   eventHandlers,
 };

--- a/nightfall-optimist/src/event-handlers/instant-withdrawal.mjs
+++ b/nightfall-optimist/src/event-handlers/instant-withdrawal.mjs
@@ -1,0 +1,13 @@
+import logger from 'common-files/utils/logger.mjs';
+import { notifyInstantWithdrawalRequest } from '../services/instant-withdrawal.mjs';
+
+async function instantWithdrawalRequestedEventHandler(data) {
+  logger.debug(
+    `Instant withdrawal request made with data ${JSON.stringify(data.returnValues, null, 2)}`,
+  );
+  const { withdrawTransactionHash, paidBy, amount } = data.returnValues;
+  // TODO get the challenger to enact an advance of withdrawal automatically
+  return notifyInstantWithdrawalRequest(withdrawTransactionHash, paidBy, amount);
+}
+
+export default instantWithdrawalRequestedEventHandler;

--- a/nightfall-optimist/src/event-handlers/subscribe.mjs
+++ b/nightfall-optimist/src/event-handlers/subscribe.mjs
@@ -77,7 +77,7 @@ export async function subscribeToChallengeWebSocketConnection(callback, ...args)
       if (message === 'challenge') callback(ws, args);
     }),
   );
-  logger.debug('Subscribed to WebSocket connection');
+  logger.debug('Subscribed to Challenge WebSocket connection');
 }
 
 export async function subscribeToBlockAssembledWebSocketConnection(callback, ...args) {
@@ -86,5 +86,14 @@ export async function subscribeToBlockAssembledWebSocketConnection(callback, ...
       if (message === 'blocks') callback(ws, args);
     }),
   );
-  logger.debug('Subscribed to WebSocket connection');
+  logger.debug('Subscribed to BlockAssembled WebSocket connection');
+}
+
+export async function subscribeToInstantWithDrawalWebSocketConnection(callback, ...args) {
+  wss.on('connection', ws =>
+    ws.on('message', message => {
+      if (message === 'instant') callback(ws, args);
+    }),
+  );
+  logger.debug('Subscribed to InstantWithDrawal WebSocket connection');
 }

--- a/nightfall-optimist/src/index.mjs
+++ b/nightfall-optimist/src/index.mjs
@@ -4,6 +4,7 @@ import {
   startEventQueue,
   subscribeToBlockAssembledWebSocketConnection,
   subscribeToChallengeWebSocketConnection,
+  subscribeToInstantWithDrawalWebSocketConnection,
   eventHandlers,
 } from './event-handlers/index.mjs';
 import Proposer from './classes/proposer.mjs';
@@ -14,6 +15,7 @@ import {
 import { setChallengeWebSocketConnection } from './services/challenges.mjs';
 import initialBlockSync from './services/state-sync.mjs';
 import { queueManager } from './services/event-queue.mjs';
+import { setInstantWithdrawalWebSocketConnection } from './services/instant-withdrawal.mjs';
 
 const main = async () => {
   try {
@@ -21,6 +23,7 @@ const main = async () => {
     // subscribe to WebSocket events first
     await subscribeToBlockAssembledWebSocketConnection(setBlockAssembledWebSocketConnection);
     await subscribeToChallengeWebSocketConnection(setChallengeWebSocketConnection);
+    await subscribeToInstantWithDrawalWebSocketConnection(setInstantWithdrawalWebSocketConnection);
     // try to sync any missing blockchain state
     // only then start making blocks and listening to new proposers
     initialBlockSync(proposer).then(() => {

--- a/nightfall-optimist/src/routes/transaction.mjs
+++ b/nightfall-optimist/src/routes/transaction.mjs
@@ -3,7 +3,7 @@ Routes for setting and removing valid challenger addresses.
 */
 import express from 'express';
 import logger from 'common-files/utils/logger.mjs';
-import advanceWithdrawal from '../services/instant-withdrawal.mjs';
+import { advanceWithdrawal } from '../services/instant-withdrawal.mjs';
 import { getTransactionByTransactionHash } from '../services/database.mjs';
 
 const router = express.Router();
@@ -12,7 +12,9 @@ router.post('/advanceWithdrawal', async (req, res, next) => {
   logger.debug('add endpoint received POST');
   try {
     const { transactionHash } = req.body;
+    console.log('TRANSACTIONHASH', transactionHash);
     const withdrawTransaction = await getTransactionByTransactionHash(transactionHash);
+    console.log('WITHDRAWTRANSACTION', withdrawTransaction);
     const result = await advanceWithdrawal(withdrawTransaction);
     res.json(result);
   } catch (err) {

--- a/nightfall-optimist/src/services/instant-withdrawal.mjs
+++ b/nightfall-optimist/src/services/instant-withdrawal.mjs
@@ -3,8 +3,9 @@ import logger from 'common-files/utils/logger.mjs';
 import { getContractInstance } from 'common-files/utils/contract.mjs';
 import { Transaction } from '../classes/index.mjs';
 
+let ws;
 const { SHIELD_CONTRACT_NAME } = config;
-const advanceWithdrawal = async transaction => {
+export const advanceWithdrawal = async transaction => {
   const shieldContractInstance = await getContractInstance(SHIELD_CONTRACT_NAME);
   try {
     const txDataToSign = await shieldContractInstance.methods
@@ -16,4 +17,15 @@ const advanceWithdrawal = async transaction => {
     throw new Error(error);
   }
 };
-export default advanceWithdrawal;
+
+export function setInstantWithdrawalWebSocketConnection(_ws) {
+  ws = _ws;
+}
+
+export async function notifyInstantWithdrawalRequest(withdrawTransactionHash, paidBy, amount) {
+  if (!ws) {
+    logger.warn('No one is listening for instant withdrawal requests');
+    return;
+  }
+  ws.send(JSON.stringify({ type: 'instant', withdrawTransactionHash, paidBy, amount }));
+}


### PR DESCRIPTION
This is a partial resolution of #177.  It adds instant withdrawals to the SDK (`Nf3 class`). It also fixes a bug in `Nf_3` whereby calls to `Nf3.close` did not shut down open Websockets, and a bug in the off-chain Keccak hash calculation for a Transaction where the proof was not compressed first and, finally, a bug in the on-chain Transaction hash calculation where `compressedSecrets` was not included.  The two methods of hash calculation now agree.

Direct transfers will be added in Pt 2.

To test you have to use the CLI.  There is a new listener which will (uncritically) service all Instant-Withdraw requests.  Run this up with `./liquidity-provider` in a spare window, after you have started nightfall_3 and the `./proposer` listener.  Then you can run the CLI itself (`./nf`). 

To test the Instant-Withdraw command first make sure you have a Withdraw transaction in a Layer 2 block (the fastest way to do this is make a block with two Deposits, then a block with a Deposit and a Withdraw. When that is done, then you can request that it is converted to an Instant Withdraw (`Instant-Withdraw` command). The operation of the command should be self-explanatory and the defaults will work.
