### PR TITLE
Westlad/balances by pkd

### DIFF
--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -127,13 +127,18 @@ async function askQuestions(nf3) {
 Simple function to print out the balances object
 */
 function printBalances(balances) {
+  console.log('BALANCES', balances);
   if (Object.keys(balances).length === 0) {
     console.log('You have no balances yet - try depositing some tokens into Layer 2 from Layer 1');
     return;
   }
-  const table = new Table({ head: ['ERC Contract Address', 'Layer 2 Balance'] });
-  table.push(balances);
-  console.log(table.toString());
+  // eslint-disable-next-line guard-for-in
+  for (const compressedPkd in balances) {
+    const table = new Table({ head: ['ERC Contract Address', 'Layer 2 Balance'] });
+    table.push(balances[compressedPkd]);
+    console.log(chalk.yellow('Balances of user', compressedPkd));
+    console.log(table.toString());
+  }
 }
 
 /**

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -168,9 +168,11 @@ export async function getWalletBalance() {
   // work out the balance contribution of each commitment  - a 721 token has no value field in the
   // commitment but each 721 token counts as a balance of 1. Then finally add up the individual
   // commitment balances to get a balance for each erc address.
+  console.log('WALLET IS', wallet);
   return wallet
     .map(e => ({
       ercAddress: BigInt(e.preimage.ercAddress).toString(16),
+      compressedPkd: e.preimage.compressedPkd,
       tokenId: !!BigInt(e.preimage.tokenId),
       value: Number(BigInt(e.preimage.value)),
     }))
@@ -181,7 +183,7 @@ export async function getWalletBalance() {
       balance: e.tokenId ? 1 : e.value,
     }))
     .reduce((acc, e) => {
-      if (!acc[e.compressedPkd]) acc[e.compressedPkd] = true;
+      if (!acc[e.compressedPkd]) acc[e.compressedPkd] = {};
       if (!acc[e.compressedPkd][e.ercAddress]) acc[e.compressedPkd][e.ercAddress] = 0;
       acc[e.compressedPkd][e.ercAddress] += e.balance;
       return acc;


### PR DESCRIPTION
fixes #196 

This PR splits out wallet balances by user and ERC contract address.  It can be tested by selecting 'View Wallet Balance' from the CLI.  Previously, all balances were summed for each ERC contract address.  

Note that the test deployment of NF_3 uses a stub ERC contract, rather than real ones and thus the contract address will be the same, irrespective of the token type chosen.  This would not be the case in a real deployment using real ERC contracts.

A 'User' is defined by their unique pkd key (see https://github.com/EYBlockchain/nightfall_3/blob/master/doc/in-band-secret-distribution.md for more details). As the pkd key is actually a curve point, we use Edwards compression to reduce the point to a single number (essentially the y coordinate with a parity bit).