### PR TITLE
Daveroga/api status widthdraws

### DIFF
--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -575,7 +575,7 @@ class Nf3 {
   @method
   @async
   @return {Promise} A promise that resolves to an axios response.
-  */  
+  */
   async registerChallenger() {
     return axios.post(`${this.optimistBaseUrl}/challenger/add`, { address: this.ethereumAddress });
   }

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -641,6 +641,39 @@ class Nf3 {
   }
 
   /**
+  Get if it's a valid withdraw transaction for finalising the
+  withdrawal of funds to L1 (only relevant for ERC20).
+  @method
+  @async
+  @param {string} withdrawTransactionHash - the hash of the Layer 2 transaction in question
+  */
+  async isValidWithdrawal(withdrawTransactionHash) {
+    let res;
+    let valid = false;
+
+    try {
+      res = await axios.get(
+        `${this.optimistBaseUrl}/block/transaction-hash/${withdrawTransactionHash}`,
+      );
+    } catch (e) {
+      // transaction is not in block yet
+      valid = false;
+    }
+
+    if (res) {
+      const { block, transactions, index } = res.data;
+      res = await axios.post(`${this.clientBaseUrl}/valid-withdrawal`, {
+        block,
+        transactions,
+        index,
+      });
+      valid = res.data.valid;
+    }
+
+    return valid;
+  }
+
+  /**
   Returns the balance of tokens held in layer 2
   @method
   @async
@@ -657,13 +690,45 @@ class Nf3 {
   Returns the commitments of tokens held in layer 2
   @method
   @async
-  @returns {Promise} This promise rosolves into an object whose properties are the
+  @returns {Promise} This promise resolves into an object whose properties are the
   addresses of the ERC contracts of the tokens held by this account in Layer 2. The
   value of each propery is an array of commitments originating from that contract.
   */
   async getLayer2Commitments() {
     const res = await axios.get(`${this.clientBaseUrl}/commitment/commitments`);
     return res.data.commitments;
+  }
+
+  /**
+  Returns the pending withdraws commitments
+  @method
+  @async
+  @returns {Promise} This promise resolves into an object whose properties are the
+  addresses of the ERC contracts of the tokens held by this account in Layer 2. The
+  value of each propery is an array of commitments originating from that contract.
+  */
+  async getPendingWithdraws() {
+    const res = await axios.get(`${this.clientBaseUrl}/commitment/withdraws`);
+    const listWithdrawCommitments = res.data.commitments[this.zkpKeys.compressedPkd];
+    const pendingWithdrawCommitments = [];
+    if (listWithdrawCommitments) {
+      // we loop through all ercaddresses in the wallet
+      const ercAddresses = Object.getOwnPropertyNames(listWithdrawCommitments);
+
+      for (let i = 0; i < ercAddresses.length; i++) {
+        for (let k = 0; k < listWithdrawCommitments[ercAddresses[i]].length; k++) {
+          // eslint-disable-next-line no-await-in-loop
+          const valid = await this.isValidWithdrawal(
+            listWithdrawCommitments[ercAddresses[i]][k].transactionNullified.transactionHash,
+          );
+          pendingWithdrawCommitments.push({
+            commitment: listWithdrawCommitments[ercAddresses[i]][k],
+            valid,
+          });
+        }
+      }
+    }
+    return pendingWithdrawCommitments;
   }
 
   /**

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -575,7 +575,7 @@ class Nf3 {
   @method
   @async
   @return {Promise} A promise that resolves to an axios response.
-  */
+  */  
   async registerChallenger() {
     return axios.post(`${this.optimistBaseUrl}/challenger/add`, { address: this.ethereumAddress });
   }
@@ -705,30 +705,11 @@ class Nf3 {
   @async
   @returns {Promise} This promise resolves into an object whose properties are the
   addresses of the ERC contracts of the tokens held by this account in Layer 2. The
-  value of each propery is an array of commitments originating from that contract.
+  value of each propery is an array of withdraw commitments originating from that contract.
   */
   async getPendingWithdraws() {
     const res = await axios.get(`${this.clientBaseUrl}/commitment/withdraws`);
-    const listWithdrawCommitments = res.data.commitments[this.zkpKeys.compressedPkd];
-    const pendingWithdrawCommitments = [];
-    if (listWithdrawCommitments) {
-      // we loop through all ercaddresses in the wallet
-      const ercAddresses = Object.getOwnPropertyNames(listWithdrawCommitments);
-
-      for (let i = 0; i < ercAddresses.length; i++) {
-        for (let k = 0; k < listWithdrawCommitments[ercAddresses[i]].length; k++) {
-          // eslint-disable-next-line no-await-in-loop
-          const valid = await this.isValidWithdrawal(
-            listWithdrawCommitments[ercAddresses[i]][k].transactionNullified.transactionHash,
-          );
-          pendingWithdrawCommitments.push({
-            commitment: listWithdrawCommitments[ercAddresses[i]][k],
-            valid,
-          });
-        }
-      }
-    }
-    return pendingWithdrawCommitments;
+    return res.data.commitments;
   }
 
   /**

--- a/doc/lib/nf3.mjs.html
+++ b/doc/lib/nf3.mjs.html
@@ -665,6 +665,39 @@ class Nf3 {
   }
 
   /**
+  Get if it's a valid withdraw transaction for finalising the
+  withdrawal of funds to L1 (only relevant for ERC20).
+  @method
+  @async
+  @param {string} withdrawTransactionHash - the hash of the Layer 2 transaction in question
+  */
+  async isValidWithdrawal(withdrawTransactionHash) {
+    let res;
+    let valid = false;
+
+    try {
+      res = await axios.get(
+        `${this.optimistBaseUrl}/block/transaction-hash/${withdrawTransactionHash}`,
+      );
+    } catch (e) {
+      // transaction is not in block yet
+      valid = false;
+    }
+
+    if (res) {
+      const { block, transactions, index } = res.data;
+      res = await axios.post(`${this.clientBaseUrl}/valid-withdrawal`, {
+        block,
+        transactions,
+        index,
+      });
+      valid = res.data.valid;
+    }
+
+    return valid;
+  }
+
+  /**
   Returns the balance of tokens held in layer 2
   @method
   @async
@@ -681,13 +714,110 @@ class Nf3 {
   Returns the commitments of tokens held in layer 2
   @method
   @async
-  @returns {Promise} This promise rosolves into an object whose properties are the
+  @returns {Promise} This promise resolves into an object whose properties are the
   addresses of the ERC contracts of the tokens held by this account in Layer 2. The
   value of each propery is an array of commitments originating from that contract.
   */
   async getLayer2Commitments() {
     const res = await axios.get(`${this.clientBaseUrl}/commitment/commitments`);
     return res.data.commitments;
+  }
+
+  /**
+  Returns the pending withdraws commitments
+  @method
+  @async
+  @returns {Promise} This promise resolves into an object whose properties are the
+  addresses of the ERC contracts of the tokens held by this account in Layer 2. The
+  value of each propery is an array of withdraw commitments originating from that contract.
+  */
+  async getPendingWithdraws() {
+    const res = await axios.get(`${this.clientBaseUrl}/commitment/withdraws`);
+    const listWithdrawCommitments = res.data.commitments[this.zkpKeys.compressedPkd];
+    const pendingWithdrawCommitments = [];
+    if (listWithdrawCommitments) {
+      // we loop through all ercaddresses in the wallet
+      const ercAddresses = Object.getOwnPropertyNames(listWithdrawCommitments);
+
+      for (let i = 0; i < ercAddresses.length; i++) {
+        for (let k = 0; k < listWithdrawCommitments[ercAddresses[i]].length; k++) {
+          // eslint-disable-next-line no-await-in-loop
+          const valid = await this.isValidWithdrawal(
+            listWithdrawCommitments[ercAddresses[i]][k].transactionNullified.transactionHash,
+          );
+          pendingWithdrawCommitments.push({
+            commitment: listWithdrawCommitments[ercAddresses[i]][k],
+            valid,
+          });
+        }
+      }
+    }
+    return pendingWithdrawCommitments;
+  }
+
+  /**
+  Set a Web3 Provider URL
+  @param {String|Object} providerData - Network url (i.e, http://localhost:8544) or an Object with the information to set the provider
+  */
+  setWeb3Provider(providerData) {
+    if (typeof providerData === 'string' || typeof window === 'undefined') {
+      this.web3 = new Web3(providerData);
+    }
+
+    if (typeof window !== 'undefined' && window.ethereum) {
+      this.web3 = new Web3(window.ethereum);
+      window.ethereum.send('eth_requestAccounts');
+    }
+  }
+
+  /**
+  Web3 provider getter
+  @returns {Object} provider
+  */
+  getWeb3Provider() {
+    return this.web3;
+  }
+
+  /**
+  Get Ethereum Balance
+  @param {String} address - Ethereum address of account
+  @returns {String} - Ether balance in account
+  */
+  getL1Balance(address) {
+    return this.web3.eth.getBalance(address).then(function (balanceWei) {
+      return Web3.utils.fromWei(balanceWei);
+    });
+  }
+
+  /**
+  Get EthereumAddress available.
+  @param {String} privateKey - Private Key - optional
+  @returns {String} - Ether balance in account
+  */
+  getAccounts() {
+    const account =
+      this.ethereumSigningKey.length === 0
+        ? this.web3.eth.getAccounts().then(address => address[0])
+        : this.web3.eth.accounts.privateKeyToAccount(this.ethereumSigningKey).address;
+    return account;
+  }
+
+  /**
+  Signs a message with a given authenticated account
+  @param {String} msg  - Message to sign
+  @param {String } account - Ethereum address of account
+  @returns {Promise} - string with the signature
+  */
+  signMessage(msg, account) {
+    return this.web3.eth.personal.sign(msg, account);
+  }
+
+  /**
+  Returns current network ID
+  @returns {Promise} - Network Id number
+  */
+  getNetworkId() {
+    return this.web3.eth.net.getId();
   }
 }
 

--- a/nightfall-client/src/app.mjs
+++ b/nightfall-client/src/app.mjs
@@ -8,6 +8,7 @@ import {
   withdraw,
   isMessageValid,
   finaliseWithdrawal,
+  isValidWithdrawal,
   peers,
   commitment,
   incomingViewingKey,
@@ -28,6 +29,7 @@ app.use('/transfer', transfer);
 app.use('/withdraw', withdraw);
 app.use('/check-message', isMessageValid);
 app.use('/finalise-withdrawal', finaliseWithdrawal);
+app.use('/valid-withdrawal', isValidWithdrawal);
 app.use('/peers', peers);
 app.use('/commitment', commitment);
 app.use('/incoming-viewing-key', incomingViewingKey);

--- a/nightfall-client/src/routes/commitment.mjs
+++ b/nightfall-client/src/routes/commitment.mjs
@@ -8,6 +8,7 @@ import {
   getCommitmentBySalt,
   getWalletBalance,
   getWalletCommitments,
+  getWithdrawCommitments,
 } from '../services/commitment-storage.mjs';
 
 const router = express.Router();
@@ -41,6 +42,17 @@ router.get('/commitments', async (req, res, next) => {
   logger.debug('commitment/commitments endpoint received GET');
   try {
     const commitments = await getWalletCommitments();
+    res.json({ commitments });
+  } catch (err) {
+    logger.error(err);
+    next(err);
+  }
+});
+
+router.get('/withdraws', async (req, res, next) => {
+  logger.debug('commitment/withdraws endpoint received GET');
+  try {
+    const commitments = await getWithdrawCommitments();
     res.json({ commitments });
   } catch (err) {
     logger.error(err);

--- a/nightfall-client/src/routes/index.mjs
+++ b/nightfall-client/src/routes/index.mjs
@@ -4,6 +4,7 @@ import transfer from './transfer.mjs';
 import withdraw from './withdraw.mjs';
 import isMessageValid from './check-message.mjs';
 import finaliseWithdrawal from './finalise-withdrawal.mjs';
+import isValidWithdrawal from './valid-withdrawal.mjs';
 import peers from './peers.mjs';
 import commitment from './commitment.mjs';
 import incomingViewingKey from './incoming-viewing-key.mjs';
@@ -17,6 +18,7 @@ export {
   getContractAddress,
   isMessageValid,
   finaliseWithdrawal,
+  isValidWithdrawal,
   peers,
   commitment,
   incomingViewingKey,

--- a/nightfall-client/src/routes/valid-withdrawal.mjs
+++ b/nightfall-client/src/routes/valid-withdrawal.mjs
@@ -1,0 +1,22 @@
+/**
+Route to get if a withdraw is valid for finalising.
+*/
+import express from 'express';
+import logger from 'common-files/utils/logger.mjs';
+import { isValidWithdrawal } from '../services/valid-withdrawal.mjs';
+
+const router = express.Router();
+
+router.post('/', async (req, res, next) => {
+  logger.debug(`valid-withdrawal endpoint received POST ${JSON.stringify(req.body, null, 2)}`);
+  try {
+    const valid = await isValidWithdrawal(req.body);
+    logger.debug(`returning valid ${valid}`);
+    res.json({ valid });
+  } catch (err) {
+    logger.error(err);
+    next(err);
+  }
+});
+
+export default router;

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -31,6 +31,7 @@ export async function storeCommitment(commitment, nsk) {
     isNullifiedOnChain: Number(commitment.isNullifiedOnChain),
     nullifier: nullifierHash,
     blockNumber: -1,
+    transactionNullified: null,
   };
   return db.collection(COMMITMENTS_COLLECTION).insertOne(data);
 }
@@ -70,10 +71,12 @@ async function markPending(commitment) {
 }
 
 // function to mark a commitment as nullified for a mongo db
-export async function markNullified(commitment) {
+export async function markNullified(commitment, transaction) {
   const connection = await mongo.connection(MONGO_URL);
   const query = { _id: commitment.hash.hex(32) };
-  const update = { $set: { isPendingNullification: false, isNullified: true } };
+  const update = {
+    $set: { isPendingNullification: false, isNullified: true, transactionNullified: transaction },
+  };
   const db = connection.db(COMMITMENTS_DB);
   return db.collection(COMMITMENTS_COLLECTION).updateOne(query, update);
 }
@@ -221,6 +224,46 @@ export async function getWalletCommitments() {
       compressedPkd: e.compressedPkd,
       ercAddress: e.ercAddress,
       balance: e.tokenId ? 1 : e.value,
+    }))
+    .reduce((acc, e) => {
+      if (!acc[e.compressedPkd]) acc[e.compressedPkd] = {};
+      if (!acc[e.compressedPkd][e.ercAddress]) acc[e.compressedPkd][e.ercAddress] = [];
+      acc[e.compressedPkd][e.ercAddress].push(e);
+      return acc;
+    }, {});
+}
+
+// function to get the withdraw commitments for each ERC address of a pkd
+export async function getWithdrawCommitments() {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(COMMITMENTS_DB);
+  const query = {
+    isNullified: true,
+    'transactionNullified.transactionType':
+      '0x0000000000000000000000000000000000000000000000000000000000000003',
+  };
+  const options = {
+    projection: {
+      preimage: { ercAddress: 1, compressedPkd: 1, tokenId: 1, value: 1 },
+      _id: 0,
+      transactionNullified: 1,
+    },
+  };
+  const wallet = await db.collection(COMMITMENTS_COLLECTION).find(query, options).toArray();
+  return wallet
+    .map(e => ({
+      ercAddress: BigInt(e.preimage.ercAddress).toString(16),
+      compressedPkd: e.preimage.compressedPkd,
+      tokenId: !!BigInt(e.preimage.tokenId),
+      value: Number(BigInt(e.preimage.value)),
+      transactionNullified: e.transactionNullified,
+    }))
+    .filter(e => e.tokenId || e.value > 0) // there should be no commitments with tokenId and value of ZERO
+    .map(e => ({
+      compressedPkd: e.compressedPkd,
+      ercAddress: e.ercAddress,
+      balance: e.tokenId ? 1 : e.value,
+      transactionNullified: e.transactionNullified,
     }))
     .reduce((acc, e) => {
       if (!acc[e.compressedPkd]) acc[e.compressedPkd] = {};

--- a/nightfall-client/src/services/transfer.mjs
+++ b/nightfall-client/src/services/transfer.mjs
@@ -20,7 +20,7 @@ import {
 } from './commitment-storage.mjs';
 import { getSiblingPath } from '../utils/timber.mjs';
 import { discoverPeers } from './peers.mjs';
-import getBlockAndTransactionsByRoot from '../utils/optimist.mjs';
+import { getBlockAndTransactionsByRoot } from '../utils/optimist.mjs';
 import { compressPublicKey, calculateIvkPkdfromAskNsk } from './keys.mjs';
 
 const {

--- a/nightfall-client/src/services/transfer.mjs
+++ b/nightfall-client/src/services/transfer.mjs
@@ -224,7 +224,9 @@ async function transfer(transferParams) {
         .filter(commitment => commitment.preimage.compressedPkd.hex(32) === compressedPkd.hex(32))
         .forEach(commitment => storeCommitment(commitment, nsk)); // TODO insertMany
       // mark the old commitments as nullified
-      await Promise.all(oldCommitments.map(commitment => markNullified(commitment)));
+      await Promise.all(
+        oldCommitments.map(commitment => markNullified(commitment, optimisticTransferTransaction)),
+      );
       return {
         transaction: optimisticTransferTransaction,
         salts: salts.map(salt => salt.hex(32)),
@@ -238,7 +240,9 @@ async function transfer(transferParams) {
       .filter(commitment => commitment.preimage.compressedPkd.hex(32) === compressedPkd.hex(32))
       .forEach(commitment => storeCommitment(commitment, nsk)); // TODO insertMany
     // mark the old commitments as nullified
-    await Promise.all(oldCommitments.map(commitment => markNullified(commitment)));
+    await Promise.all(
+      oldCommitments.map(commitment => markNullified(commitment, optimisticTransferTransaction)),
+    );
     return {
       rawTransaction,
       transaction: optimisticTransferTransaction,

--- a/nightfall-client/src/services/valid-withdrawal.mjs
+++ b/nightfall-client/src/services/valid-withdrawal.mjs
@@ -9,6 +9,7 @@ import { buildSolidityStruct } from './finalise-withdrawal.mjs';
 
 const { SHIELD_CONTRACT_NAME } = config;
 
+// eslint-disable-next-line import/prefer-default-export
 export async function isValidWithdrawal({ block, transactions, index }) {
   const shieldContractInstance = await getContractInstance(SHIELD_CONTRACT_NAME);
   try {
@@ -25,5 +26,3 @@ export async function isValidWithdrawal({ block, transactions, index }) {
     return false;
   }
 }
-
-export default isValidWithdrawal;

--- a/nightfall-client/src/services/valid-withdrawal.mjs
+++ b/nightfall-client/src/services/valid-withdrawal.mjs
@@ -5,21 +5,9 @@ address.
 import config from 'config';
 import { getContractInstance } from 'common-files/utils/contract.mjs';
 import { Transaction } from '../classes/index.mjs';
+import { buildSolidityStruct } from './finalise-withdrawal.mjs';
 
 const { SHIELD_CONTRACT_NAME } = config;
-
-// TODO move classes to their own folder so this is not needed (it's already a
-// static function in the Block class)
-export function buildSolidityStruct(block) {
-  const { proposer, root, leafCount, blockNumberL2, previousBlockHash } = block;
-  return {
-    proposer,
-    root,
-    leafCount: Number(leafCount),
-    blockNumberL2: Number(blockNumberL2),
-    previousBlockHash,
-  };
-}
 
 export async function isValidWithdrawal({ block, transactions, index }) {
   const shieldContractInstance = await getContractInstance(SHIELD_CONTRACT_NAME);
@@ -37,3 +25,5 @@ export async function isValidWithdrawal({ block, transactions, index }) {
     return false;
   }
 }
+
+export default isValidWithdrawal;

--- a/nightfall-client/src/services/valid-withdrawal.mjs
+++ b/nightfall-client/src/services/valid-withdrawal.mjs
@@ -1,0 +1,39 @@
+/**
+Module to endable withdrawal of funds from the Shield contract to the user's
+address.
+*/
+import config from 'config';
+import { getContractInstance } from 'common-files/utils/contract.mjs';
+import { Transaction } from '../classes/index.mjs';
+
+const { SHIELD_CONTRACT_NAME } = config;
+
+// TODO move classes to their own folder so this is not needed (it's already a
+// static function in the Block class)
+export function buildSolidityStruct(block) {
+  const { proposer, root, leafCount, blockNumberL2, previousBlockHash } = block;
+  return {
+    proposer,
+    root,
+    leafCount: Number(leafCount),
+    blockNumberL2: Number(blockNumberL2),
+    previousBlockHash,
+  };
+}
+
+export async function isValidWithdrawal({ block, transactions, index }) {
+  const shieldContractInstance = await getContractInstance(SHIELD_CONTRACT_NAME);
+  try {
+    const valid = await shieldContractInstance.methods
+      .isValidWithdrawal(
+        buildSolidityStruct(block),
+        block.blockNumberL2,
+        transactions.map(t => Transaction.buildSolidityStruct(t)),
+        index,
+      )
+      .call();
+    return valid;
+  } catch (err) {
+    return false;
+  }
+}

--- a/nightfall-client/src/services/withdraw.mjs
+++ b/nightfall-client/src/services/withdraw.mjs
@@ -133,7 +133,7 @@ async function withdraw(withdrawParams) {
       .submitTransaction(Transaction.buildSolidityStruct(optimisticWithdrawTransaction))
       .encodeABI();
     // on successful computation of the transaction mark the old commitments as nullified
-    await markNullified(oldCommitment);
+    await markNullified(oldCommitment, optimisticWithdrawTransaction);
     return { rawTransaction, transaction: optimisticWithdrawTransaction };
   } catch (err) {
     await clearPending(oldCommitment);

--- a/nightfall-client/src/services/withdraw.mjs
+++ b/nightfall-client/src/services/withdraw.mjs
@@ -14,7 +14,7 @@ import { Nullifier, PublicInputs, Transaction } from '../classes/index.mjs';
 import { findUsableCommitmentsMutex, markNullified, clearPending } from './commitment-storage.mjs';
 import { getSiblingPath } from '../utils/timber.mjs';
 import { discoverPeers } from './peers.mjs';
-import getBlockAndTransactionsByRoot from '../utils/optimist.mjs';
+import { getBlockAndTransactionsByRoot } from '../utils/optimist.mjs';
 import { calculateIvkPkdfromAskNsk } from './keys.mjs';
 
 const {

--- a/nightfall-client/src/utils/optimist.mjs
+++ b/nightfall-client/src/utils/optimist.mjs
@@ -19,5 +19,3 @@ export async function getBlockByTransactionHash(withdrawTransactionHash) {
   const response = await axios.get(`${url}/block/transaction-hash/${withdrawTransactionHash}`);
   return response.data;
 }
-
-export default getBlockAndTransactionsByRoot;

--- a/nightfall-client/src/utils/optimist.mjs
+++ b/nightfall-client/src/utils/optimist.mjs
@@ -8,9 +8,15 @@ import logger from 'common-files/utils/logger.mjs';
 
 const url = `http://${config.OPTIMIST_HOST}:${config.OPTIMIST_PORT}`;
 
-async function getBlockAndTransactionsByRoot(root) {
+export async function getBlockAndTransactionsByRoot(root) {
   logger.http(`Calling block/root/${root}`);
   const response = await axios.get(`${url}/block/root/${root}`);
+  return response.data;
+}
+
+export async function getBlockByTransactionHash(withdrawTransactionHash) {
+  logger.http(`Calling block/transaction-hash/${withdrawTransactionHash}`);
+  const response = await axios.get(`${url}/block/transaction-hash/${withdrawTransactionHash}`);
   return response.data;
 }
 

--- a/test/e2e/nightfall-sdk.test.mjs
+++ b/test/e2e/nightfall-sdk.test.mjs
@@ -538,8 +538,14 @@ describe('Testing the Nightfall SDK', () => {
   describe('Get pending withdraw commitments tests', () => {
     it('should get current pending withdraw commitments for the account (with 0 valid commitments)', async function () {
       const commitments = await nf3User1.getPendingWithdraws();
-      expect(commitments.length).to.be.greaterThan(0);
-      expect(commitments.filter(c => c.valid === true).length).to.be.equal(0);
+      expect(
+        commitments[nf3User1.zkpKeys.compressedPkd][BigInt(ercAddress).toString(16)].length,
+      ).to.be.greaterThan(0);
+      expect(
+        commitments[nf3User1.zkpKeys.compressedPkd][BigInt(ercAddress).toString(16)].filter(
+          c => c.valid === true,
+        ).length,
+      ).to.be.equal(0);
     });
   });
 
@@ -568,8 +574,14 @@ describe('Testing the Nightfall SDK', () => {
     it('should get a valid withdraw commitment with a time-jump capable test client (because sufficient time has passed)', async function () {
       if (nodeInfo.includes('TestRPC')) await timeJump(3600 * 24 * 10); // jump in time by 10 days
       const commitments = await nf3User1.getPendingWithdraws();
-      expect(commitments.length).to.be.greaterThan(0);
-      expect(commitments.filter(c => c.valid === true).length).to.be.greaterThan(0);
+      expect(
+        commitments[nf3User1.zkpKeys.compressedPkd][BigInt(ercAddress).toString(16)].length,
+      ).to.be.greaterThan(0);
+      expect(
+        commitments[nf3User1.zkpKeys.compressedPkd][BigInt(ercAddress).toString(16)].filter(
+          c => c.valid === true,
+        ).length,
+      ).to.be.greaterThan(0);
     });
 
     it('should create a passing finalise-withdrawal with a time-jump capable test client (because sufficient time has passed)', async function () {

--- a/test/e2e/nightfall-sdk.test.mjs
+++ b/test/e2e/nightfall-sdk.test.mjs
@@ -535,11 +535,17 @@ describe('Testing the Nightfall SDK', () => {
     });
   });
 
+  describe('Get pending withdraw commitments tests', () => {
+    it('should get current pending withdraw commitments for the account (with 0 valid commitments)', async function () {
+      const commitments = await nf3User1.getPendingWithdraws();
+      expect(commitments.length).to.be.greaterThan(0);
+      expect(commitments.filter(c => c.valid === true).length).to.be.equal(0);
+    });
+  });
+
   // when the widthdraw transaction is finalised, we want to be able to pull the
   // funds into layer1
-  describe('Withdraw funds to layer 1', () => {
-    let startBalance;
-    let endBalance;
+  describe('Withdraw funds to layer 1 failing (because insufficient time has passed)', () => {
     it('Should create a failing finalise-withdrawal (because insufficient time has passed)', async function () {
       let error = null;
       try {
@@ -553,10 +559,21 @@ describe('Testing the Nightfall SDK', () => {
         'Returned error: VM Exception while processing transaction: revert It is too soon to withdraw funds from this block',
       );
     });
+  });
 
-    it('Should create a passing finalise-withdrawal with a time-jump capable test client (because sufficient time has passed)', async function () {
+  describe('Withdraw funds to layer 1 with a time-jump capable test client (because sufficient time has passed)', () => {
+    let startBalance;
+    let endBalance;
+
+    it('should get a valid withdraw commitment with a time-jump capable test client (because sufficient time has passed)', async function () {
       if (nodeInfo.includes('TestRPC')) await timeJump(3600 * 24 * 10); // jump in time by 10 days
+      const commitments = await nf3User1.getPendingWithdraws();
+      expect(commitments.length).to.be.greaterThan(0);
+      expect(commitments.filter(c => c.valid === true).length).to.be.greaterThan(0);
+    });
 
+    it('should create a passing finalise-withdrawal with a time-jump capable test client (because sufficient time has passed)', async function () {
+      if (nodeInfo.includes('TestRPC')) await timeJump(3600 * 24 * 10); // jump in time by 10 days
       startBalance = await getBalance(nf3User1.ethereumAddress);
       // now we need to sign the transaction and send it to the blockchain
       // this will only work if we're using Ganache, otherwiise expect failure


### PR DESCRIPTION
This PR provides method in the SDK to get the pending withdraws for a wallet and indicates wether they are valid for finalising the withdraw (older than 7 days).

When we take a commitment from the nightfall-client database and use it to form a withdraw transaction, we make the commitment as nullified (markNullified(oldCommitment)).  The difficulty is that if you later on query the db, you won't easily know if the nullified commitment was the input to a withdraw transaction or a transfer transaction - or indeed, what the transactionHash was.

To solve this I've followed this steps:

- Modify `markNullified` to also store the transaction object in a property `transactionNullified` of the commitment document.
- In the `withdraw` and `transfer` methods that call this `markNullified` pass this transaction as parameter (Note that for this case we only need withdraws but we have also manage transfer for future cases).
- Create view function `isValidWithdrawal`  in `Shield.sol` contract similar to what `finaliseWithdrawal` does but only to check if a transaction is valid for finalising the withdrawal.
- Create method `getPendingWithdraws` in the SDK nf3 to get pending withdraws for a pkd. This method will get all pending withdraws in the db based on commitments and filtering by `transactionType=3` that is the type corresponding to withdraws. After that we will check all this pending withdraws for being valid for finalising with the `isValidWithdrawal` method of the `Shield.sol` contract and will return the collection of this pending withdraws with a `valid` additional property that will be `true` in case of being valid to finalise the withdraw and `false` otherwise.
- Added corresponding tests to `test/e2e/nightfall-sdk.test.mjs` to test this new feature that can be tested with `npm run test-e2e`.

Example
```json
{
    "compressedPkd": "0xa47e1471eb85eaf82e72ef8aad52dff32a73e33dccfd2dfde338f0dcfa2585c4",
    "ercAddress": "e1b7b854f19a2cebf96b433ba30050d8890618ab",
    "balance": 10,
    "transactionNullified": {
      "fee": "0x0000000000000000000000000000000000000000000000000000000000000001",
      "historicRootBlockNumberL2": "0x000000000000000000000000000000000000000000000000000000000000000a",
      "transactionType": "0x0000000000000000000000000000000000000000000000000000000000000003",
      "tokenType": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "publicInputHash": "0x008ac05bf45942bcd8394a61476e542ea481003399ba6a5c31b16fc92ad98004",
      "tokenId": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "value": "0x000000000000000000000000000000000000000000000000000000000000000a",
      "ercAddress": "0x000000000000000000000000e1b7B854F19A2CEBF96B433ba30050D8890618ab",
      "recipientAddress": "0x0000000000000000000000009C8B2276D490141Ae1440Da660E470E7C0349C63",
      "commitments": [Array],
      "nullifiers": [Array],
      "compressedSecrets": [Array],
      "proof": [Array],
      "transactionHash": "0x4556e6c35cb00d39e876197e40bffefd943f4eee617c06a599ec388aeb82d95b"
    }
    "valid": false
}
```