### PR TITLE
Enqueue Block Assembler

### DIFF
--- a/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
+++ b/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
@@ -43,7 +43,7 @@ async function newCurrentProposerEventHandler(data, args) {
     // are we the next proposer?
     proposer.isMe = !!(await isRegisteredProposerAddressMine(currentProposer));
     // trigger enqueue operation of blockassembler if you are currentproposer
-    if (proposer.isMe) {
+    if (proposer.isMe && !weWereLastProposer) {
       logger.info(`triggering enqueue operation of blockassembler`);
       await eventQueueManager(conditionalMakeBlock, 0, proposer);
     }

--- a/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
+++ b/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
@@ -5,8 +5,6 @@ import {
   isRegisteredProposerAddressMine,
   addTransactionsToMemPoolFromBlockNumberL2,
 } from '../services/database.mjs';
-import { conditionalMakeBlock } from '../services/block-assembler.mjs';
-import { eventQueueManager } from '../services/event-queue.mjs';
 
 const { STATE_CONTRACT_NAME } = config;
 
@@ -42,11 +40,6 @@ async function newCurrentProposerEventHandler(data, args) {
     // !! converts this to a "is not null" check - i.e. false if is null
     // are we the next proposer?
     proposer.isMe = !!(await isRegisteredProposerAddressMine(currentProposer));
-    // trigger enqueue operation of blockassembler if you are currentproposer
-    if (proposer.isMe) {
-      logger.info(`triggering enqueue operation of blockassembler`);
-      await eventQueueManager(conditionalMakeBlock, 0, proposer);
-    }
   } catch (err) {
     // handle errors
     logger.error(err);

--- a/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
+++ b/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
@@ -43,7 +43,7 @@ async function newCurrentProposerEventHandler(data, args) {
     // are we the next proposer?
     proposer.isMe = !!(await isRegisteredProposerAddressMine(currentProposer));
     // trigger enqueue operation of blockassembler if you are currentproposer
-    if (proposer.isMe ) {
+    if (proposer.isMe) {
       logger.info(`triggering enqueue operation of blockassembler`);
       await eventQueueManager(conditionalMakeBlock, 0, proposer);
     }

--- a/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
+++ b/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
@@ -43,7 +43,7 @@ async function newCurrentProposerEventHandler(data, args) {
     // are we the next proposer?
     proposer.isMe = !!(await isRegisteredProposerAddressMine(currentProposer));
     // trigger enqueue operation of blockassembler if you are currentproposer
-    if (proposer.isMe && !weWereLastProposer) {
+    if (proposer.isMe ) {
       logger.info(`triggering enqueue operation of blockassembler`);
       await eventQueueManager(conditionalMakeBlock, 0, proposer);
     }

--- a/nightfall-optimist/src/index.mjs
+++ b/nightfall-optimist/src/index.mjs
@@ -8,10 +8,13 @@ import {
   eventHandlers,
 } from './event-handlers/index.mjs';
 import Proposer from './classes/proposer.mjs';
-import { setBlockAssembledWebSocketConnection } from './services/block-assembler.mjs';
+import {
+  setBlockAssembledWebSocketConnection,
+  conditionalMakeBlock,
+} from './services/block-assembler.mjs';
 import { setChallengeWebSocketConnection } from './services/challenges.mjs';
 import initialBlockSync from './services/state-sync.mjs';
-import { queueManager } from './services/event-queue.mjs';
+import { queueManager, queues, enqueueEvent } from './services/event-queue.mjs';
 import { setInstantWithdrawalWebSocketConnection } from './services/instant-withdrawal.mjs';
 
 const main = async () => {
@@ -23,8 +26,14 @@ const main = async () => {
     await subscribeToInstantWithDrawalWebSocketConnection(setInstantWithdrawalWebSocketConnection);
     // try to sync any missing blockchain state
     // only then start making blocks and listening to new proposers
-    initialBlockSync(proposer).then(() => {
-      startEventQueue(queueManager, eventHandlers, proposer);
+    initialBlockSync(proposer).then(async () => {
+      await startEventQueue(queueManager, eventHandlers, proposer);
+      queues[0].on('end', () => {
+        // We do the proposer isMe check here to fail fast instead of re-enqueing.
+        if (proposer.isMe) return enqueueEvent(conditionalMakeBlock, 0, proposer);
+        // eslint-disable-next-line no-void, no-useless-return
+        return void false; // This is here to satisfy consistent return rules, we do nothing.
+      });
     });
     app.listen(80);
   } catch (err) {

--- a/nightfall-optimist/src/index.mjs
+++ b/nightfall-optimist/src/index.mjs
@@ -30,6 +30,7 @@ const main = async () => {
       await startEventQueue(queueManager, eventHandlers, proposer);
       queues[0].on('end', () => {
         // We do the proposer isMe check here to fail fast instead of re-enqueing.
+        logger.info('Queue has emptied. Queueing block assembler.');
         if (proposer.isMe) return enqueueEvent(conditionalMakeBlock, 0, proposer);
         // eslint-disable-next-line no-void, no-useless-return
         return void false; // This is here to satisfy consistent return rules, we do nothing.

--- a/nightfall-optimist/src/routes/block.mjs
+++ b/nightfall-optimist/src/routes/block.mjs
@@ -10,7 +10,7 @@ import {
   getBlockByRoot,
   getTransactionsByTransactionHashes,
 } from '../services/database.mjs';
-import { waitUntilCurrentQueueIsProcessed } from '../services/event-queue.mjs';
+import { flushQueue } from '../services/event-queue.mjs';
 
 const router = express.Router();
 
@@ -60,7 +60,7 @@ router.get('/root/:root', async (req, res, next) => {
     // yet.  Let's wait for the current queue to empty and try again.
     if (block === null) {
       logger.debug('Block not found, waiting for current queue to process before trying once more');
-      await waitUntilCurrentQueueIsProcessed(0);
+      await flushQueue(0);
       block = await getBlockByRoot(root);
     }
     if (block !== null) {

--- a/nightfall-optimist/src/routes/block.mjs
+++ b/nightfall-optimist/src/routes/block.mjs
@@ -10,6 +10,7 @@ import {
   getBlockByRoot,
   getTransactionsByTransactionHashes,
 } from '../services/database.mjs';
+import { waitUntilCurrentQueueIsProcessed } from '../services/event-queue.mjs';
 
 const router = express.Router();
 
@@ -53,7 +54,15 @@ router.get('/root/:root', async (req, res, next) => {
     const { root } = req.params;
     logger.debug(`searching for block containing root ${root}`);
     // get data to return
-    const block = await getBlockByRoot(root);
+    let block = await getBlockByRoot(root);
+    // if we don't get a block, it's possible that the corresponding 'BlockProposed'
+    // event is still in the event queue, so Nightfall doesn't have it in its database
+    // yet.  Let's wait for the current queue to empty and try again.
+    if (block === null) {
+      logger.debug('Block not found, waiting for current queue to process before trying once more');
+      await waitUntilCurrentQueueIsProcessed(0);
+      block = await getBlockByRoot(root);
+    }
     if (block !== null) {
       const transactions = await getTransactionsByTransactionHashes(block.transactionHashes);
       delete block?._id; // this is database specific so no need to send it

--- a/nightfall-optimist/src/routes/proposer.mjs
+++ b/nightfall-optimist/src/routes/proposer.mjs
@@ -234,8 +234,6 @@ router.post('/encode', async (req, res, next) => {
     // normally we re-compute the leafcount. If however block.leafCount is -ve
     // that's a signal to use the value given (once we've flipped the sign back)
     if (block.leafCount < 0) currentLeafCount = -block.leafCount;
-    const blockNumberL2 = Number(await stateContractInstance.methods.getNumberOfL2Blocks().call());
-    const previousBlockHash = await stateContractInstance.methods.getLatestBlockHash().call();
 
     const newTransactions = await Promise.all(
       transactions.map(t => {
@@ -259,8 +257,8 @@ router.post('/encode', async (req, res, next) => {
       root: block.root,
       leafCount: currentLeafCount,
       nCommitments: block.nCommitments,
-      blockNumberL2,
-      previousBlockHash,
+      blockNumberL2: block.blockNumberL2,
+      previousBlockHash: block.previousBlockHash,
     };
     newBlock.blockHash = await Block.calcHash(newBlock, newTransactions);
     logger.debug(`New block encoded for test ${JSON.stringify(newBlock, null, 2)}`);

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -11,7 +11,6 @@ import {
   getMostProfitableTransactions,
   numberOfUnprocessedTransactions,
 } from './database.mjs';
-import { eventQueueManager } from './event-queue.mjs';
 import Block from '../classes/block.mjs';
 import { Transaction } from '../classes/index.mjs';
 import { waitForContract } from '../event-handlers/subscribe.mjs';
@@ -72,11 +71,8 @@ export async function conditionalMakeBlock(proposer) {
       // remove the transactiosn from the mempool so we don't keep making new
       // blocks with them
       await removeTransactionsFromMemPool(block);
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      eventQueueManager(conditionalMakeBlock, 0, proposer);
-      // TODO is await needed?
-    } else {
-      await eventQueueManager(conditionalMakeBlock, 0, proposer);
     }
   }
+  // Let's slow down here so we don't slam the database.
+  await new Promise(resolve => setTimeout(resolve, 3000));
 }

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -11,7 +11,7 @@ import {
   getMostProfitableTransactions,
   numberOfUnprocessedTransactions,
 } from './database.mjs';
-import { queues, eventQueueManager } from './event-queue.mjs';
+import { eventQueueManager } from './event-queue.mjs';
 import Block from '../classes/block.mjs';
 import { Transaction } from '../classes/index.mjs';
 import { waitForContract } from '../event-handlers/subscribe.mjs';

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -47,10 +47,7 @@ export async function conditionalMakeBlock(proposer) {
   // transaction. If not, we must wait until either we have enough (hooray)
   // or we're no-longer the proposer (boo).
   if (proposer.isMe) {
-    if (
-      (await numberOfUnprocessedTransactions()) >= TRANSACTIONS_PER_BLOCK &&
-      queues[0].length === 0
-    ) {
+    if ((await numberOfUnprocessedTransactions()) >= TRANSACTIONS_PER_BLOCK) {
       const { block, transactions } = await makeBlock(proposer.address);
       logger.info(`Block Assembler - New Block created, ${JSON.stringify(block, null, 2)}`);
       // propose this block to the Shield contract here
@@ -76,7 +73,7 @@ export async function conditionalMakeBlock(proposer) {
       // blocks with them
       await removeTransactionsFromMemPool(block);
       await new Promise(resolve => setTimeout(resolve, 1000));
-      await eventQueueManager(conditionalMakeBlock, 0, proposer);
+      eventQueueManager(conditionalMakeBlock, 0, proposer);
       // TODO is await needed?
     } else {
       await eventQueueManager(conditionalMakeBlock, 0, proposer);

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -63,7 +63,7 @@ export async function conditionalMakeBlock(proposer) {
         )
         .encodeABI();
       if (ws)
-        ws.send(
+        await ws.send(
           JSON.stringify({
             type: 'block',
             txDataToSign: unsignedProposeBlockTransaction,

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -17,6 +17,7 @@ const {
   NULLIFIER_COLLECTION,
   COMMIT_COLLECTION,
   TIMBER_COLLECTION,
+  ZERO,
 } = config;
 
 /**
@@ -155,6 +156,21 @@ export async function getBlockByRoot(root) {
   const db = connection.db(OPTIMIST_DB);
   const query = { root };
   return db.collection(SUBMITTED_BLOCKS_COLLECTION).findOne(query);
+}
+
+/** 
+get the latest blockNumberL2 in our database
+*/
+export async function getLatestBlockInfo() {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  const [blockInfo] = await db
+    .collection(SUBMITTED_BLOCKS_COLLECTION)
+    .find({}, { blockNumberL2: 1, blockHash: 1 })
+    .sort({ blockNumberL2: -1 })
+    .limit(1)
+    .toArray();
+  return blockInfo ?? { blockNumberL2: -1, blockHash: ZERO };
 }
 
 /**

--- a/nightfall-optimist/src/services/event-queue.mjs
+++ b/nightfall-optimist/src/services/event-queue.mjs
@@ -45,8 +45,8 @@ function nextHigherPriorityQueueHasEmptied(priority) {
 
 export async function eventQueueManager(callback, priority, args) {
   queues[priority].push(async () => {
-    //await nextHigherPriorityQueueHasEmptied(priority); 
-    //prevent conditionalmakeblock from running until fastQueue is emptied
+    // await nextHigherPriorityQueueHasEmptied(priority);
+    // prevent conditionalmakeblock from running until fastQueue is emptied
     await callback(args);
   });
 }
@@ -78,7 +78,7 @@ export async function queueManager(eventObject, eventArgs) {
   } else {
     logger.info(`Queueing event ${eventObject.event}`);
     queues[priority].push(async () => {
-      //await nextHigherPriorityQueueHasEmptied(priority); // prevent eventHandlers running until the higher priority queue has emptied
+      // await nextHigherPriorityQueueHasEmptied(priority); // prevent eventHandlers running until the higher priority queue has emptied
       eventHandlers[eventObject.event](eventObject, args);
     });
   }

--- a/nightfall-optimist/src/services/event-queue.mjs
+++ b/nightfall-optimist/src/services/event-queue.mjs
@@ -45,7 +45,8 @@ function nextHigherPriorityQueueHasEmptied(priority) {
 
 export async function eventQueueManager(callback, priority, args) {
   queues[priority].push(async () => {
-    //await nextHigherPriorityQueueHasEmptied(priority); // prevent conditionalmakeblock from running until fastQueue is emptied
+    //await nextHigherPriorityQueueHasEmptied(priority); 
+    //prevent conditionalmakeblock from running until fastQueue is emptied
     await callback(args);
   });
 }

--- a/nightfall-optimist/src/services/event-queue.mjs
+++ b/nightfall-optimist/src/services/event-queue.mjs
@@ -24,7 +24,7 @@ import logger from 'common-files/utils/logger.mjs';
 const { MAX_QUEUE } = config;
 const fastQueue = new Queue({ autostart: true, concurrency: 1 });
 const slowQueue = new Queue({ autostart: true, concurrency: 1 });
-export const queues = [fastQueue, slowQueue];
+const queues = [fastQueue, slowQueue];
 
 /**
 This function will return a promise that resolves to true when the next highest

--- a/nightfall-optimist/src/services/event-queue.mjs
+++ b/nightfall-optimist/src/services/event-queue.mjs
@@ -43,6 +43,21 @@ function nextHigherPriorityQueueHasEmptied(priority) {
   });
 }
 
+/**
+This function will wait until all the functions currently in a queue have been
+processed.  It's useful if you want to ensure that Nightfall has had an opportunity
+to update its database with something that you know has happened on the blockchain
+but that Nightfall may not have processed yet, because it's still in the event queue.
+*/
+export function waitUntilCurrentQueueIsProcessed(priority) {
+  const p = new Promise(resolve => {
+    queues[priority].push(cb => {
+      cb(null, resolve());
+    });
+  });
+  return p;
+}
+
 export async function enqueueEvent(callback, priority, args) {
   queues[priority].push(async () => {
     // await nextHigherPriorityQueueHasEmptied(priority);

--- a/nightfall-optimist/src/services/event-queue.mjs
+++ b/nightfall-optimist/src/services/event-queue.mjs
@@ -49,7 +49,7 @@ processed.  It's useful if you want to ensure that Nightfall has had an opportun
 to update its database with something that you know has happened on the blockchain
 but that Nightfall may not have processed yet, because it's still in the event queue.
 */
-export function waitUntilCurrentQueueIsProcessed(priority) {
+export function flushQueue(priority) {
   const p = new Promise(resolve => {
     queues[priority].push(cb => {
       cb(null, resolve());

--- a/nightfall-optimist/src/services/event-queue.mjs
+++ b/nightfall-optimist/src/services/event-queue.mjs
@@ -45,8 +45,8 @@ function nextHigherPriorityQueueHasEmptied(priority) {
 
 export async function eventQueueManager(callback, priority, args) {
   queues[priority].push(async () => {
-    await nextHigherPriorityQueueHasEmptied(priority); // prevent conditionalmakeblock from running until fastQueue is emptied
-    callback(args);
+    //await nextHigherPriorityQueueHasEmptied(priority); // prevent conditionalmakeblock from running until fastQueue is emptied
+    await callback(args);
   });
 }
 
@@ -77,7 +77,7 @@ export async function queueManager(eventObject, eventArgs) {
   } else {
     logger.info(`Queueing event ${eventObject.event}`);
     queues[priority].push(async () => {
-      await nextHigherPriorityQueueHasEmptied(priority); // prevent eventHandlers running until the higher priority queue has emptied
+      //await nextHigherPriorityQueueHasEmptied(priority); // prevent eventHandlers running until the higher priority queue has emptied
       eventHandlers[eventObject.event](eventObject, args);
     });
   }

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -408,6 +408,17 @@ describe('Testing the challenge http API', () => {
       await new Promise(resolve => setTimeout(resolve, 5000));
     });
 
+    after(async () => {
+      // At the very end make sure we wait for any good blocks before dropping out of the test.
+      while (eventLogs[0] !== 'blockProposed') {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise(resolve => setTimeout(resolve, 3000));
+      }
+
+      eventLogs.shift();
+      await new Promise(resolve => setTimeout(resolve, 5000));
+    });
+
     describe('Challenge 1: Incorrect root challenge', () => {
       it('Should delete the flawed block and rollback the leaves', async () => {
         await testForEvents(stateAddress, [


### PR DESCRIPTION
This enqueues the block assembler using the `end` emitter from `queue`. Essentially, we try to enqueue the assembler when the queue is empty.

A few things to note:

- We check the `proposer.isMe` condition in the emitter to fail fast. Otherwise, a non-proposer will constantly try to re-enqueue and eventual consume their memory. We should investigate if long periods of re-enqueueing (i.e. is the proposer just does not have transactions to submit) causes memory issues.

- Note that the `proposer.isMe` check in `block-assembler` is now redundant, however removing that args input will require a bit more re-architecting so I've left it for now.

- I've been able to run the tests without any errors, however i can see the "Out of order block" error happen on multiple consecutive `npm t` runs (without restarting).  This is harder to debug as `client` is potentially very out of sync at this point. Another reason why this could be happening is that we happen to have a `Block-assemble` event queued in front of a `Rollback` event, therefore we try to assemble the block before processing the `Rollback` (even though on-chain the `Rollback` has completed). We could fix this by having logic that purges the assemble events if a Rollback is "received" (not processed).

- Finally, there is a new `after` hook in the `neg-http` tests, the websocket was quitting too early. This hook will capture the final 'good' block that is proposed (it was being dropped before). This was we do not immediately get an "Out of order block" error if we try and run the tests again without restarting.


Overall this greatly simplifies the enqueuing code and makes it more consistent. Closes #227 