### PR TITLE
client chain-reorg functionality

### DIFF
--- a/doc/chain-reorgs.md
+++ b/doc/chain-reorgs.md
@@ -135,37 +135,20 @@ the L2 Block record are relevant, this being the only event that Client subscrib
 we will consider later)  Here is specifically how Client responds:
 
 First, the event removals are created.  If a `BlockProposed` event is removed, then we need to mark the transactions
-that were in that block (assuming they are 'our' transactions and therefore in the Client database) accordingly:
+that were in that block (assuming they are 'our' transactions and therefore in the Client database) accordingly.
 
-#### `BlockProposed` removals
-For Deposit transactions, commitment changes;
-```
-.isDeposited = no change
-.isOnChain = -1
-.isNullified = false
-.isNullifiedOnChain = false
-.isPendingNullification = false
-```
-For Transfer transactions, input commitment changes (can be found by a lookup on the nullifier);
-```
-.isDeposited = no change
-.isOnChain = -1
-.isNullified = false
-.isNullifiedOnChain = false
-.isPendingNullification = false
-```
-For Transfer transactions, output commitments should be deleted because the `proposeBlock` transaction that created
-them has been removed;
+Removal of a block means that commitments and nullifiers which were on-chain (in the sense of being in a proposed block)
+no longer are. Thus we update `.isOnChain` and `.isNullifiedOnChain` to `-1` (these properties hold a blockNumber
+when set, so they're no simply boolean).
 
-For withdraw transactions, the commitment is no longer nullified;
-```
-.isDeposited = no change
-.isOnChain = -1
-.isNullified = false
-.isNullifiedOnChain = false
-.isPendingNullification = false
-```
+This is the simplest approach that we can take, but it's not the full story because the locally determine state
+(`.isNullified`, `isPendingNullification`) is not reset.  That means that these commitments will not be reused
+by Client in new transactions.  That's ok because eventually the transactions will be picked up again by a
+Proposer and placed in a new block.  If we were to clear their internal state then they may be re-spent before
+this happens.  That would create an invalid transaction.
 
-We need to make sure that these properties are appropriately reset, should the block be re-mined. It's also possible that
-client may re-spend a removed commitment before it gets re-mined.  In this case the re-mined block would be open to challenge.
-This tells us that a Proposer must check that their commitment is not in a tx in the L1 mempool before submitting a block!
+A potential complication arises if dependent L2 transactions are taken off-chain.  This is because a Proposer
+may attempt to re-incorporate them into a block in the wrong order (e.g. incorporating a transfer before the
+deposit which enabled it).  If that happens, the dependent transaction will fail the Proposer's check and will
+be dropped.  That's ok though because this mimics the behaviour that an L1 dependent transaction would experience in a
+chain-reorganisation.

--- a/doc/chain-reorgs.md
+++ b/doc/chain-reorgs.md
@@ -142,9 +142,9 @@ For Deposit transactions, commitment changes;
 ```
 .isDeposited = no change
 .isOnChain = -1
-.isNullified = no change
-.isNullifiedOnChain = no change
-.isPendingNullification = no change
+.isNullified = false
+.isNullifiedOnChain = false
+.isPendingNullification = false
 ```
 For Transfer transactions, input commitment changes (can be found by a lookup on the nullifier);
 ```
@@ -165,3 +165,7 @@ For withdraw transactions, the commitment is no longer nullified;
 .isNullifiedOnChain = false
 .isPendingNullification = false
 ```
+
+We need to make sure that these properties are appropriately reset, should the block be re-mined. It's also possible that
+client may re-spend a removed commitment before it gets re-mined.  In this case the re-mined block would be open to challenge.
+This tells us that a Proposer must check that their commitment is not in a tx in the L1 mempool before submitting a block!

--- a/docker-compose.host.docker.internal.yml
+++ b/docker-compose.host.docker.internal.yml
@@ -5,9 +5,10 @@ version: '3.5'
 # See the readme for more information.
 services:
 
-  client1: 
+  client1:
     environment:
       BLOCKCHAIN_WS_HOST: host.docker.internal
+      AUTOSTART_RETRIES: 100
 
   client2:
     environment:
@@ -26,10 +27,12 @@ services:
   timber1:
     environment:
       BLOCKCHAIN_WS_HOST: host.docker.internal
+      AUTOSTART_RETRIES: 100
 
   optimist1:
     environment:
       BLOCKCHAIN_WS_HOST: host.docker.internal
+      AUTOSTART_RETRIES: 100
 
   timber2:
     environment:

--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -31,7 +31,12 @@ async function blockProposedEventHandler(data) {
       // this client and stored during deposit transaction creation. If so, only update that commitment is on chain
       // If not this commitment need not be stored or updated by other clients
       if ((await countCommitments(transaction.commitments)) > 0) {
-        await markOnChain(nonZeroCommitments, blockNumberL2, data.blockNumber);
+        await markOnChain(
+          nonZeroCommitments,
+          blockNumberL2,
+          data.blockNumber,
+          data.transactionHash,
+        );
       }
       // if transaction is single transfer or double transfer
     } else if (transaction.transactionType === '1' || transaction.transactionType === '2') {
@@ -42,8 +47,13 @@ async function blockProposedEventHandler(data) {
       // nothing needs to be stored
       if ((await countCommitments(transaction.commitments)) > 0) {
         await Promise.all([
-          markOnChain(nonZeroCommitments, blockNumberL2, data.blockNumber),
-          markNullifiedOnChain(nonZeroNullifiers, blockNumberL2, data.blockNumber),
+          markOnChain(nonZeroCommitments, blockNumberL2, data.blockNumber, data.transactionHash),
+          markNullifiedOnChain(
+            nonZeroNullifiers,
+            blockNumberL2,
+            data.blockNumber,
+            data.transactionHash,
+          ),
         ]);
       } else {
         // eslint-disable-next-line consistent-return
@@ -60,7 +70,12 @@ async function blockProposedEventHandler(data) {
             else {
               // store commitment if the new commitment in this transaction is intended for this client
               await storeCommitment(commitment, nsks[i]);
-              await markOnChain(nonZeroCommitments, blockNumberL2, data.blockNumber);
+              await markOnChain(
+                nonZeroCommitments,
+                blockNumberL2,
+                data.blockNumber,
+                data.transactionHash,
+              );
               return false; // to exit every() loop once the a key has successfully decrypted the secrets of the transaction
             }
           } catch (err) {
@@ -75,7 +90,12 @@ async function blockProposedEventHandler(data) {
       // this client and stored during withdraw transaction creation. If so, only update that nullifier is on chain
       // If not this nullifier need not be stored or updated by other clients
       if ((await countNullifiers(transaction.nullifiers)) > 0) {
-        await markNullifiedOnChain(nonZeroNullifiers, blockNumberL2, data.blockNumber);
+        await markNullifiedOnChain(
+          nonZeroNullifiers,
+          blockNumberL2,
+          data.blockNumber,
+          data.transactionHash,
+        );
       }
     } else logger.error('Transaction type is invalid. Transaction type is', transaction.Type);
   });

--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -20,85 +20,87 @@ async function blockProposedEventHandler(data) {
   logger.info(`Received Block Proposed event`);
   // ivk will be used to decrypt secrets whilst nsk will be used to calculate nullifiers for commitments and store them
   const { transactions, blockNumberL2 } = await getProposeBlockCalldata(data);
-
-  transactions.forEach(async transaction => {
-    // filter out non zero commitments and nullifiers
-    const nonZeroCommitments = transaction.commitments.flat().filter(n => n !== ZERO);
-    const nonZeroNullifiers = transaction.nullifiers.flat().filter(n => n !== ZERO);
-    // if transaction is deposit
-    if (transaction.transactionType === '0') {
-      // if the commitment from deposit is already stored in database, then this commitment has been created by
-      // this client and stored during deposit transaction creation. If so, only update that commitment is on chain
-      // If not this commitment need not be stored or updated by other clients
-      if ((await countCommitments(transaction.commitments)) > 0) {
-        await markOnChain(
-          nonZeroCommitments,
-          blockNumberL2,
-          data.blockNumber,
-          data.transactionHash,
-        );
-      }
-      // if transaction is single transfer or double transfer
-    } else if (transaction.transactionType === '1' || transaction.transactionType === '2') {
-      // if the commitment from transfer is already stored in database, then this commitment(s) has(ve) been created by
-      // this client and stored during transfer transaction creation. If so, only update that this(ese) commitment(s) is(are)
-      // on chain. If not, a decryption of the secrets will be done by the recipient client. If the decryption is successful,
-      // then the commitment will be stored in the database and will be marked as on chain. If the decryption is unsuccessful,
-      // nothing needs to be stored
-      if ((await countCommitments(transaction.commitments)) > 0) {
-        await Promise.all([
-          markOnChain(nonZeroCommitments, blockNumberL2, data.blockNumber, data.transactionHash),
-          markNullifiedOnChain(
+  // we return a promise so that the queue awaits this function properly
+  return Promise.all(
+    transactions.map(async transaction => {
+      // filter out non zero commitments and nullifiers
+      const nonZeroCommitments = transaction.commitments.flat().filter(n => n !== ZERO);
+      const nonZeroNullifiers = transaction.nullifiers.flat().filter(n => n !== ZERO);
+      // if transaction is deposit
+      if (transaction.transactionType === '0') {
+        // if the commitment from deposit is already stored in database, then this commitment has been created by
+        // this client and stored during deposit transaction creation. If so, only update that commitment is on chain
+        // If not this commitment need not be stored or updated by other clients
+        if ((await countCommitments(transaction.commitments)) > 0) {
+          await markOnChain(
+            nonZeroCommitments,
+            blockNumberL2,
+            data.blockNumber,
+            data.transactionHash,
+          );
+        }
+        // if transaction is single transfer or double transfer
+      } else if (transaction.transactionType === '1' || transaction.transactionType === '2') {
+        // if the commitment from transfer is already stored in database, then this commitment(s) has(ve) been created by
+        // this client and stored during transfer transaction creation. If so, only update that this(ese) commitment(s) is(are)
+        // on chain. If not, a decryption of the secrets will be done by the recipient client. If the decryption is successful,
+        // then the commitment will be stored in the database and will be marked as on chain. If the decryption is unsuccessful,
+        // nothing needs to be stored
+        if ((await countCommitments(transaction.commitments)) > 0) {
+          await Promise.all([
+            markOnChain(nonZeroCommitments, blockNumberL2, data.blockNumber, data.transactionHash),
+            markNullifiedOnChain(
+              nonZeroNullifiers,
+              blockNumberL2,
+              data.blockNumber,
+              data.transactionHash,
+            ),
+          ]);
+        } else {
+          // eslint-disable-next-line consistent-return
+          ivks.every(async (key, i) => {
+            // decompress the secrets first and then we will decrypt the secrets from this
+            const decompressedSecrets = Secrets.decompressSecrets(transaction.compressedSecrets);
+            try {
+              const commitment = Secrets.decryptSecrets(
+                decompressedSecrets,
+                key,
+                transaction.commitments[0],
+              );
+              if (commitment === {}) logger.info("This encrypted message isn't for this recipient");
+              else {
+                // store commitment if the new commitment in this transaction is intended for this client
+                await storeCommitment(commitment, nsks[i]);
+                await markOnChain(
+                  nonZeroCommitments,
+                  blockNumberL2,
+                  data.blockNumber,
+                  data.transactionHash,
+                );
+                return false; // to exit every() loop once the a key has successfully decrypted the secrets of the transaction
+              }
+            } catch (err) {
+              logger.info(err);
+              logger.info("This encrypted message isn't for this recipient");
+            }
+          });
+        }
+        // if transaction is withdraw
+      } else if (transaction.transactionType === '3') {
+        // if the nullifier from withdraw is already stored in database, then this nullifier has been created by
+        // this client and stored during withdraw transaction creation. If so, only update that nullifier is on chain
+        // If not this nullifier need not be stored or updated by other clients
+        if ((await countNullifiers(transaction.nullifiers)) > 0) {
+          await markNullifiedOnChain(
             nonZeroNullifiers,
             blockNumberL2,
             data.blockNumber,
             data.transactionHash,
-          ),
-        ]);
-      } else {
-        // eslint-disable-next-line consistent-return
-        ivks.every(async (key, i) => {
-          // decompress the secrets first and then we will decrypt the secrets from this
-          const decompressedSecrets = Secrets.decompressSecrets(transaction.compressedSecrets);
-          try {
-            const commitment = Secrets.decryptSecrets(
-              decompressedSecrets,
-              key,
-              transaction.commitments[0],
-            );
-            if (commitment === {}) logger.info("This encrypted message isn't for this recipient");
-            else {
-              // store commitment if the new commitment in this transaction is intended for this client
-              await storeCommitment(commitment, nsks[i]);
-              await markOnChain(
-                nonZeroCommitments,
-                blockNumberL2,
-                data.blockNumber,
-                data.transactionHash,
-              );
-              return false; // to exit every() loop once the a key has successfully decrypted the secrets of the transaction
-            }
-          } catch (err) {
-            logger.info(err);
-            logger.info("This encrypted message isn't for this recipient");
-          }
-        });
-      }
-      // if transaction is withdraw
-    } else if (transaction.transactionType === '3') {
-      // if the nullifier from withdraw is already stored in database, then this nullifier has been created by
-      // this client and stored during withdraw transaction creation. If so, only update that nullifier is on chain
-      // If not this nullifier need not be stored or updated by other clients
-      if ((await countNullifiers(transaction.nullifiers)) > 0) {
-        await markNullifiedOnChain(
-          nonZeroNullifiers,
-          blockNumberL2,
-          data.blockNumber,
-          data.transactionHash,
-        );
-      }
-    } else logger.error('Transaction type is invalid. Transaction type is', transaction.Type);
-  });
+          );
+        }
+      } else logger.error('Transaction type is invalid. Transaction type is', transaction.Type);
+    }),
+  );
 }
 
 export default blockProposedEventHandler;

--- a/nightfall-client/src/event-handlers/chain-reorg.mjs
+++ b/nightfall-client/src/event-handlers/chain-reorg.mjs
@@ -8,55 +8,29 @@ the result of a layer 1 chain reorganisation.
 function to update the state of a commitment following the removal of a
 BlockProposed event.
 */
-import { Mutex } from 'async-mutex';
 import logger from 'common-files/utils/logger.mjs';
 import {
   getCommitmentsByTransactionHashL1,
-  getOutputCommitmentsByTransactionHashL1,
-  deleteCommitments,
+  getNullifiedByTransactionHashL1,
   updateCommitment,
 } from '../services/commitment-storage.mjs';
 
-const mutex = new Mutex();
-
-// function to get all generations of output commitments
-async function recurseOutputCommitments(transactionHash, outputCommitments) {
-  const ocs = await getOutputCommitmentsByTransactionHashL1(transactionHash);
-  if (ocs.length === 0) return outputCommitments;
-  await mutex.runExclusive(() => outputCommitments.push(...ocs));
-  return Promise.all(
-    ocs.map(oc => recurseOutputCommitments(oc.transactionHashCommittedL1, outputCommitments)),
-  );
-}
-
-export async function removeBlockProposedEventHandler(eventObject) {
+async function removeBlockProposedEventHandler(eventObject) {
   logger.info('Received block proposed removal event');
   // let's get the L1 transactionHash that created the block, we can use this
-  // to pull the commitment from the L2 database
+  // to pull the commitments and nullifiers in the block from the L2 database
   const { transactionHash } = eventObject;
-  const commitments = await getCommitmentsByTransactionHashL1(transactionHash);
-  logger.debug(`Found these commitments in the db ${JSON.stringify(commitments, null, 2)}`);
+  const commitmentsAddedInBlock = await getCommitmentsByTransactionHashL1(transactionHash);
+  const commitmentsNullifiedInBlock = await getNullifiedByTransactionHashL1(transactionHash);
+  logger.debug(
+    `Found these commitments in the db ${JSON.stringify(commitmentsAddedInBlock, null, 2)}`,
+  );
   // now we have these commitments, we need to reset their properties according to the
   // instructions in doc/chain-reorgs.md.
-  const processedCommitments = commitments.map(ct => {
-    const c = ct;
-    c.isOnChain = -1;
-    c.isNullified = false;
-    c.isNullifiedOnChain = false;
-    c.isPendingNullification = false;
-    return c;
-  });
-  // should we await this?
-  processedCommitments.forEach((c, i) => updateCommitment(commitments[i], processedCommitments[i]));
-  console.log('Processed Commitments are', processedCommitments);
-  // we have one more job, and that's to delete the output commitments (if any)
-  // that were created from these commitments. There may more than one generation
-  // of output commitments. We get them all.
-  // const outputCommitments = await recurseOutputCommitments(transactionHash, []);
-  // await deleteCommitments(outputCommitments.map(c => c._id));
-  // console.log('Found output commitments', outputCommitments);
+  return Promise.all([
+    ...commitmentsAddedInBlock.map(c => updateCommitment(c, { isOnChain: -1 })),
+    ...commitmentsNullifiedInBlock.map(c => updateCommitment(c, { isNullifiedOnChain: -1 })),
+  ]);
 }
 
-export async function removeTransactionSubmittedEventHandler(eventObject) {
-  console.log('TRANSACTIONSUBMITTEDREMOVED', eventObject);
-}
+export default removeBlockProposedEventHandler;

--- a/nightfall-client/src/event-handlers/chain-reorg.mjs
+++ b/nightfall-client/src/event-handlers/chain-reorg.mjs
@@ -8,8 +8,26 @@ the result of a layer 1 chain reorganisation.
 function to update the state of a commitment following the removal of a
 BlockProposed event.
 */
+import { Mutex } from 'async-mutex';
 import logger from 'common-files/utils/logger.mjs';
-import { getCommitmentsByTransactionHashL1 } from '../services/commitment-storage.mjs';
+import {
+  getCommitmentsByTransactionHashL1,
+  getOutputCommitmentsByTransactionHashL1,
+  deleteCommitments,
+  updateCommitment,
+} from '../services/commitment-storage.mjs';
+
+const mutex = new Mutex();
+
+// function to get all generations of output commitments
+async function recurseOutputCommitments(transactionHash, outputCommitments) {
+  const ocs = await getOutputCommitmentsByTransactionHashL1(transactionHash);
+  if (ocs.length === 0) return outputCommitments;
+  await mutex.runExclusive(() => outputCommitments.push(...ocs));
+  return Promise.all(
+    ocs.map(oc => recurseOutputCommitments(oc.transactionHashCommittedL1, outputCommitments)),
+  );
+}
 
 export async function removeBlockProposedEventHandler(eventObject) {
   logger.info('Received block proposed removal event');
@@ -17,7 +35,26 @@ export async function removeBlockProposedEventHandler(eventObject) {
   // to pull the commitment from the L2 database
   const { transactionHash } = eventObject;
   const commitments = await getCommitmentsByTransactionHashL1(transactionHash);
-  logger.debug(`Found these commitments in the db ${JSON.stringify}`)
+  logger.debug(`Found these commitments in the db ${JSON.stringify(commitments, null, 2)}`);
+  // now we have these commitments, we need to reset their properties according to the
+  // instructions in doc/chain-reorgs.md.
+  const processedCommitments = commitments.map(ct => {
+    const c = ct;
+    c.isOnChain = -1;
+    c.isNullified = false;
+    c.isNullifiedOnChain = false;
+    c.isPendingNullification = false;
+    return c;
+  });
+  // should we await this?
+  processedCommitments.forEach((c, i) => updateCommitment(commitments[i], processedCommitments[i]));
+  console.log('Processed Commitments are', processedCommitments);
+  // we have one more job, and that's to delete the output commitments (if any)
+  // that were created from these commitments. There may more than one generation
+  // of output commitments. We get them all.
+  // const outputCommitments = await recurseOutputCommitments(transactionHash, []);
+  // await deleteCommitments(outputCommitments.map(c => c._id));
+  // console.log('Found output commitments', outputCommitments);
 }
 
 export async function removeTransactionSubmittedEventHandler(eventObject) {

--- a/nightfall-client/src/event-handlers/chain-reorg.mjs
+++ b/nightfall-client/src/event-handlers/chain-reorg.mjs
@@ -1,0 +1,25 @@
+/**
+@module chain-reorg.mjs
+@desc This module contains functions for handling updates to the layer 2 state as
+the result of a layer 1 chain reorganisation.
+*/
+
+/**
+function to update the state of a commitment following the removal of a
+BlockProposed event.
+*/
+import logger from 'common-files/utils/logger.mjs';
+import { getCommitmentsByTransactionHashL1 } from '../services/commitment-storage.mjs';
+
+export async function removeBlockProposedEventHandler(eventObject) {
+  logger.info('Received block proposed removal event');
+  // let's get the L1 transactionHash that created the block, we can use this
+  // to pull the commitment from the L2 database
+  const { transactionHash } = eventObject;
+  const commitments = await getCommitmentsByTransactionHashL1(transactionHash);
+  logger.debug(`Found these commitments in the db ${JSON.stringify}`)
+}
+
+export async function removeTransactionSubmittedEventHandler(eventObject) {
+  console.log('TRANSACTIONSUBMITTEDREMOVED', eventObject);
+}

--- a/nightfall-client/src/event-handlers/index.mjs
+++ b/nightfall-client/src/event-handlers/index.mjs
@@ -1,7 +1,7 @@
 import { startEventQueue } from './subscribe.mjs';
 import blockProposedEventHandler from './block-proposed.mjs';
 import rollbackEventHandler from './rollback.mjs';
-import { removeBlockProposedEventHandler } from './chain-reorg.mjs';
+import removeBlockProposedEventHandler from './chain-reorg.mjs';
 
 const eventHandlers = {
   BlockProposed: blockProposedEventHandler,

--- a/nightfall-client/src/event-handlers/index.mjs
+++ b/nightfall-client/src/event-handlers/index.mjs
@@ -1,13 +1,14 @@
 import { startEventQueue } from './subscribe.mjs';
 import blockProposedEventHandler from './block-proposed.mjs';
 import rollbackEventHandler from './rollback.mjs';
+import { removeBlockProposedEventHandler } from './chain-reorg.mjs';
 
 const eventHandlers = {
   BlockProposed: blockProposedEventHandler,
   Rollback: rollbackEventHandler,
-  // removers: {
-  // BlockProposed: removeBlockProposedEventHandler,
-  // },
+  removers: {
+    BlockProposed: removeBlockProposedEventHandler,
+  },
   priority: {
     BlockProposed: 0,
     Rollback: 0,

--- a/nightfall-client/src/event-handlers/subscribe.mjs
+++ b/nightfall-client/src/event-handlers/subscribe.mjs
@@ -42,6 +42,7 @@ async function waitForContract(contractName) {
 export async function startEventQueue(callback, ...args) {
   const emitter = (await waitForContract(STATE_CONTRACT_NAME)).events.allEvents();
   emitter.on('data', event => callback(event, args));
+  emitter.on('changed', event => callback(event, args));
   logger.debug('Subscribed to layer 2 state events');
   return emitter;
 }

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -37,9 +37,7 @@ export async function storeCommitment(commitment, nsk) {
   };
   // a chain reorg may cause an attempted overwrite. We should allow this, hence
   // the use of replaceOne.
-  return db
-    .collection(COMMITMENTS_COLLECTION)
-    .replaceOne({ _id: commitment.hash.hex(32) }, data, { upsert: true });
+  return db.collection(COMMITMENTS_COLLECTION).insertOne(data);
 }
 // function to update an existing commitment
 export async function updateCommitment(commitment, updates) {

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -30,12 +30,16 @@ export async function storeCommitment(commitment, nsk) {
     isOnChain: Number(commitment.isOnChain) || -1,
     isPendingNullification: false, // will not be pending when stored
     isNullified: commitment.isNullified,
-    isNullifiedOnChain: Number(commitment.isNullifiedOnChain),
+    isNullifiedOnChain: Number(commitment.isNullifiedOnChain) || -1,
     nullifier: nullifierHash,
     blockNumber: -1,
     transactionNullified: null,
   };
-  return db.collection(COMMITMENTS_COLLECTION).insertOne(data);
+  // a chain reorg may cause an attempted overwrite. We should allow this, hence
+  // the use of replaceOne.
+  return db
+    .collection(COMMITMENTS_COLLECTION)
+    .replaceOne({ _id: commitment.hash.hex(32) }, data, { upsert: true });
 }
 // function to update an existing commitment
 export async function updateCommitment(commitment, updates) {
@@ -109,30 +113,20 @@ export async function getCommitmentBySalt(salt) {
   return commitments;
 }
 
-// function to retrieve commitment by transactionHash of the block in which it was
+// function to retrieve commitments by transactionHash of the block in which they were
 // committed to
 export async function getCommitmentsByTransactionHashL1(transactionHashCommittedL1) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(COMMITMENTS_DB);
   return db.collection(COMMITMENTS_COLLECTION).find({ transactionHashCommittedL1 }).toArray();
 }
-
-// function to retrieve the output commitments from a nullified input commitment
-export async function getOutputCommitmentsByTransactionHashL1(transactionHashCommittedL1) {
+// function to retrieve commitments by transactionhash of the block in which they were
+// nullified
+export async function getNullifiedByTransactionHashL1(transactionHashNullifiedL1) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(COMMITMENTS_DB);
-  const query = { transactionHashCommittedL1, transactionHashNullified: { $exists: true } };
-  const options = { projection: { transactionHashNullified: 1, _id: 0 } };
-  const transactionHashesNullified = await db
-    .collection(COMMITMENTS_COLLECTION)
-    .find(query, options)
-    .toArray();
-  const outputCommitments = transactionHashesNullified.map(t =>
-    getCommitmentsByTransactionHashL1(t),
-  );
-  return Promise.all(outputCommitments);
+  return db.collection(COMMITMENTS_COLLECTION).find({ transactionHashNullifiedL1 }).toArray();
 }
-
 /*
 function to clear a commitments nullified status after a rollback.
 commitments have two stages of nullification (1) when they are spent by Client
@@ -183,7 +177,7 @@ export async function markNullifiedOnChain(
   nullifiers,
   blockNumberL2,
   blockNumber,
-  transactionHashNullifiedL1,
+  transactionHashNullifiedL1, // the tx in which the nullification happened
 ) {
   const connection = await mongo.connection(MONGO_URL);
   const query = { nullifier: { $in: nullifiers }, isNullifiedOnChain: { $eq: -1 } };

--- a/nightfall-optimist/src/event-handlers/block-proposed.mjs
+++ b/nightfall-optimist/src/event-handlers/block-proposed.mjs
@@ -49,8 +49,6 @@ async function blockProposedEventHandler(data) {
     const latestTree = await getLatestTree();
     const blockCommitments = transactions.map(t => t.commitments.filter(c => c !== ZERO)).flat();
     const updatedTimber = Timber.statelessUpdate(latestTree, blockCommitments);
-    // latestTree.insertLeaves(blockCommitments);
-    // logger.info(`latestTree leafCount: ${latestTree.leafCount}`);
     const res = await saveTree(currentBlockCount, block.blockNumberL2, updatedTimber);
     logger.debug(`Saving tree with block number ${block.blockNumberL2}, ${res}`);
     // signal to the block-making routines that a block is received: they

--- a/nightfall-optimist/src/event-handlers/block-proposed.mjs
+++ b/nightfall-optimist/src/event-handlers/block-proposed.mjs
@@ -51,7 +51,8 @@ async function blockProposedEventHandler(data) {
     const updatedTimber = Timber.statelessUpdate(latestTree, blockCommitments);
     // latestTree.insertLeaves(blockCommitments);
     // logger.info(`latestTree leafCount: ${latestTree.leafCount}`);
-    await saveTree(currentBlockCount, block.blockNumberL2, updatedTimber);
+    const res = await saveTree(currentBlockCount, block.blockNumberL2, updatedTimber);
+    logger.debug(`Saving tree with block number ${block.blockNumberL2}, ${res}`);
     // signal to the block-making routines that a block is received: they
     // won't make a new block until their previous one is stored on-chain.
     // we'll check the block and issue a challenge if appropriate

--- a/nightfall-optimist/src/event-handlers/chain-reorg.mjs
+++ b/nightfall-optimist/src/event-handlers/chain-reorg.mjs
@@ -74,7 +74,8 @@ export async function removeBlockProposedEventHandler(eventObject) {
   // so find out which L2 block has been removed by this event removal.
   const block = await getBlockByTransactionHashL1(eventObject.transactionHash);
   // then we delete the Timber record associated with this block
-  await deleteTreeByBlockNumberL2(block.blockNumberL2);
+  const res = await deleteTreeByBlockNumberL2(block.blockNumberL2);
+  logger.debug(`Deleted tree with block number ${block.blockNumberL2}, ${res}`);
   // now we can clear the L1 blocknumber to indicate that the L2 block is no longer
   // on chain.
   return clearBlockNumberL1ForBlock(eventObject.transactionHash);

--- a/nightfall-optimist/src/event-handlers/chain-reorg.mjs
+++ b/nightfall-optimist/src/event-handlers/chain-reorg.mjs
@@ -64,6 +64,7 @@ import {
   isRegisteredProposerAddressMine,
   getBlockByTransactionHashL1,
   deleteTreeByBlockNumberL2,
+  deleteNullifiersForBlock,
 } from '../services/database.mjs';
 import { waitForContract } from './subscribe.mjs';
 
@@ -76,6 +77,9 @@ export async function removeBlockProposedEventHandler(eventObject) {
   // then we delete the Timber record associated with this block
   const res = await deleteTreeByBlockNumberL2(block.blockNumberL2);
   logger.debug(`Deleted tree with block number ${block.blockNumberL2}, ${res}`);
+  // we also need to remove any nullifiers that were added by this block, because
+  // they're no longer valid.
+  await deleteNullifiersForBlock(block.blockHash);
   // now we can clear the L1 blocknumber to indicate that the L2 block is no longer
   // on chain.
   return clearBlockNumberL1ForBlock(eventObject.transactionHash);

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -424,11 +424,19 @@ export async function resetNullifiers(blockHash) {
   return db.collection(NULLIFIER_COLLECTION).updateMany(query, update);
 }
 
-// delete all the nullifiers in this block
+// delete nullifiers by nullifier value
 export async function deleteNullifiers(hashes) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   const query = { hash: { $in: hashes } };
+  return db.collection(NULLIFIER_COLLECTION).deleteMany(query);
+}
+
+// delete all the nullifiers in this block
+export async function deleteNullifiersForBlock(blockHash) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  const query = { blockHash };
   return db.collection(NULLIFIER_COLLECTION).deleteMany(query);
 }
 

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -158,7 +158,7 @@ export async function getBlockByRoot(root) {
   return db.collection(SUBMITTED_BLOCKS_COLLECTION).findOne(query);
 }
 
-/** 
+/**
 get the latest blockNumberL2 in our database
 */
 export async function getLatestBlockInfo() {
@@ -466,7 +466,8 @@ export async function saveTree(blockNumber, blockNumberL2, timber) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   return db.collection(TIMBER_COLLECTION).insertOne({
-    _id: blockNumber,
+    _id: timber.root,
+    blockNumber,
     blockNumberL2,
     frontier: timber.frontier,
     leafCount: timber.leafCount,
@@ -480,7 +481,7 @@ export async function getLatestTree() {
   const timberObjArr = await db
     .collection(TIMBER_COLLECTION)
     .find()
-    .sort({ _id: -1 })
+    .sort({ blockNumberL2: -1 })
     .limit(1)
     .toArray();
 

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -474,7 +474,7 @@ export async function saveTree(blockNumber, blockNumberL2, timber) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   return db.collection(TIMBER_COLLECTION).insertOne({
-    _id: timber.root,
+    _id: timber.blockNumberL2,
     blockNumber,
     blockNumberL2,
     frontier: timber.frontier,

--- a/test/chain-reorg.mjs
+++ b/test/chain-reorg.mjs
@@ -49,7 +49,7 @@ describe('Testing the http API', () => {
   const txPerBlock = 2;
   const eventLogs = [];
 
-  const doDeposits = async numDeposits => {
+  const doDeposits = async (numDeposits, amount = value) => {
     // We create enough transactions to fill numDeposits blocks full of deposits.
     const depositTransactions = (
       await Promise.all(
@@ -57,7 +57,7 @@ describe('Testing the http API', () => {
           chai
             .request(url)
             .post('/deposit')
-            .send({ ercAddress, tokenId, tokenType, value, pkd: pkd1, nsk: nsk1, fee }),
+            .send({ ercAddress, tokenId, tokenType, value: amount, pkd: pkd1, nsk: nsk1, fee }),
         ),
       )
     ).map(res => res.body);
@@ -252,10 +252,12 @@ describe('Testing the http API', () => {
 
   describe('Start a normal chain', () => {
     // we start by just sending enough deposits to fill one block
+    // these have a bumped up value so they won't be picked for inputs to the
+    // single transfer
     // set the number of deposit transactions blocks to perform.
     const numDeposits = 1;
     it('should deposit enough crypto into fork to fill one layer 2 block', async () => {
-      await expect(doDeposits(numDeposits)).to.eventually.be.fulfilled;
+      await expect(doDeposits(numDeposits, value + 1)).to.eventually.be.fulfilled;
       console.log('     BlockNumber is:', await web3.eth.getBlockNumber());
     });
   });

--- a/test/chain-reorg.mjs
+++ b/test/chain-reorg.mjs
@@ -28,7 +28,7 @@ describe('Testing the http API', () => {
   let ercAddress;
   let connection; // WS connection
   let web3;
-  // let ask1;
+  let ask1;
   let nsk1;
   let ivk1;
   let pkd1;
@@ -87,6 +87,59 @@ describe('Testing the http API', () => {
     return receiptArrays;
   };
 
+  const doDepositsAndTransfer = async numDeposits => {
+    // We create enough transactions to fill numDeposits blocks full of deposits and one transfer
+    const depositTransactions = (
+      await Promise.all(
+        Array.from({ length: txPerBlock * numDeposits - 1 }, () =>
+          chai
+            .request(url)
+            .post('/deposit')
+            .send({ ercAddress, tokenId, tokenType, value, pkd: pkd1, nsk: nsk1, fee }),
+        ),
+      )
+    ).map(res => res.body);
+    const transferTransaction = await chai
+      .request(url)
+      .post('/transfer')
+      .send({
+        ercAddress,
+        tokenId,
+        recipientData: {
+          values: [value],
+          recipientPkds: [pkd1],
+        },
+        nsk: nsk1,
+        ask: ask1,
+        fee,
+      });
+    const transactions = depositTransactions.concat(transferTransaction.body);
+    transactions.forEach(({ txDataToSign }) => expect(txDataToSign).to.be.a('string'));
+    const receiptArrays = [];
+    for (let i = 0; i < transactions.length; i++) {
+      const { txDataToSign } = transactions[i];
+      receiptArrays.push(
+        // eslint-disable-next-line no-await-in-loop
+        await submitTransaction(txDataToSign, privateKey, shieldAddress, gas, fee),
+        // we need to await here as we need transactions to be submitted sequentially or we run into nonce issues.
+      );
+    }
+    receiptArrays.forEach(receipt => {
+      expect(receipt).to.have.property('transactionHash');
+      expect(receipt).to.have.property('blockHash');
+    });
+    // Wait until we see the right number of blocks appear
+    while (eventLogs.length !== numDeposits) {
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise(resolve => setTimeout(resolve, 3000));
+    }
+    // Now we can empty the event queue
+    for (let i = 0; i < numDeposits; i++) {
+      eventLogs.shift();
+    }
+    return receiptArrays;
+  };
+
   before(async () => {
     web3 = await connectWeb3();
 
@@ -112,6 +165,7 @@ describe('Testing the http API', () => {
       nsk: nsk1,
       ivk: ivk1,
       pkd: pkd1,
+      ask: ask1,
     } = (
       await chai.request(url).post('/generate-keys').send({ mnemonic, path: `m/44'/60'/0'/0` })
     ).body);
@@ -223,6 +277,9 @@ describe('Testing the http API', () => {
       await new Promise(resolve => setTimeout(resolve, 60000));
       console.log('     Creating one block of deposit transactions with node set 1');
       receipts = await doDeposits(numDeposits); // add transactions to the other half
+      console.log('     Block created');
+      console.log('     Creating one block of a deposit and a single transfer with node set 1');
+      receipts = await doDepositsAndTransfer(numDeposits);
       console.log('     Block created');
       // test the receipts are good.
       const recs = await Promise.all(

--- a/timber/src/filter-controller.mjs
+++ b/timber/src/filter-controller.mjs
@@ -230,12 +230,14 @@ async function removeBlockProposedFunction(eventObject, args) {
   // we can search for the event in Timber's history and extract the leafCount
   const historyService = new HistoryService(db);
   const history = await historyService.getTreeHistoryByTransactionHash(transactionHash);
-  //
-  // Now, the leafCount just before this block was added was block.leafCount
-  // that's where we need to roll back to.
+  // check we do actually have such a history. We could get multiple removals of
+  // block proposed events coming together in undefined order. It's possible that
+  // an earlier rollback has already removed the tree history.  That's fine, our
+  // work is already done.
+  if (!history) return true;
+  // Now, the leafCount just before this block was added was history.currentLeafCount.
+  // That's where we need to roll back to.
   return mtc.rollback(db, treeHeight, Number(history.currentLeafCount));
-  // and now we need to roll forwards to the present, along our new timeline
-  // return resync(blockNumber, args);
 }
 
 /**


### PR DESCRIPTION
fixes #205 

This PR provides the capability to nightfall-client to cope with a chain reorganisation and to update its L2 database to reflect the new truth of the cannonical chain.  It can currently handle removal of `blockProposed` events by a chain-reorg but not removal of an L2 `rollback` event.  That will be a later PR. 

A new eventHandler has been added that runs when removal of a `blockProposed` event occurs and performs the L2 database updates.  These are actually just resetting information for commitments and nullifications that have been marked as on-chain.  The logic for this approach is discussed [here](https://github.com/EYBlockchain/nightfall_3/blob/westlad/client-reorg/doc/chain-reorgs.md#layer-2-client).

To test, you need to run up the local Geth blockchain, which has the ability to force chain-reorgs by pausing some of the docker containers.  Do:
```sh
./geth-standalone -s #starts the chain
./geth-standalone -l #starts logging to the terminal
```
Wait until the DAG generation is complete then run up nightfall_3  in another terminal with options to connect it to the Geth chain (`./start-nightfall -l -s`). Then finally run the test in a third terminal: `npm run test-chain-reorg`.