### PR TITLE
Add chain-reorg capability for Timber class

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: admin
       MONGO_INITDB_ROOT_PASSWORD: admin
-      LOG_LEVEL: debug
+      LOG_LEVEL: error
       BLOCKCHAIN_WS_HOST: blockchain1
       BLOCKCHAIN_PORT: 8546
       ZOKRATES_WORKER_HOST: worker
@@ -235,7 +235,7 @@ services:
       MONGO_PORT: 27017
       MONGO_NAME: merkle_tree
       HASH_TYPE: mimc
-      LOG_LEVEL: info
+      LOG_LEVEL: error
       AUTOSTART: enabled
 
   #The database storing the merkle tree
@@ -345,7 +345,7 @@ services:
       BLOCKCHAIN_WS_HOST: blockchain1
       BLOCKCHAIN_PORT: 8546
       HASH_TYPE: mimc
-      LOG_LEVEL: debug
+      LOG_LEVEL: error
       IS_CHALLENGER: 'true'
       TRANSACTIONS_PER_BLOCK: ${TRANSACTIONS_PER_BLOCK:-2}
       TIMBER_HOST: timber2

--- a/nightfall-optimist/src/event-handlers/chain-reorg.mjs
+++ b/nightfall-optimist/src/event-handlers/chain-reorg.mjs
@@ -62,12 +62,21 @@ import {
   clearBlockNumberL1ForBlock,
   clearBlockNumberL1ForTransaction,
   isRegisteredProposerAddressMine,
+  getBlockByTransactionHashL1,
+  deleteTreeByBlockNumberL2,
 } from '../services/database.mjs';
 import { waitForContract } from './subscribe.mjs';
 
 const { STATE_CONTRACT_NAME } = config;
 
 export async function removeBlockProposedEventHandler(eventObject) {
+  // we need to remove the state associated with this event from the Timber class
+  // so find out which L2 block has been removed by this event removal.
+  const block = await getBlockByTransactionHashL1(eventObject.transactionHash);
+  // then we delete the Timber record associated with this block
+  await deleteTreeByBlockNumberL2(block.blockNumberL2);
+  // now we can clear the L1 blocknumber to indicate that the L2 block is no longer
+  // on chain.
   return clearBlockNumberL1ForBlock(eventObject.transactionHash);
 }
 

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -120,6 +120,13 @@ export async function getBlockByTransactionHash(transactionHash) {
   return db.collection(SUBMITTED_BLOCKS_COLLECTION).find(query).toArray();
 }
 
+export async function getBlockByTransactionHashL1(transactionHashL1) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  const query = { transactionHashL1 };
+  return db.collection(SUBMITTED_BLOCKS_COLLECTION).findOne(query);
+}
+
 export async function numberOfBlockWithTransactionHash(transactionHash) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);

--- a/test/chain-reorg.mjs
+++ b/test/chain-reorg.mjs
@@ -85,87 +85,7 @@ describe('Testing the http API', () => {
     }
     return receiptArrays;
   };
-  /*
-  const createDepositTransactions = async numDeposits => {
-    // We create enough transactions to fill numDeposits blocks full of deposits.
-    const depositTransactions = (
-      await Promise.all(
-        Array.from({ length: txPerBlock * numWithdraws }, () =>
-          chai.request(url).post('/withdraw').send({
-            ercAddress,
-            tokenId,
-            tokenType,
-            value,
-            recipientAddress,
-            nsk: nsk1,
-            ask: ask1,
-          }),
-        ),
-      )
-    ).map(res => res.body.txDataToSign);
-    depositTransactions.forEach(txDataToSign => expect(txDataToSign).to.be.a('string'));
-    return depositTransactions;
-  };
 
-  const submitDepositTransactions = async depositTransactions => {
-    const receiptArrays = [];
-    for (let i = 0; i < depositTransactions.length; i++) {
-      const txDataToSign = depositTransactions[i];
-      receiptArrays.push(
-        // eslint-disable-next-line no-await-in-loop
-        await submitTransaction(txDataToSign, privateKey, shieldAddress, gas, fee),
-        // we need to await here as we need transactions to be submitted sequentially or we run into nonce issues.
-      );
-    }
-    receiptArrays.forEach(receipt => {
-      expect(receipt).to.have.property('transactionHash');
-      expect(receipt).to.have.property('blockHash');
-    });
-    // Wait until we see the right number of blocks appear
-    while (eventLogs.length !== numDeposits) {
-      // eslint-disable-next-line no-await-in-loop
-      await new Promise(resolve => setTimeout(resolve, 3000));
-    }
-    // Now we can empty the event queue
-    for (let i = 0; i < numDeposits; i++) {
-      eventLogs.shift();
-    }
-    return receiptArrays;
-  };
-
-  const doSingleTransferTwice = async () => {
-    let res = await chai
-      .request(url)
-      .post('/transfer')
-      .send({
-        ercAddress,
-        tokenId,
-        recipientData: {
-          values: [value],
-          recipientPkds: [pkd1],
-        },
-        nsk: nsk1,
-        ask: ask1,
-        fee,
-      });
-    if (res.status !== 200) throw new Error(res.text);
-    res = await chai
-      .request(url)
-      .post('/transfer')
-      .send({
-        ercAddress,
-        tokenId,
-        recipientData: {
-          values: [value],
-          recipientPkds: [pkd1],
-        },
-        nsk: nsk1,
-        ask: ask1,
-        fee,
-      });
-    if (res.status !== 200) throw new Error(res.text);
-  };
-*/
   before(async () => {
     web3 = await connectWeb3();
 
@@ -284,36 +204,6 @@ describe('Testing the http API', () => {
     const numDeposits = 1;
     let blocks1;
     let receipts;
-    /*
-    it('should create a chain fork with both branches containing NF_3 transactions', async () => {
-      // at this point we have no suitable commitments. Let's hold half of the nodes
-      // and add some commitments to the un-held half
-      console.log(
-        '     *Nightfall_3 is connected to node set 1, nothing is connected to node set 2*',
-      );
-      console.log(
-        '     Pausing node set 2 and waiting one minute for all L1 transactions to complete',
-      );
-      await pauseBlockchain(2); // hold one half of the nodes
-      await new Promise(resolve => setTimeout(resolve, 60000));
-      console.log('     Creating one block of deposit transactions with node set 1');
-      receipts = await doDeposits(numDeposits); // add transactions to the other half
-      console.log('     Block created');
-      // test the receipts are good.
-      const recs = await Promise.all(
-        receipts.map(receipt => web3.eth.getTransactionReceipt(receipt.transactionHash)),
-      );
-      expect(recs).to.not.include(null);
-      blocks1 = await web3.eth.getBlockNumber();
-      console.log(
-        '     BlockNumber for node set 1 is:',
-        blocks1,
-        '. Pausing node set 1 and unpausing node set 2',
-      );
-      await pauseBlockchain(1);
-      await unpauseBlockchain(2);
-    });
-    */
     it('should create a chain fork containing transactions', async () => {
       // at this point we have no suitable commitments. Let's hold half of the nodes
       // and add some commitments to the un-held half
@@ -373,7 +263,7 @@ describe('Testing the http API', () => {
       // a chain reorg should now occur - wait a minute for it to happen
       console.log('     Blocknumber for node set 2 is:', await web3b.eth.getBlockNumber());
       console.log('     BlockNumber for node set 1 is:', await web3.eth.getBlockNumber());
-      console.log('     Waiting 10 s to check that the reorg occurs');
+      console.log('     Waiting 1 minute to check that the reorg occurs');
       await new Promise(resolve => setTimeout(resolve, 60000));
       console.log('     Blocknumber for node set 2 is:', await web3b.eth.getBlockNumber());
       console.log('     BlockNumber for node set 1 is:', await web3.eth.getBlockNumber());


### PR DESCRIPTION
fixes #246 

The new Timber class in Optimist has created a new collection of Merkle tree data (`TIMBER_COLLECTION`).  This needs to have its content modified to take into account chain reorganisations, specifically, removal of `BlockProposed` events by the chain reorg needs to remove all tree data in the collection corresponding to the proposed L2 block and any subsequent L2 blocks. This is achieved by some extra code in the event removal handler, a much simpler solution than is required for a separate Timber microservice.

In addition, the log level for the second set of nightfall containers has been set to `error`.  This is to prevent duplication of log output, which makes the logs hard to read. Now, except when an error occurs, only the first set of containers writes to the log.

To test this PR:

 - run up a full local Geth blockchain (`./geth-standalone -s`) and wait untill DAG generation is complete (check the logs with `./geth-standalone -l`).
 - In another terminal, run up nightfall with a configuration to use the Geth blockchain, which exposes ports on `localhost` - `./start-nightfall -l -s`.
 - In another terminal run the test `npm run test-chain-reorg`.  You should see two `TransactionSubmitted` and then one `BlockProposed` event removed as the chain reorg occurs.  These will then be re-mined by the Geth miners and re-added to the L2 state.
 - You can shut down the Geth blockchain with `./geth-standalone -d`.
 