### PR TITLE
Add queue to client

### DIFF
--- a/common-files/utils/event-queue.mjs
+++ b/common-files/utils/event-queue.mjs
@@ -1,3 +1,5 @@
+/* eslint import/no-extraneous-dependencies: "off" */
+
 /**
 If we're changing the layer 2 state, we want to make sure that we can complete
 that change before the state is further altered by incoming events.  A good
@@ -49,7 +51,7 @@ processed.  It's useful if you want to ensure that Nightfall has had an opportun
 to update its database with something that you know has happened on the blockchain
 but that Nightfall may not have processed yet, because it's still in the event queue.
 */
-export function flushQueue(priority) {
+function flushQueue(priority) {
   const p = new Promise(resolve => {
     queues[priority].push(cb => {
       cb(null, resolve());
@@ -58,7 +60,7 @@ export function flushQueue(priority) {
   return p;
 }
 
-export async function enqueueEvent(callback, priority, args) {
+async function enqueueEvent(callback, priority, args) {
   queues[priority].push(async () => {
     // await nextHigherPriorityQueueHasEmptied(priority);
     // prevent conditionalmakeblock from running until fastQueue is emptied
@@ -66,7 +68,7 @@ export async function enqueueEvent(callback, priority, args) {
   });
 }
 
-export async function queueManager(eventObject, eventArgs) {
+async function queueManager(eventObject, eventArgs) {
   // First element of eventArgs must be the eventHandlers object
   const [eventHandlers, ...args] = eventArgs;
   // handlers contains the functions needed to handle particular types of event,
@@ -101,3 +103,6 @@ export async function queueManager(eventObject, eventArgs) {
   if (queues[priority].length > MAX_QUEUE)
     logger.warn(`The event queue has more than ${MAX_QUEUE} events`);
 }
+
+/* ignore unused exports */
+export { flushQueue, enqueueEvent, queueManager };

--- a/nightfall-client/package-lock.json
+++ b/nightfall-client/package-lock.json
@@ -314,32 +314,13 @@
       }
     },
     "ansi-align": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
       "dev": true,
       "requires": {
-        "string-width": "^3.0.0"
-      },
-      "dependencies": {
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        }
+        "string-width": "^4.1.0"
       }
-    },
-    "ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -445,11 +426,11 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "balanced-match": {
@@ -4582,12 +4563,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
-    },
     "enabled": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
@@ -4978,9 +4953,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
     },
     "foreach": {
       "version": "2.0.5",
@@ -5397,12 +5372,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
-    },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
     "is-function": {
@@ -6216,6 +6185,14 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
+    "queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "requires": {
+        "inherits": "~2.0.3"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -6585,9 +6562,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "emoji-regex": {
@@ -6635,15 +6612,6 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
-    "strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^4.1.0"
-      }
     },
     "strip-hex-prefix": {
       "version": "1.0.0",
@@ -6738,17 +6706,17 @@
       }
     },
     "tar": {
-      "version": "4.4.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.15.tgz",
-      "integrity": "sha512-ItbufpujXkry7bHH9NpQyTXPbJ72iTlXgkBAYsAjDXk3Ds8t/3NfO5P4xZGy7u+sYuQUbimgzswX4uQIEeNVOA==",
+      "version": "4.4.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
       "requires": {
-        "chownr": "^1.1.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.8.6",
-        "minizlib": "^1.2.1",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.3"
+        "chownr": "^1.1.4",
+        "fs-minipass": "^1.2.7",
+        "minipass": "^2.9.0",
+        "minizlib": "^1.3.3",
+        "mkdirp": "^0.5.5",
+        "safe-buffer": "^5.2.1",
+        "yallist": "^3.1.1"
       },
       "dependencies": {
         "mkdirp": {
@@ -6944,9 +6912,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/nightfall-client/package.json
+++ b/nightfall-client/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "amqplib": "^0.8.0",
     "async-mutex": "^0.3.1",
-    "axios": "^0.21.1",
+    "axios": "^0.21.4",
     "body-parser": "1.19.0",
     "chai-as-promised": "^7.1.1",
     "common-files": "file:../common-files",
@@ -38,6 +38,7 @@
     "keccak": "^3.0.1",
     "mongodb": "^3.6.2",
     "path": "^0.12.7",
+    "queue": "^6.0.2",
     "safe-buffer": "^5.2.1",
     "web3": "^1.4.0",
     "winston": "^3.3.3",

--- a/nightfall-client/src/event-handlers/index.mjs
+++ b/nightfall-client/src/event-handlers/index.mjs
@@ -1,10 +1,17 @@
-import { subscribeToBlockProposedEvent, subscribeToRollbackEventHandler } from './subscribe.mjs';
+import { startEventQueue } from './subscribe.mjs';
 import blockProposedEventHandler from './block-proposed.mjs';
 import rollbackEventHandler from './rollback.mjs';
 
-export {
-  subscribeToBlockProposedEvent,
-  blockProposedEventHandler,
-  subscribeToRollbackEventHandler,
-  rollbackEventHandler,
+const eventHandlers = {
+  BlockProposed: blockProposedEventHandler,
+  Rollback: rollbackEventHandler,
+  // removers: {
+  // BlockProposed: removeBlockProposedEventHandler,
+  // },
+  priority: {
+    BlockProposed: 0,
+    Rollback: 0,
+  },
 };
+
+export { startEventQueue, eventHandlers };

--- a/nightfall-client/src/event-handlers/subscribe.mjs
+++ b/nightfall-client/src/event-handlers/subscribe.mjs
@@ -38,16 +38,10 @@ async function waitForContract(contractName) {
   return instance;
 }
 
-export async function subscribeToBlockProposedEvent(callback, ...args) {
-  const emitter = (await waitForContract(STATE_CONTRACT_NAME)).events.BlockProposed();
+// eslint-disable-next-line import/prefer-default-export
+export async function startEventQueue(callback, ...args) {
+  const emitter = (await waitForContract(STATE_CONTRACT_NAME)).events.allEvents();
   emitter.on('data', event => callback(event, args));
-  logger.debug('Subscribed to BlockProposed event');
-  return emitter;
-}
-
-export async function subscribeToRollbackEventHandler(callback, ...args) {
-  const emitter = (await waitForContract(STATE_CONTRACT_NAME)).events.Rollback();
-  emitter.on('data', event => callback(event, args));
-  logger.debug('Subscribed to Rollback event');
+  logger.debug('Subscribed to layer 2 state events');
   return emitter;
 }

--- a/nightfall-client/src/index.mjs
+++ b/nightfall-client/src/index.mjs
@@ -1,16 +1,12 @@
 import config from 'config';
 import logger from 'common-files/utils/logger.mjs';
 import mongo from 'common-files/utils/mongo.mjs';
+import { queueManager } from 'common-files/utils/event-queue.mjs';
 import app from './app.mjs';
 import rabbitmq from './utils/rabbitmq.mjs';
 import queues from './queues/index.mjs';
 import { initialClientSync } from './services/state-sync.mjs';
-import {
-  subscribeToBlockProposedEvent,
-  blockProposedEventHandler,
-  subscribeToRollbackEventHandler,
-  rollbackEventHandler,
-} from './event-handlers/index.mjs';
+import { startEventQueue, eventHandlers } from './event-handlers/index.mjs';
 
 const main = async () => {
   try {
@@ -18,9 +14,8 @@ const main = async () => {
       await rabbitmq.connect();
       queues();
     }
-    initialClientSync().then(() => {
-      subscribeToBlockProposedEvent(blockProposedEventHandler);
-      subscribeToRollbackEventHandler(rollbackEventHandler);
+    initialClientSync().then(async () => {
+      await startEventQueue(queueManager, eventHandlers);
     });
     await mongo.connection(config.MONGO_URL); // get a db connection
     app.listen(80);

--- a/nightfall-optimist/src/index.mjs
+++ b/nightfall-optimist/src/index.mjs
@@ -1,4 +1,5 @@
 import logger from 'common-files/utils/logger.mjs';
+import { queueManager, queues, enqueueEvent } from 'common-files/utils/event-queue.mjs';
 import app from './app.mjs';
 import {
   startEventQueue,
@@ -14,7 +15,6 @@ import {
 } from './services/block-assembler.mjs';
 import { setChallengeWebSocketConnection } from './services/challenges.mjs';
 import initialBlockSync from './services/state-sync.mjs';
-import { queueManager, queues, enqueueEvent } from './services/event-queue.mjs';
 import { setInstantWithdrawalWebSocketConnection } from './services/instant-withdrawal.mjs';
 
 const main = async () => {

--- a/nightfall-optimist/src/routes/block.mjs
+++ b/nightfall-optimist/src/routes/block.mjs
@@ -3,6 +3,7 @@ Routes for checking that a block is valid.
 */
 import express from 'express';
 import logger from 'common-files/utils/logger.mjs';
+import { flushQueue } from 'common-files/utils/event-queue.mjs';
 import checkBlock from '../services/check-block.mjs';
 import Block from '../classes/block.mjs';
 import {
@@ -10,7 +11,6 @@ import {
   getBlockByRoot,
   getTransactionsByTransactionHashes,
 } from '../services/database.mjs';
-import { flushQueue } from '../services/event-queue.mjs';
 
 const router = express.Router();
 


### PR DESCRIPTION
This elevates the queue implementation out of `optimist` into `common-files` so it also be used in `client` without duplication.

Note that to do this quickly, we exploit the fact that `common-files` is copied into the `client` and `optimist` during the build. This allows us to keep the `queues` array inside the `event-queue` file (as there is a fresh instantiation in each copy of the `event-queue` file in both `client` and `optimist`).

Long-term we can certainly do better than this and should look at a way to instantiate the `queue` in the `main` files for `optimist` and `client` rather than instantiating in `common-files` and copying it across. This provides some benefits in terms of flexibility on setup (e.g. `client` does not need two queues) and minimises any potential issues with global mutation and the copy process.


P.S there is a slight bump in some packages as a result of fixing some high-risk vulnerabilities with `npm audit fix`

This closes #230  