### PR TITLE
github acton workflow for Infura ropsten deployment and integration test

### DIFF
--- a/.github/workflows/check-PRs.yml
+++ b/.github/workflows/check-PRs.yml
@@ -129,7 +129,7 @@ jobs:
       - name: wait 2000s for Containers startup and setup completion
         run: sleep 2000
 
-      # kept for future debug
+      # kept it for future debug
       # - run: sleep 1000
       # - name: debug logs - after container startup 1
       #   if: always()

--- a/.github/workflows/check-PRs.yml
+++ b/.github/workflows/check-PRs.yml
@@ -126,18 +126,19 @@ jobs:
           docker-compose build
           ./start-nightfall -t &> testnet-test.log &disown
 
-      # - name: wait 2000s for Containers startup and setup completion
-      #   run: sleep 2000
+      - name: wait 2000s for Containers startup and setup completion
+        run: sleep 2000
 
-      - run: sleep 1000
-      - name: debug logs - after container startup 1
-        if: always()
-        run: cat testnet-test.log
+      # kept for future debug
+      # - run: sleep 1000
+      # - name: debug logs - after container startup 1
+      #   if: always()
+      #   run: cat testnet-test.log
 
-      - run: sleep 1000
-      - name: debug logs - after container startup 2
-        if: always()
-        run: cat testnet-test.log
+      # - run: sleep 1000
+      # - name: debug logs - after container startup 2
+      #   if: always()
+      #   run: cat testnet-test.log
 
       - name: Run integration test
         run: |

--- a/.github/workflows/check-PRs.yml
+++ b/.github/workflows/check-PRs.yml
@@ -126,10 +126,16 @@ jobs:
           docker-compose build
           ./start-nightfall -t &> testnet-test.log &disown
 
-      - name: wait 2000s for Containers startup and setup completion
-        run: sleep 2000
+      # - name: wait 2000s for Containers startup and setup completion
+      #   run: sleep 2000
 
-      - name: debug logs - after container startup
+      - run: sleep 1000
+      - name: debug logs - after container startup 1
+        if: always()
+        run: cat testnet-test.log
+
+      - run: sleep 1000
+      - name: debug logs - after container startup 2
         if: always()
         run: cat testnet-test.log
 

--- a/.github/workflows/check-PRs.yml
+++ b/.github/workflows/check-PRs.yml
@@ -31,13 +31,19 @@ jobs:
           docker-compose build
           ./start-nightfall -g &> ganache-test.log &disown
 
+      - name: wait 1000s for Containers startup and setup completion
+        run: sleep 1000
+
+      - name: debug logs - after container startup
+        if: always()
+        run: cat ganache-test.log
+
       - name: Run integration test
         run: |
           npm ci
-          sleep 1000
           npm test
 
-      - name: debug logs
+      - name: debug logs - after integration test run
         if: always()
         run: cat ganache-test.log
 
@@ -68,13 +74,19 @@ jobs:
         env:
           TRANSACTIONS_PER_BLOCK: 32
 
+      - name: wait 1000s for Containers startup and setup completion
+        run: sleep 1000
+
+      - name: debug logs - after container startup
+        if: always()
+        run: cat test-gas.log
+
       - name: Run tx-gas.mjs test suites
         run: |
           npm ci
-          sleep 1000
           npm run test-gas
 
-      - name: debug logs
+      - name: debug logs - after integration test run
         if: always()
         run: cat test-gas.log
 
@@ -88,3 +100,62 @@ jobs:
         with:
           name: test-gas-logs
           path: ./test-gas.log
+
+  testnet-test:
+    runs-on: ubuntu-18.04
+    environment: TESTNET_DEPLOYMENT
+    env:
+      ETH_PRIVATE_KEY: ${{ secrets.ETH_PRIVATE_KEY }}
+      INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
+      INFURA_PROJECT_SECRET: ${{ secrets.INFURA_PROJECT_SECRET }}
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.17.0'
+
+      - name: balance before deployment and integration test
+        run: |
+          curl -u :$INFURA_PROJECT_SECRET https://ropsten.infura.io/v3/$INFURA_PROJECT_ID \
+          -X POST \
+          -H "Content-Type: application/json" \
+          -d '{"jsonrpc":"2.0","method":"eth_getBalance","params": ["0x29100E7E3dA6654BF63d9E7804ADe518aCc5AaA5", "latest"],"id":1}'
+
+      - name: Start Containers
+        run: |
+          docker-compose build
+          ./start-nightfall -t &> testnet-test.log &disown
+
+      - name: wait 2000s for Containers startup and setup completion
+        run: sleep 2000
+
+      - name: debug logs - after container startup
+        if: always()
+        run: cat testnet-test.log
+
+      - name: Run integration test
+        run: |
+          npm ci
+          npm run testnet-test
+
+      - name: balance after deployment and integration test
+        run: |
+          curl  -u :$INFURA_PROJECT_SECRET https://ropsten.infura.io/v3/$INFURA_PROJECT_ID \
+          -X POST \
+          -H "Content-Type: application/json" \
+          -d '{"jsonrpc":"2.0","method":"eth_getBalance","params": ["0x29100E7E3dA6654BF63d9E7804ADe518aCc5AaA5", "latest"],"id":1}'
+
+      - name: debug logs - after integration test run
+        if: always()
+        run: cat testnet-test.log
+
+      - name: If integration test failed, shutdown the Containers
+        if: failure()
+        run: docker-compose down -v
+
+      - name: If integration test failed, upload logs files as artifacts
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: testnet-test-logs
+          path: ./testnet-test.log

--- a/docker-compose.testnet.yml
+++ b/docker-compose.testnet.yml
@@ -32,26 +32,26 @@ services:
     environment:
       BLOCKCHAIN_URL: 'wss://ropsten.infura.io/ws/v3/${INFURA_PROJECT_ID}'
       USE_INFURA: 'true'
-      AUTOSTART_RETRIES: 300
+      AUTOSTART_RETRIES: 500
       INFURA_PROJECT_SECRET: $INFURA_PROJECT_SECRET
 
   timber2:
     environment:
       BLOCKCHAIN_URL: 'wss://ropsten.infura.io/ws/v3/${INFURA_PROJECT_ID}'
       USE_INFURA: 'true'
-      AUTOSTART_RETRIES: 300
+      AUTOSTART_RETRIES: 500
       INFURA_PROJECT_SECRET: $INFURA_PROJECT_SECRET
 
   optimist1:
     environment:
       BLOCKCHAIN_URL: 'wss://ropsten.infura.io/ws/v3/${INFURA_PROJECT_ID}'
       USE_INFURA: 'true'
-      AUTOSTART_RETRIES: 300
+      AUTOSTART_RETRIES: 500
       INFURA_PROJECT_SECRET: $INFURA_PROJECT_SECRET
 
   optimist2:
     environment:
       BLOCKCHAIN_URL: 'wss://ropsten.infura.io/ws/v3/${INFURA_PROJECT_ID}'
       USE_INFURA: 'true'
-      AUTOSTART_RETRIES: 300
+      AUTOSTART_RETRIES: 500
       INFURA_PROJECT_SECRET: $INFURA_PROJECT_SECRET

--- a/docker-compose.testnet.yml
+++ b/docker-compose.testnet.yml
@@ -7,14 +7,14 @@ services:
     environment:
       BLOCKCHAIN_URL: 'wss://ropsten.infura.io/ws/v3/${INFURA_PROJECT_ID}'
       USE_INFURA: 'true'
-      AUTOSTART_RETRIES: 300
+      AUTOSTART_RETRIES: 500
       INFURA_PROJECT_SECRET: $INFURA_PROJECT_SECRET
 
   client2:
     environment:
       BLOCKCHAIN_URL: 'wss://ropsten.infura.io/ws/v3/${INFURA_PROJECT_ID}'
       USE_INFURA: 'true'
-      AUTOSTART_RETRIES: 300
+      AUTOSTART_RETRIES: 500
       INFURA_PROJECT_SECRET: $INFURA_PROJECT_SECRET
 
   deployer:

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -87,6 +87,7 @@ module.exports = {
       provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_URL),
       network_id: 3,
       gas: 8000000,
+      gasPrice: 10000000000,
       networkCheckTimeout: 10000000,
       timeoutBlocks: 500,
     },

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -87,7 +87,7 @@ module.exports = {
       provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_URL),
       network_id: 3,
       gas: 7992189,
-      gasPrice: 100000000000000000
+      gasPrice: 100000000000000000,
       networkCheckTimeout: 100000000,
       timeoutBlocks: 20000,
       skipDryRun: true,

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -87,10 +87,8 @@ module.exports = {
       provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_URL),
       network_id: 3,
       networkCheckTimeout: 1000000000,
-      timeoutBlocks: 20000,
+      timeoutBlocks: 200,
       skipDryRun: true,
-      disableConfirmationListener: true,
-      websockets: true,
     },
 
     // Another network with more advanced options...

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -86,6 +86,7 @@ module.exports = {
     ropsten: {
       provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_URL),
       network_id: 3,
+      gas: 8000000,
       networkCheckTimeout: 10000000,
       timeoutBlocks: 500,
     },

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -86,6 +86,7 @@ module.exports = {
     ropsten: {
       provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_URL),
       network_id: 3,
+      gasPrice: 10000000000,
       networkCheckTimeout: 10000000,
       timeoutBlocks: 500,
     },

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -87,7 +87,6 @@ module.exports = {
       provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_URL),
       network_id: 3,
       networkCheckTimeout: 10000000,
-      disableConfirmationListener: true,
     },
 
     // Another network with more advanced options...

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -86,7 +86,7 @@ module.exports = {
     ropsten: {
       provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_URL),
       network_id: 3,
-      gasPrice: 1000000000000,
+      gasPrice: 1000000000000000000,
       networkCheckTimeout: 10000000,
       timeoutBlocks: 500,
     },

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -86,7 +86,6 @@ module.exports = {
     ropsten: {
       provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_URL),
       network_id: 3,
-      gas: 7992189,
       networkCheckTimeout: 1000000000,
       timeoutBlocks: 20000,
       skipDryRun: true,

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -87,11 +87,11 @@ module.exports = {
       provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_URL),
       network_id: 3,
       gas: 7992189,
-      gasPrice: 100000000000000000,
-      networkCheckTimeout: 100000000,
+      networkCheckTimeout: 1000000000,
       timeoutBlocks: 20000,
       skipDryRun: true,
       disableConfirmationListener: true,
+      websockets: true,
     },
 
     // Another network with more advanced options...

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -87,6 +87,7 @@ module.exports = {
       provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_URL),
       network_id: 3,
       networkCheckTimeout: 10000000,
+      timeoutBlocks: 500,
     },
 
     // Another network with more advanced options...

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -86,8 +86,6 @@ module.exports = {
     ropsten: {
       provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_URL),
       network_id: 3,
-      gas: 8000000,
-      gasPrice: 10000000000,
       networkCheckTimeout: 10000000,
       timeoutBlocks: 500,
     },

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -86,7 +86,7 @@ module.exports = {
     ropsten: {
       provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_URL),
       network_id: 3,
-      gasPrice: 10000000000,
+      gasPrice: 1000000000000,
       networkCheckTimeout: 10000000,
       timeoutBlocks: 500,
     },

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -87,8 +87,10 @@ module.exports = {
       provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_URL),
       network_id: 3,
       gas: 7992189,
-      networkCheckTimeout: 10000000,
+      networkCheckTimeout: 100000000,
       timeoutBlocks: 1000,
+      skipDryRun: true,
+      disableConfirmationListener: true,
     },
 
     // Another network with more advanced options...

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -86,9 +86,9 @@ module.exports = {
     ropsten: {
       provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_URL),
       network_id: 3,
-      gasPrice: 1000000000000000000,
+      gas: 7992189,
       networkCheckTimeout: 10000000,
-      timeoutBlocks: 500,
+      timeoutBlocks: 1000,
     },
 
     // Another network with more advanced options...

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -87,6 +87,7 @@ module.exports = {
       provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_URL),
       network_id: 3,
       networkCheckTimeout: 10000000,
+      disableConfirmationListener: true,
     },
 
     // Another network with more advanced options...

--- a/nightfall-deployer/truffle-config.js
+++ b/nightfall-deployer/truffle-config.js
@@ -87,8 +87,9 @@ module.exports = {
       provider: () => new HDWalletProvider(config.ETH_PRIVATE_KEY, config.BLOCKCHAIN_URL),
       network_id: 3,
       gas: 7992189,
+      gasPrice: 100000000000000000
       networkCheckTimeout: 100000000,
-      timeoutBlocks: 1000,
+      timeoutBlocks: 20000,
       skipDryRun: true,
       disableConfirmationListener: true,
     },

--- a/nightfall-optimist/src/routes/block.mjs
+++ b/nightfall-optimist/src/routes/block.mjs
@@ -32,7 +32,7 @@ router.get('/transaction-hash/:transactionHash', async (req, res, next) => {
     logger.debug(`searching for block containing transaction hash ${transactionHash}`);
     // get data to return
     const [block] = await getBlockByTransactionHash(transactionHash);
-    if (!block) {
+    if (block !== null) {
       const transactions = await getTransactionsByTransactionHashes(block.transactionHashes);
       const index = block.transactionHashes.indexOf(transactionHash);
       delete block?._id; // this is database specific so no need to send it

--- a/nightfall-optimist/src/routes/block.mjs
+++ b/nightfall-optimist/src/routes/block.mjs
@@ -32,7 +32,7 @@ router.get('/transaction-hash/:transactionHash', async (req, res, next) => {
     logger.debug(`searching for block containing transaction hash ${transactionHash}`);
     // get data to return
     const [block] = await getBlockByTransactionHash(transactionHash);
-    if (block !== null) {
+    if (!block) {
       const transactions = await getTransactionsByTransactionHashes(block.transactionHashes);
       const index = block.transactionHashes.indexOf(transactionHash);
       delete block?._id; // this is database specific so no need to send it

--- a/nightfall-optimist/src/services/check-block.mjs
+++ b/nightfall-optimist/src/services/check-block.mjs
@@ -46,9 +46,14 @@ async function checkBlock(block, transactions) {
     history = await getBlockByBlockNumberL2(block.blockNumberL2 - 1);
     logger.debug('Block has no commitments - checking its root is the same as the previous block');
   } else {
-    history = await getTreeByLeafCount(block.leafCount + block.nCommitments);
-    logger.debug(`Block has commitments - retrieved history from Timber`);
-    logger.silly(`Timber history was ${JSON.stringify(history, null, 2)}`);
+    while (!history) {
+      // eslint-disable-next-line no-await-in-loop
+      history = await getTreeByLeafCount(block.leafCount + block.nCommitments);
+      logger.debug(`Block has commitments - retrieved history from Timber`);
+      logger.silly(`Timber history was ${JSON.stringify(history, null, 2)}`);
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise(resolve => setTimeout(resolve, 3000));
+    }
   }
   if (history.root !== block.root)
     throw new BlockError(

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -621,7 +621,7 @@ describe('Testing the http API', () => {
           .request(optimistUrl)
           .get(`/block/transaction-hash/${withdrawTransactionHash}`);
         ({ block, transactions, index } = res.body);
-      } while (block === null || block === undefined);
+      } while (block === null);
       // Need this while wait when running geth as it runs slower than ganache
       expect(block).not.to.be.undefined; // eslint-disable-line
       expect(Object.entries(block).length).not.to.equal(0); // empty object {}

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -68,6 +68,14 @@ describe('Testing the http API', () => {
     registerProposer: 0,
   };
 
+  function holdupQueue(txType, waitTillCount) {
+    while(logCounts[txType] < waitTillCount) {
+      console.log('in holdupQueue --', txType, logCounts[txType], waitTillCount);
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise(resolve => setTimeout(resolve, 3000));
+    }
+  }
+
   const waitForTxExecution = async (count, txType) => {
     while (count === logCounts[txType]) {
       console.log('in waitForTxExecution --', count, txType);
@@ -318,6 +326,9 @@ describe('Testing the http API', () => {
       depositTransactions.forEach(({ txDataToSign }) => expect(txDataToSign).to.be.a('string'));
 
       const receiptArrays = [];
+      txQueue.push(async () => {
+        await holdupQueue('deposit', logCounts.deposit + depositTransactions.length);
+      });
       for (let i = 0; i < depositTransactions.length; i++) {
         const count = logCounts.deposit;
         const { txDataToSign } = depositTransactions[i];

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -621,7 +621,7 @@ describe('Testing the http API', () => {
           .request(optimistUrl)
           .get(`/block/transaction-hash/${withdrawTransactionHash}`);
         ({ block, transactions, index } = res.body);
-      } while (block === null);
+      } while (block === null || block === undefined);
       // Need this while wait when running geth as it runs slower than ganache
       expect(block).not.to.be.undefined; // eslint-disable-line
       expect(Object.entries(block).length).not.to.equal(0); // empty object {}

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -90,6 +90,7 @@ describe('Testing the http API', () => {
     web3.eth.subscribe('logs', { address: shieldAddress }).on('data', log => {
       if (log.topics[0] === web3.eth.abi.encodeEventSignature('TransactionSubmitted()')) {
         logCounts.deposit += 1;
+        console.log('event log received', logCounts.deposit);
       }
     });
 

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -135,6 +135,7 @@ describe('Testing the http API', () => {
     connection.onmessage = async message => {
       const msg = JSON.parse(message.data);
       const { type, txDataToSign } = msg;
+      console.log('-- in on onmessage', type);
       try {
         if (type === 'block') {
           await blockSubmissionFunction(txDataToSign, privateKey, stateAddress, gas, BLOCK_STAKE);

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -70,7 +70,6 @@ describe('Testing the http API', () => {
 
   const holdupQueue = async (txType, waitTillCount) => {
     while (logCounts[txType] < waitTillCount) {
-      console.log('in holdupQueue --', txType, logCounts[txType], waitTillCount);
       // eslint-disable-next-line no-await-in-loop
       await new Promise(resolve => setTimeout(resolve, 3000));
     }
@@ -78,7 +77,6 @@ describe('Testing the http API', () => {
 
   const waitForTxExecution = async (count, txType) => {
     while (count === logCounts[txType]) {
-      console.log('in waitForTxExecution --', count, txType);
       // eslint-disable-next-line no-await-in-loop
       await new Promise(resolve => setTimeout(resolve, 3000));
     }
@@ -569,7 +567,6 @@ describe('Testing the http API', () => {
         ask: ask1,
       });
       transactions.push(res.body.transaction); // a new transaction
-      console.log(res.body.transaction);
       expect(res.body.txDataToSign).to.be.a('string');
       let count = logCounts.deposit;
       // now we need to sign the transaction and send it to the blockchain
@@ -623,7 +620,6 @@ describe('Testing the http API', () => {
     it('Should find the block containing the withdraw transaction', async function () {
       const withdrawTransactionHash = transactions[0].transactionHash;
       do {
-        console.log('in while loop');
         // eslint-disable-next-line no-await-in-loop
         await new Promise(resolve => setTimeout(resolve, 3000));
         // eslint-disable-next-line no-await-in-loop

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -68,13 +68,13 @@ describe('Testing the http API', () => {
     registerProposer: 0,
   };
 
-  function holdupQueue(txType, waitTillCount) {
-    while(logCounts[txType] < waitTillCount) {
+  const holdupQueue = async (txType, waitTillCount) => {
+    while (logCounts[txType] < waitTillCount) {
       console.log('in holdupQueue --', txType, logCounts[txType], waitTillCount);
       // eslint-disable-next-line no-await-in-loop
       await new Promise(resolve => setTimeout(resolve, 3000));
     }
-  }
+  };
 
   const waitForTxExecution = async (count, txType) => {
     while (count === logCounts[txType]) {

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -69,6 +69,7 @@ describe('Testing the http API', () => {
 
   const waitForTxExecution = async (count, txType) => {
     while (count === logCounts[txType]) {
+      console.log('in waitForTxExecution --', count, txType);
       // eslint-disable-next-line no-await-in-loop
       await new Promise(resolve => setTimeout(resolve, 3000));
     }
@@ -90,7 +91,7 @@ describe('Testing the http API', () => {
     web3.eth.subscribe('logs', { address: shieldAddress }).on('data', log => {
       if (log.topics[0] === web3.eth.abi.encodeEventSignature('TransactionSubmitted()')) {
         logCounts.deposit += 1;
-        console.log('event log received', logCounts.deposit);
+        console.log('event log deposit received', logCounts.deposit);
       }
     });
 
@@ -105,6 +106,7 @@ describe('Testing the http API', () => {
     web3.eth.subscribe('logs', { address: proposersAddress }).on('data', log => {
       if (log.topics[0] === web3.eth.abi.encodeEventSignature('NewCurrentProposer(address)')) {
         logCounts.registerProposer += 1;
+        console.log('event log registerProposer received', logCounts.registerProposer);
       }
     });
 

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -4,7 +4,6 @@ import chaiAsPromised from 'chai-as-promised';
 import Queue from 'queue';
 import WebSocket from 'ws';
 import { GN } from 'general-number';
-import Queue from 'queue';
 import {
   closeWeb3Connection,
   submitTransaction,

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -571,7 +571,7 @@ describe('Testing the http API', () => {
       transactions.push(res.body.transaction); // a new transaction
       console.log(res.body.transaction);
       expect(res.body.txDataToSign).to.be.a('string');
-      const count = logCounts.deposit;
+      let count = logCounts.deposit;
       // now we need to sign the transaction and send it to the blockchain
       const receipt = await submitTransaction(
         res.body.txDataToSign,
@@ -599,7 +599,7 @@ describe('Testing the http API', () => {
         await holdupQueue('deposit', logCounts.deposit + depositTransactions.length);
       });
       for (let i = 0; i < depositTransactions.length; i++) {
-        const count = logCounts.deposit;
+        count = logCounts.deposit;
         const { txDataToSign } = depositTransactions[i];
         // eslint-disable-next-line no-await-in-loop
         await submitTransaction(txDataToSign, privateKey, shieldAddress, gas, fee);

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -113,7 +113,6 @@ describe('Testing the http API', () => {
     web3.eth.subscribe('logs', { address: proposersAddress }).on('data', log => {
       if (log.topics[0] === web3.eth.abi.encodeEventSignature('NewCurrentProposer(address)')) {
         logCounts.registerProposer += 1;
-        console.log('event log registerProposer received', logCounts.registerProposer);
       }
     });
 

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -64,7 +64,7 @@ describe('Testing the http API', () => {
   let stateBalance = 0;
   const logCounts = {
     deposit: 0,
-    regsterProposer: 0,
+    registerProposer: 0,
   };
 
   const waitForTxExecution = async (count, txType) => {
@@ -104,7 +104,7 @@ describe('Testing the http API', () => {
       .address;
     web3.eth.subscribe('logs', { address: proposersAddress }).on('data', log => {
       if (log.topics[0] === web3.eth.abi.encodeEventSignature('NewCurrentProposer(address)')) {
-        logCounts.regsterProposer += 1;
+        logCounts.registerProposer += 1;
       }
     });
 
@@ -214,9 +214,9 @@ describe('Testing the http API', () => {
       const { txDataToSign } = res.body;
       expect(txDataToSign).to.be.a('string');
       const bond = 10;
-      const count = logCounts.regsterProposer;
+      const count = logCounts.registerProposer;
       await submitTransaction(txDataToSign, privateKey, proposersAddress, gas, bond);
-      await waitForTxExecution(count, 'regsterProposer');
+      await waitForTxExecution(count, 'registerProposer');
       stateBalance += bond;
     });
 
@@ -232,7 +232,7 @@ describe('Testing the http API', () => {
       const bond = 10;
       const gasCosts = 5000000000000000;
       const startBalance = await getBalance(myAddress);
-      const count = logCounts.regsterProposer;
+      const count = logCounts.registerProposer;
       // now we need to sign the transaction and send it to the blockchain
       const receipt = await submitTransaction(
         txDataToSign,
@@ -241,7 +241,7 @@ describe('Testing the http API', () => {
         gas,
         bond,
       );
-      await waitForTxExecution(count, 'regsterProposer');
+      await waitForTxExecution(count, 'registerProposer');
       const endBalance = await getBalance(myAddress);
       expect(receipt).to.have.property('transactionHash');
       expect(receipt).to.have.property('blockHash');

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -68,7 +68,7 @@ describe('Testing the http API', () => {
     registerProposer: 0,
   };
 
-  const holdupQueue = async (txType, waitTillCount) => {
+  const holdupTxQueue = async (txType, waitTillCount) => {
     while (logCounts[txType] < waitTillCount) {
       // eslint-disable-next-line no-await-in-loop
       await new Promise(resolve => setTimeout(resolve, 3000));
@@ -98,7 +98,6 @@ describe('Testing the http API', () => {
     web3.eth.subscribe('logs', { address: shieldAddress }).on('data', log => {
       if (log.topics[0] === web3.eth.abi.encodeEventSignature('TransactionSubmitted()')) {
         logCounts.deposit += 1;
-        console.log('event log deposit received', logCounts.deposit);
       }
     });
 
@@ -144,7 +143,6 @@ describe('Testing the http API', () => {
       txQueue.push(async () => {
         const msg = JSON.parse(message.data);
         const { type, txDataToSign } = msg;
-        console.log('-- in on onmessage', type);
         try {
           if (type === 'block') {
             await blockSubmissionFunction(txDataToSign, privateKey, stateAddress, gas, BLOCK_STAKE);
@@ -324,7 +322,7 @@ describe('Testing the http API', () => {
 
       const receiptArrays = [];
       txQueue.push(async () => {
-        await holdupQueue('deposit', logCounts.deposit + depositTransactions.length);
+        await holdupTxQueue('deposit', logCounts.deposit + depositTransactions.length);
       });
       for (let i = 0; i < depositTransactions.length; i++) {
         const count = logCounts.deposit;
@@ -592,7 +590,7 @@ describe('Testing the http API', () => {
       ).map(dRes => dRes.body);
 
       txQueue.push(async () => {
-        await holdupQueue('deposit', logCounts.deposit + depositTransactions.length);
+        await holdupTxQueue('deposit', logCounts.deposit + depositTransactions.length);
       });
       for (let i = 0; i < depositTransactions.length; i++) {
         count = logCounts.deposit;

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -97,7 +97,6 @@ describe('Testing the challenge http API', () => {
     web3.eth.subscribe('logs', { address: shieldAddress }).on('data', log => {
       if (log.topics[0] === web3.eth.abi.encodeEventSignature('TransactionSubmitted()')) {
         logCounts.deposit += 1;
-        console.log('event log deposit received', logCounts.deposit);
       }
     });
 
@@ -158,7 +157,6 @@ describe('Testing the challenge http API', () => {
         const msg = JSON.parse(message.data);
         const { type } = msg;
         let { txDataToSign } = msg;
-        console.log('-- in on onmessage', type, counter);
         try {
           if (type === 'block') {
             const { block, transactions } = msg;
@@ -498,7 +496,6 @@ describe('Testing the challenge http API', () => {
             ask: ask1,
             fee,
           });
-        console.log(res.body, res.error);
         const { txDataToSign } = res.body;
         expect(txDataToSign).to.be.a('string');
         await submitTransaction(txDataToSign, privateKey, shieldAddress, gas);

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -478,6 +478,7 @@ describe('Testing the challenge http API', () => {
             ask: ask1,
             fee,
           });
+        console.log(res);
         const { txDataToSign } = res.body;
         expect(txDataToSign).to.be.a('string');
         await submitTransaction(txDataToSign, privateKey, shieldAddress, gas);

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -66,7 +66,7 @@ describe('Testing the challenge http API', () => {
     deposit: 0,
   };
 
-  const holdupQueue = async (txType, waitTillCount) => {
+  const holdupTxQueue = async (txType, waitTillCount) => {
     while (logCounts[txType] < waitTillCount) {
       // eslint-disable-next-line no-await-in-loop
       await new Promise(resolve => setTimeout(resolve, 3000));
@@ -300,7 +300,7 @@ describe('Testing the challenge http API', () => {
 
       const receiptArrays = [];
       txQueue.push(async () => {
-        await holdupQueue('deposit', logCounts.deposit + depositTransactions.length);
+        await holdupTxQueue('deposit', logCounts.deposit + depositTransactions.length);
       });
       for (let i = 0; i < depositTransactions.length; i++) {
         const { txDataToSign } = depositTransactions[i];

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -62,6 +62,16 @@ describe('Testing the challenge http API', () => {
   let topicsBlockHashDuplicateNullifier;
   let topicsBlockHashIncorrectLeafCount;
   let web3;
+  const logCounts = {
+    deposit: 0,
+  };
+
+  const holdupQueue = async (txType, waitTillCount) => {
+    while (logCounts[txType] < waitTillCount) {
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise(resolve => setTimeout(resolve, 3000));
+    }
+  };
 
   before(async () => {
     web3 = await connectWeb3(BLOCKCHAIN_URL);
@@ -84,6 +94,12 @@ describe('Testing the challenge http API', () => {
 
     res = await chai.request(url).get('/contract-address/Shield');
     shieldAddress = res.body.address;
+    web3.eth.subscribe('logs', { address: shieldAddress }).on('data', log => {
+      if (log.topics[0] === web3.eth.abi.encodeEventSignature('TransactionSubmitted()')) {
+        logCounts.deposit += 1;
+        console.log('event log deposit received', logCounts.deposit);
+      }
+    });
 
     res = await chai.request(url).get('/contract-address/Challenges');
     challengeAddress = res.body.address;
@@ -283,6 +299,9 @@ describe('Testing the challenge http API', () => {
       depositTransactions.forEach(({ txDataToSign }) => expect(txDataToSign).to.be.a('string'));
 
       const receiptArrays = [];
+      txQueue.push(async () => {
+        await holdupQueue('deposit', logCounts.deposit + depositTransactions.length);
+      });
       for (let i = 0; i < depositTransactions.length; i++) {
         const { txDataToSign } = depositTransactions[i];
         receiptArrays.push(

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -142,6 +142,7 @@ describe('Testing the challenge http API', () => {
         const msg = JSON.parse(message.data);
         const { type } = msg;
         let { txDataToSign } = msg;
+        console.log('-- in on onmessage', type, counter);
         try {
           if (type === 'block') {
             const { block, transactions } = msg;
@@ -240,7 +241,7 @@ describe('Testing the challenge http API', () => {
             // console.log('tx hash of challenge block is', txReceipt.transactionHash);
           } else throw new Error(`Unhandled transaction type: ${type}`);
         } catch (err) {
-          console.error(`neg-http.mjs for ${type} ${counter} onmessage: ${err}`);
+          console.error(`neg-http.mjs onmessage error: ${err}`);
         }
       });
     };

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -240,7 +240,7 @@ describe('Testing the challenge http API', () => {
             // console.log('tx hash of challenge block is', txReceipt.transactionHash);
           } else throw new Error(`Unhandled transaction type: ${type}`);
         } catch (err) {
-          console.log(err);
+          console.error(`neg-http.mjs for ${type} ${counter} onmessage: ${err}`);
         }
       });
     };
@@ -582,11 +582,11 @@ describe('Testing the challenge http API', () => {
       connection.close();
     } else {
       // TODO work out what's still running and close it properly
-      txQueue.end();
       txQueue.on('end', () => {
         closeWeb3Connection();
         connection.close();
       });
+      txQueue.end();
     }
   });
 });

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -478,7 +478,7 @@ describe('Testing the challenge http API', () => {
             ask: ask1,
             fee,
           });
-        console.log(res);
+        console.log(res.body, res.error);
         const { txDataToSign } = res.body;
         expect(txDataToSign).to.be.a('string');
         await submitTransaction(txDataToSign, privateKey, shieldAddress, gas);

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -79,7 +79,7 @@ export async function submitTransaction(
 ) {
   while (isSubmitTxLocked) {
     // eslint-disable-next-line no-await-in-loop
-    await new Promise(resolve => setTimeout(resolve, 3000));
+    await new Promise(resolve => setTimeout(resolve, 1000));
   }
   isSubmitTxLocked = true;
   let gas = gasCount;

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -97,7 +97,6 @@ export async function submitTransaction(
       // get gaslimt from latest block as gaslimt may vary
       gas = (await web3.eth.getBlock('latest')).gasLimit;
       const blockGasPrice = Number(await web3.eth.getGasPrice());
-      console.log('blockGasPrice ', blockGasPrice, typeof blockGasPrice);
       if (blockGasPrice > gasPrice) gasPrice = blockGasPrice;
     }
     const tx = {
@@ -112,7 +111,6 @@ export async function submitTransaction(
     const signed = await web3.eth.accounts.signTransaction(tx, privateKey);
     nonce++;
     nonceDict[privateKey] = nonce;
-    console.log('nonceDict[privateKey] after increment', nonceDict[privateKey]);
     receipt = await web3.eth.sendSignedTransaction(signed.rawTransaction);
   } finally {
     console.log('in finally block');

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -99,9 +99,11 @@ export async function submitTransaction(
     gasPrice,
     nonce,
   };
+  console.log('tx.nonce - ', tx.nonce);
   const signed = await web3.eth.accounts.signTransaction(tx, privateKey);
   nonce++;
   nonceDict[privateKey] = nonce;
+  console.log('nonceDict[privateKey] after increment', nonceDict[privateKey]);
   return web3.eth.sendSignedTransaction(signed.rawTransaction);
 }
 

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -107,7 +107,7 @@ export async function submitTransaction(
       gasPrice,
       nonce,
     };
-    console.log('tx.nonce - ', tx.nonce);
+    console.log('tx.nonce gas gasPrice - ', tx.nonce, gas, gasPrice);
     const signed = await web3.eth.accounts.signTransaction(tx, privateKey);
     nonce++;
     nonceDict[privateKey] = nonce;

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -97,6 +97,7 @@ export async function submitTransaction(
       // get gaslimt from latest block as gaslimt may vary
       gas = (await web3.eth.getBlock('latest')).gasLimit;
       const blockGasPrice = await web3.eth.getGasPrice();
+      console.log('blockGasPrice ', blockGasPrice);
       if (blockGasPrice > gasPrice) gasPrice = blockGasPrice;
     }
     const tx = {

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -97,7 +97,7 @@ export async function submitTransaction(
       // get gaslimt from latest block as gaslimt may vary
       gas = (await web3.eth.getBlock('latest')).gasLimit;
       const blockGasPrice = await web3.eth.getGasPrice();
-      console.log('blockGasPrice ', blockGasPrice);
+      console.log('blockGasPrice ', blockGasPrice, typeof blockGasPrice);
       if (blockGasPrice > gasPrice) gasPrice = blockGasPrice;
     }
     const tx = {

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -84,6 +84,7 @@ export async function submitTransaction(
   isSubmitTxLocked = true;
   let gas = gasCount;
   let gasPrice = 10000000000;
+  let receipt;
   let nonce = nonceDict[privateKey];
   // if the nonce hasn't been set, then use the transaction count
   try {
@@ -110,10 +111,11 @@ export async function submitTransaction(
     nonce++;
     nonceDict[privateKey] = nonce;
     console.log('nonceDict[privateKey] after increment', nonceDict[privateKey]);
-    await web3.eth.sendSignedTransaction(signed.rawTransaction);
+    receipt = await web3.eth.sendSignedTransaction(signed.rawTransaction);
   } finally {
     isSubmitTxLocked = false;
   }
+  return receipt;
 }
 
 // This only works with Ganache but it can move block time forwards

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -78,7 +78,6 @@ export async function submitTransaction(
   value = 0,
 ) {
   while (isSubmitTxLocked) {
-    console.log('in isSubmitTxLocked while loop', isSubmitTxLocked);
     // eslint-disable-next-line no-await-in-loop
     await new Promise(resolve => setTimeout(resolve, 1000));
   }
@@ -107,13 +106,11 @@ export async function submitTransaction(
       gasPrice,
       nonce,
     };
-    console.log('tx.nonce gas gasPrice - ', tx.nonce, gas, gasPrice);
     const signed = await web3.eth.accounts.signTransaction(tx, privateKey);
     nonce++;
     nonceDict[privateKey] = nonce;
     receipt = await web3.eth.sendSignedTransaction(signed.rawTransaction);
   } finally {
-    console.log('in finally block');
     isSubmitTxLocked = false;
   }
   return receipt;

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -106,11 +106,9 @@ export async function submitTransaction(
       gasPrice,
       nonce,
     };
-    console.log('tx.nonce - ', tx.nonce);
     const signed = await web3.eth.accounts.signTransaction(tx, privateKey);
     nonce++;
     nonceDict[privateKey] = nonce;
-    console.log('nonceDict[privateKey] after increment', nonceDict[privateKey]);
     receipt = await web3.eth.sendSignedTransaction(signed.rawTransaction);
   } finally {
     isSubmitTxLocked = false;

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -78,6 +78,7 @@ export async function submitTransaction(
   value = 0,
 ) {
   while (isSubmitTxLocked) {
+    console.log('in isSubmitTxLocked while loop', isSubmitTxLocked);
     // eslint-disable-next-line no-await-in-loop
     await new Promise(resolve => setTimeout(resolve, 1000));
   }
@@ -106,11 +107,14 @@ export async function submitTransaction(
       gasPrice,
       nonce,
     };
+    console.log('tx.nonce - ', tx.nonce);
     const signed = await web3.eth.accounts.signTransaction(tx, privateKey);
     nonce++;
     nonceDict[privateKey] = nonce;
+    console.log('nonceDict[privateKey] after increment', nonceDict[privateKey]);
     receipt = await web3.eth.sendSignedTransaction(signed.rawTransaction);
   } finally {
+    console.log('in finally block');
     isSubmitTxLocked = false;
   }
   return receipt;

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -96,7 +96,7 @@ export async function submitTransaction(
     if (USE_INFURA) {
       // get gaslimt from latest block as gaslimt may vary
       gas = (await web3.eth.getBlock('latest')).gasLimit;
-      const blockGasPrice = await web3.eth.getGasPrice();
+      const blockGasPrice = Number(await web3.eth.getGasPrice());
       console.log('blockGasPrice ', blockGasPrice, typeof blockGasPrice);
       if (blockGasPrice > gasPrice) gasPrice = blockGasPrice;
     }


### PR DESCRIPTION
this fixes #203 
and add github action workflow to deploy and run integration test (env - infura ropsten)

briefing changes and new code added in this PR.
1. added while loop to fetch `getTreeHistoryByCurrentLeafCount()` from `timber` in `optimist`
2. implemented queue with ({ concurrency: 1 }) for transaction coming from optimist via websocket
3. two new function implemented in `http.mjs`, which are `waitForTxExecution()` and `holdupTxQueue()`
     waitForTxExecution() :- used in registerProposer and in for loop of deposits,
                                             This function wait/listen for log of event (for deposit `TransactionSubmitted` and for registerProposer its `NewCurrentProposer`)
                                             It fix an error (appears sometimes )`transaction has not mined in 50 blocks` even though nonce to tx are correct (as we have for loop with awaits)
                                             
     holdupTxQueue() :- this function is also implemented in `neg-http.mjs`
                                       It push a job in txQueue so that submitTransaction from web socket onMessage for block creation(optimist) get queue up, this Job will only be complete once all the deposit transaction executed and their respective event log been received by test suits (http.mjs and neg-http.mjs)
                                       
 _Things I have noticed - integration test behaviour with infura ropsten network_
 1. nonce (which is `getTransactionCount` of an EOA) does not increase right away after submitTransaction (sendSignedTransaction) success (may this because submitTransaction mined the block in miner node and infura handle all get calls in a normal node - get call include `getTransactionCount` ) so function `waitForTxExecution` wait till new block arrives and tx get execute with event emit. 
 2. In integration test (both in http.mjs and neg-http.mjs) test suits fails if block submitTransaction get execute before all deposit transaction in for loop is complete ( since we have `txPerBlock = 2` in test suits it make sense optimist send message/tx of type block once 2 deposit is complete so it can be submitted, but submitting it fails unless until all deposit from transaction is execute and event log is received - which is exactly new function  `holdupTxQueue()` function do