### PR TITLE
fix: previous proposer check before enqueue

### DIFF
--- a/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
+++ b/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
@@ -43,7 +43,7 @@ async function newCurrentProposerEventHandler(data, args) {
     // are we the next proposer?
     proposer.isMe = !!(await isRegisteredProposerAddressMine(currentProposer));
     // trigger enqueue operation of blockassembler if you are currentproposer
-    if (proposer.isMe) {
+    if (proposer.isMe && !weWereLastProposer) {
       logger.info(`triggering enqueue operation of blockassembler`);
       await eventQueueManager(conditionalMakeBlock, 0, proposer);
     }

--- a/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
+++ b/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
@@ -43,7 +43,7 @@ async function newCurrentProposerEventHandler(data, args) {
     // are we the next proposer?
     proposer.isMe = !!(await isRegisteredProposerAddressMine(currentProposer));
     // trigger enqueue operation of blockassembler if you are currentproposer
-    if (proposer.isMe ) {
+    if (proposer.isMe) {
       logger.info(`triggering enqueue operation of blockassembler`);
       await eventQueueManager(conditionalMakeBlock, 0, proposer);
     }

--- a/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
+++ b/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
@@ -43,7 +43,7 @@ async function newCurrentProposerEventHandler(data, args) {
     // are we the next proposer?
     proposer.isMe = !!(await isRegisteredProposerAddressMine(currentProposer));
     // trigger enqueue operation of blockassembler if you are currentproposer
-    if (proposer.isMe && !weWereLastProposer) {
+    if (proposer.isMe ) {
       logger.info(`triggering enqueue operation of blockassembler`);
       await eventQueueManager(conditionalMakeBlock, 0, proposer);
     }

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -11,7 +11,7 @@ import {
   getMostProfitableTransactions,
   numberOfUnprocessedTransactions,
 } from './database.mjs';
-import { queues, eventQueueManager } from './event-queue.mjs';
+import { eventQueueManager } from './event-queue.mjs';
 import Block from '../classes/block.mjs';
 import { Transaction } from '../classes/index.mjs';
 import { waitForContract } from '../event-handlers/subscribe.mjs';

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -47,10 +47,7 @@ export async function conditionalMakeBlock(proposer) {
   // transaction. If not, we must wait until either we have enough (hooray)
   // or we're no-longer the proposer (boo).
   if (proposer.isMe) {
-    if (
-      (await numberOfUnprocessedTransactions()) >= TRANSACTIONS_PER_BLOCK &&
-      queues[0].length === 0
-    ) {
+    if ((await numberOfUnprocessedTransactions()) >= TRANSACTIONS_PER_BLOCK) {
       const { block, transactions } = await makeBlock(proposer.address);
       logger.info(`Block Assembler - New Block created, ${JSON.stringify(block, null, 2)}`);
       // propose this block to the Shield contract here
@@ -76,7 +73,7 @@ export async function conditionalMakeBlock(proposer) {
       // blocks with them
       await removeTransactionsFromMemPool(block);
       await new Promise(resolve => setTimeout(resolve, 1000));
-      await eventQueueManager(conditionalMakeBlock, 0, proposer);
+      eventQueueManager(conditionalMakeBlock, 0, proposer);
       // TODO is await needed?
     } else {
       await eventQueueManager(conditionalMakeBlock, 0, proposer);

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -63,7 +63,7 @@ export async function conditionalMakeBlock(proposer) {
         )
         .encodeABI();
       if (ws)
-        ws.send(
+        await ws.send(
           JSON.stringify({
             type: 'block',
             txDataToSign: unsignedProposeBlockTransaction,

--- a/nightfall-optimist/src/services/event-queue.mjs
+++ b/nightfall-optimist/src/services/event-queue.mjs
@@ -45,8 +45,8 @@ function nextHigherPriorityQueueHasEmptied(priority) {
 
 export async function eventQueueManager(callback, priority, args) {
   queues[priority].push(async () => {
-    //await nextHigherPriorityQueueHasEmptied(priority); 
-    //prevent conditionalmakeblock from running until fastQueue is emptied
+    // await nextHigherPriorityQueueHasEmptied(priority);
+    // prevent conditionalmakeblock from running until fastQueue is emptied
     await callback(args);
   });
 }
@@ -78,7 +78,7 @@ export async function queueManager(eventObject, eventArgs) {
   } else {
     logger.info(`Queueing event ${eventObject.event}`);
     queues[priority].push(async () => {
-      //await nextHigherPriorityQueueHasEmptied(priority); // prevent eventHandlers running until the higher priority queue has emptied
+      // await nextHigherPriorityQueueHasEmptied(priority); // prevent eventHandlers running until the higher priority queue has emptied
       eventHandlers[eventObject.event](eventObject, args);
     });
   }

--- a/nightfall-optimist/src/services/event-queue.mjs
+++ b/nightfall-optimist/src/services/event-queue.mjs
@@ -45,7 +45,8 @@ function nextHigherPriorityQueueHasEmptied(priority) {
 
 export async function eventQueueManager(callback, priority, args) {
   queues[priority].push(async () => {
-    //await nextHigherPriorityQueueHasEmptied(priority); // prevent conditionalmakeblock from running until fastQueue is emptied
+    //await nextHigherPriorityQueueHasEmptied(priority); 
+    //prevent conditionalmakeblock from running until fastQueue is emptied
     await callback(args);
   });
 }

--- a/nightfall-optimist/src/services/event-queue.mjs
+++ b/nightfall-optimist/src/services/event-queue.mjs
@@ -24,7 +24,7 @@ import logger from 'common-files/utils/logger.mjs';
 const { MAX_QUEUE } = config;
 const fastQueue = new Queue({ autostart: true, concurrency: 1 });
 const slowQueue = new Queue({ autostart: true, concurrency: 1 });
-export const queues = [fastQueue, slowQueue];
+const queues = [fastQueue, slowQueue];
 
 /**
 This function will return a promise that resolves to true when the next highest

--- a/nightfall-optimist/src/services/event-queue.mjs
+++ b/nightfall-optimist/src/services/event-queue.mjs
@@ -45,8 +45,8 @@ function nextHigherPriorityQueueHasEmptied(priority) {
 
 export async function eventQueueManager(callback, priority, args) {
   queues[priority].push(async () => {
-    await nextHigherPriorityQueueHasEmptied(priority); // prevent conditionalmakeblock from running until fastQueue is emptied
-    callback(args);
+    //await nextHigherPriorityQueueHasEmptied(priority); // prevent conditionalmakeblock from running until fastQueue is emptied
+    await callback(args);
   });
 }
 
@@ -77,7 +77,7 @@ export async function queueManager(eventObject, eventArgs) {
   } else {
     logger.info(`Queueing event ${eventObject.event}`);
     queues[priority].push(async () => {
-      await nextHigherPriorityQueueHasEmptied(priority); // prevent eventHandlers running until the higher priority queue has emptied
+      //await nextHigherPriorityQueueHasEmptied(priority); // prevent eventHandlers running until the higher priority queue has emptied
       eventHandlers[eventObject.event](eventObject, args);
     });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2053,9 +2053,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001228",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+      "version": "1.0.30001271",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
+      "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
       "dev": true
     },
     "caseless": {


### PR DESCRIPTION
This fixes #227 

Two instances of `blockassembler`  was triggered when the proposer before and after rollback is the same. The fix is to not enqueue `blockassembler` from `newCurrentProposerEventHandler` in this scenario.