### PR TITLE
Docker images and release

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -18,7 +18,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Login to docker registry
-      run: docker login ghcr.io -u ${{ github.actor }} -p $GITHUB_TOKEN
+      run: docker login ghcr.io -u $GITHUB_ACTOR -p $GITHUB_TOKEN
 
     - name: Build docker client image
       run: docker build . -f client.Dockerfile

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - miranda/docker-images
 
 jobs:
   release:

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,5 +1,5 @@
 name: Release
-
+// MON change to gchr.io
 on:
   push:
     branches:
@@ -16,7 +16,9 @@ jobs:
       id: semantic
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: Login to docker registry
+      run: docker login ghcr.io -u ${{ github.actor }} -p $GITHUB_TOKEN
 
     - name: Build docker client image
       run: docker build . -f client.Dockerfile
@@ -26,9 +28,8 @@ jobs:
     - name: Docker push version
       if: steps.semantic.outputs.new-release-published == 'true'
       run: |
-        docker login https://docker.pkg.github.com -u $GITHUB_ACTOR -p $GITHUB_TOKEN
-        docker build -t docker.pkg.github.com/eyblockchain/TODO/TODO:$RELEASE_VERSION . -f client.Dockerfile
-        docker push docker.pkg.github.com/eyblockchain/TODO/TODO:$RELEASE_VERSION
+        docker build -t ghcr.io/eyblockchain/nightfall3-client:$RELEASE_VERSION . -f client.Dockerfile
+        docker push ghcr.io/eyblockchain//nightfall3-client:$RELEASE_VERSION
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -40,9 +41,8 @@ jobs:
     - name: Docker push version
       if: steps.semantic.outputs.new-release-published == 'true'
       run: |
-        docker login https://docker.pkg.github.com -u $GITHUB_ACTOR -p $GITHUB_TOKEN
-        docker build -t docker.pkg.github.com/eyblockchain/TODO/TODO:$RELEASE_VERSION . -f worker.Dockerfile
-        docker push docker.pkg.github.com/eyblockchain/TODO/TODO:$RELEASE_VERSION
+        docker build -t ghcr.io/eyblockchain/nightfall3-worker:$RELEASE_VERSION . -f worker.Dockerfile
+        docker push ghcr.io/eyblockchain/nightfall3-worker:$RELEASE_VERSION
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -54,9 +54,8 @@ jobs:
     - name: Docker push version
       if: steps.semantic.outputs.new-release-published == 'true'
       run: |
-        docker login https://docker.pkg.github.com -u $GITHUB_ACTOR -p $GITHUB_TOKEN
-        docker build -t docker.pkg.github.com/eyblockchain/TODO/TODO:$RELEASE_VERSION . -f deployer.Dockerfile
-        docker push docker.pkg.github.com/eyblockchain/TODO/TODO:$RELEASE_VERSION
+        docker build -t ghcr.io/eyblockchain/nightfall3-deployer:$RELEASE_VERSION . -f deployer.Dockerfile
+        docker push ghcr.io/eyblockchain/nightfall3-deployer:$RELEASE_VERSION
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -68,8 +67,7 @@ jobs:
     - name: Docker push version
       if: steps.semantic.outputs.new-release-published == 'true'
       run: |
-        docker login https://docker.pkg.github.com -u $GITHUB_ACTOR -p $GITHUB_TOKEN
-        docker build -t docker.pkg.github.com/eyblockchain/TODO/TODO:$RELEASE_VERSION . -f optimist.Dockerfile
-        docker push docker.pkg.github.com/eyblockchain/TODO/TODO:$RELEASE_VERSION
+        docker build -t ghcr.io/eyblockchain/nightfall3-optimist:$RELEASE_VERSION . -f optimist.Dockerfile
+        docker push ghcr.io/eyblockchain/nightfall3-optimist:$RELEASE_VERSION
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,5 +1,4 @@
-name: Release
-// MON change to gchr.io
+name: "Publish docker images"
 on:
   push:
     branches:

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - uses: codfish/semantic-release-action@master
+      id: semantic
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: Build docker client image
+      run: docker build . -f client.Dockerfile
+
+    - run: echo ${{ steps.semantic.outputs.release-version }}
+
+    - name: Docker push version
+      if: steps.semantic.outputs.new-release-published == 'true'
+      run: |
+        docker login https://docker.pkg.github.com -u $GITHUB_ACTOR -p $GITHUB_TOKEN
+        docker build -t docker.pkg.github.com/eyblockchain/TODO/TODO:$RELEASE_VERSION . -f client.Dockerfile
+        docker push docker.pkg.github.com/eyblockchain/TODO/TODO:$RELEASE_VERSION
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build docker zokrates worker image
+      run: docker build . -f worker.Dockerfile
+
+    - run: echo ${{ steps.semantic.outputs.release-version }}
+
+    - name: Docker push version
+      if: steps.semantic.outputs.new-release-published == 'true'
+      run: |
+        docker login https://docker.pkg.github.com -u $GITHUB_ACTOR -p $GITHUB_TOKEN
+        docker build -t docker.pkg.github.com/eyblockchain/TODO/TODO:$RELEASE_VERSION . -f worker.Dockerfile
+        docker push docker.pkg.github.com/eyblockchain/TODO/TODO:$RELEASE_VERSION
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build docker deployer image
+      run: docker build . -f deployer.Dockerfile
+
+    - run: echo ${{ steps.semantic.outputs.release-version }}
+
+    - name: Docker push version
+      if: steps.semantic.outputs.new-release-published == 'true'
+      run: |
+        docker login https://docker.pkg.github.com -u $GITHUB_ACTOR -p $GITHUB_TOKEN
+        docker build -t docker.pkg.github.com/eyblockchain/TODO/TODO:$RELEASE_VERSION . -f deployer.Dockerfile
+        docker push docker.pkg.github.com/eyblockchain/TODO/TODO:$RELEASE_VERSION
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build docker optimist image
+      run: docker build . -f optimist.Dockerfile
+
+    - run: echo ${{ steps.semantic.outputs.release-version }}
+
+    - name: Docker push version
+      if: steps.semantic.outputs.new-release-published == 'true'
+      run: |
+        docker login https://docker.pkg.github.com -u $GITHUB_ACTOR -p $GITHUB_TOKEN
+        docker build -t docker.pkg.github.com/eyblockchain/TODO/TODO:$RELEASE_VERSION . -f optimist.Dockerfile
+        docker push docker.pkg.github.com/eyblockchain/TODO/TODO:$RELEASE_VERSION
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -15,7 +15,8 @@ jobs:
     - uses: codfish/semantic-release-action@master
       id: semantic
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+        GITHUB_ACTOR: ${{ secrets.DOCKER_ACTOR }}
 
     - name: Login to docker registry
       run: docker login ghcr.io -u $GITHUB_ACTOR -p $GITHUB_TOKEN

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - miranda/docker-images
 
 jobs:
   release:
@@ -18,7 +17,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Login to docker registry
-      run: docker login ghcr.io -u $DOCKER_ACTOR -p $GITHUB_TOKEN
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $DOCKER_ACTOR --password-stdin
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         DOCKER_ACTOR: ${{ secrets.DOCKER_ACTOR }}

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -15,12 +15,12 @@ jobs:
     - uses: codfish/semantic-release-action@master
       id: semantic
       env:
-        GITHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Login to docker registry
       run: docker login ghcr.io -u $DOCKER_ACTOR -p $GITHUB_TOKEN
       env:
-        GITHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         DOCKER_ACTOR: ${{ secrets.DOCKER_ACTOR }}
 
     - name: Build docker client image
@@ -34,7 +34,7 @@ jobs:
         docker build -t ghcr.io/eyblockchain/nightfall3-client:$RELEASE_VERSION . -f client.Dockerfile
         docker push ghcr.io/eyblockchain//nightfall3-client:$RELEASE_VERSION
       env:
-        GITHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build docker zokrates worker image
       run: docker build . -f worker.Dockerfile
@@ -47,7 +47,7 @@ jobs:
         docker build -t ghcr.io/eyblockchain/nightfall3-worker:$RELEASE_VERSION . -f worker.Dockerfile
         docker push ghcr.io/eyblockchain/nightfall3-worker:$RELEASE_VERSION
       env:
-        GITHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build docker deployer image
       run: docker build . -f deployer.Dockerfile
@@ -60,7 +60,7 @@ jobs:
         docker build -t ghcr.io/eyblockchain/nightfall3-deployer:$RELEASE_VERSION . -f deployer.Dockerfile
         docker push ghcr.io/eyblockchain/nightfall3-deployer:$RELEASE_VERSION
       env:
-        GITHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build docker optimist image
       run: docker build . -f optimist.Dockerfile
@@ -73,4 +73,4 @@ jobs:
         docker build -t ghcr.io/eyblockchain/nightfall3-optimist:$RELEASE_VERSION . -f optimist.Dockerfile
         docker push ghcr.io/eyblockchain/nightfall3-optimist:$RELEASE_VERSION
       env:
-        GITHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -16,10 +16,12 @@ jobs:
       id: semantic
       env:
         GITHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}
-        GITHUB_ACTOR: ${{ secrets.DOCKER_ACTOR }}
 
     - name: Login to docker registry
-      run: docker login ghcr.io -u $GITHUB_ACTOR -p $GITHUB_TOKEN
+      run: docker login ghcr.io -u $DOCKER_ACTOR -p $GITHUB_TOKEN
+      env:
+        GITHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+        DOCKER_ACTOR: ${{ secrets.DOCKER_ACTOR }}
 
     - name: Build docker client image
       run: docker build . -f client.Dockerfile
@@ -32,7 +34,7 @@ jobs:
         docker build -t ghcr.io/eyblockchain/nightfall3-client:$RELEASE_VERSION . -f client.Dockerfile
         docker push ghcr.io/eyblockchain//nightfall3-client:$RELEASE_VERSION
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 
     - name: Build docker zokrates worker image
       run: docker build . -f worker.Dockerfile
@@ -45,7 +47,7 @@ jobs:
         docker build -t ghcr.io/eyblockchain/nightfall3-worker:$RELEASE_VERSION . -f worker.Dockerfile
         docker push ghcr.io/eyblockchain/nightfall3-worker:$RELEASE_VERSION
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 
     - name: Build docker deployer image
       run: docker build . -f deployer.Dockerfile
@@ -58,7 +60,7 @@ jobs:
         docker build -t ghcr.io/eyblockchain/nightfall3-deployer:$RELEASE_VERSION . -f deployer.Dockerfile
         docker push ghcr.io/eyblockchain/nightfall3-deployer:$RELEASE_VERSION
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 
     - name: Build docker optimist image
       run: docker build . -f optimist.Dockerfile
@@ -71,4 +73,4 @@ jobs:
         docker build -t ghcr.io/eyblockchain/nightfall3-optimist:$RELEASE_VERSION . -f optimist.Dockerfile
         docker push ghcr.io/eyblockchain/nightfall3-optimist:$RELEASE_VERSION
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}

--- a/client.Dockerfile
+++ b/client.Dockerfile
@@ -1,0 +1,31 @@
+FROM mongo:4.4.1-bionic
+
+# install node
+RUN apt-get update
+
+# TEMPORARY WORKAROUND FOR ISSUE https://github.com/nodesource/distributions/issues/1266
+RUN apt-get install -y ca-certificates
+
+RUN apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt-get install -y nodejs
+RUN apt-get install -y netcat
+
+WORKDIR /
+COPY common-files common-files
+COPY config/default.js app/config/default.js
+
+WORKDIR /app
+RUN mkdir /app/mongodb
+
+COPY nightfall-client/src src
+COPY nightfall-client/docker-entrypoint.sh nightfall-client/pre-start-script.sh nightfall-client/package.json nightfall-client/package-lock.json ./
+
+RUN npm ci
+
+EXPOSE 27017
+EXPOSE 80
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+
+CMD ["npm", "start"]

--- a/deployer.Dockerfile
+++ b/deployer.Dockerfile
@@ -1,0 +1,19 @@
+FROM node:14.17
+
+WORKDIR /
+COPY common-files common-files
+COPY config/default.js app/config/default.js
+
+WORKDIR /app
+RUN apt-get update -y
+RUN apt-get install -y netcat-openbsd
+COPY nightfall-deployer/package*.json nightfall-deployer/pre-start-script.sh ./
+COPY nightfall-deployer/src src
+COPY nightfall-deployer/contracts contracts
+COPY nightfall-deployer/migrations migrations
+COPY nightfall-deployer/truffle-config.js truffle-config.js
+COPY nightfall-deployer/circuits circuits
+COPY nightfall-deployer/entrypoint.sh entrypoint.sh
+
+RUN npm ci
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker-compose.images.example.yml
+++ b/docker-compose.images.example.yml
@@ -1,9 +1,9 @@
 version: '3.5'
 # Use this script for running up nightfall_3 with images
-# To test locally, run docker build . -f <image-name>.Dockerfile for each container and paste the resulting image hash below
+# If you replace the main docker-compose with this file, it should work!
 services:
   client1:
-    image: f375d8c72152c9258c63f0c12fd98cd39c2a30b0d5a1927f3c4292de1126fd22
+    image: ghcr.io/eyblockchain/nightfall3-client:latest
     volumes:
       - type: volume
         source: build
@@ -39,7 +39,7 @@ services:
     command: ['npm', 'run', 'dev']
 
   client2:
-    image: f375d8c72152c9258c63f0c12fd98cd39c2a30b0d5a1927f3c4292de1126fd22
+    image: ghcr.io/eyblockchain/nightfall3-client:latest
     volumes:
       - type: volume
         source: build
@@ -72,7 +72,7 @@ services:
     command: ['npm', 'run', 'dev']
 
   worker:
-    image: c7dd75e375928295d32f646f83a57ff6812c508e027de3bafa17591caaf03674
+    image: ghcr.io/eyblockchain/nightfall3-worker
     volumes:
       - type: volume
         source: ./proving_files
@@ -86,7 +86,7 @@ services:
 
     # Temporary container to deploy contracts and circuits and populate volumes
   deployer:
-    image: dac0ebfb1c2343a08286dfa9747fac67ab3de9777a097571ae38709c08188482
+    image: ghcr.io/eyblockchain/nightfall3-deployer
     volumes:
       - type: volume
         source: build
@@ -218,7 +218,7 @@ services:
       - nightfall_network
 
   optimist1:
-    image: bc840d1516ad957af9d51ebed66b4de119dcb6eb22fa7465c38edcdc81be022f
+    image: ghcr.io/eyblockchain/nightfall3-optimist:latest
     depends_on:
       - timber1
       - deployer
@@ -245,7 +245,7 @@ services:
     command: ['npm', 'run', 'dev']
 
   optimist2:
-    image: bc840d1516ad957af9d51ebed66b4de119dcb6eb22fa7465c38edcdc81be022f
+    image: ghcr.io/eyblockchain/nightfall3-optimist:latest
     depends_on:
       - timber2
       - deployer

--- a/docker-compose.images.example.yml
+++ b/docker-compose.images.example.yml
@@ -1,0 +1,290 @@
+version: '3.5'
+# Use this script for running up nightfall_3 with images
+# To test locally, run docker build . -f <image-name>.Dockerfile for each container and paste the resulting image hash below
+services:
+  client1:
+    image: f375d8c72152c9258c63f0c12fd98cd39c2a30b0d5a1927f3c4292de1126fd22
+    volumes:
+      - type: volume
+        source: build
+        target: /app/build
+      - type: volume
+        source: mongodb1
+        target: /app/mongodb
+    networks:
+      - nightfall_network
+    ports:
+      - 27017:27017
+      - 8080:80
+    depends_on:
+      - deployer
+      - worker
+      - timber1
+      - rabbitmq1
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: admin
+      MONGO_INITDB_ROOT_PASSWORD: admin
+      LOG_LEVEL: debug
+      BLOCKCHAIN_WS_HOST: blockchain1
+      BLOCKCHAIN_PORT: 8546
+      ZOKRATES_WORKER_HOST: worker
+      RABBITMQ_HOST: amqp://rabbitmq1
+      RABBITMQ_PORT: 5672
+      TIMBER_HOST: timber1
+      TIMBER_PORT: 80
+      ENABLE_QUEUE: 1
+      OPTIMIST_HOST: optimist1
+      OPTIMIST_PORT: 80
+      USE_STUBS: 'false' # make sure this flag is the same as in deployer service
+    command: ['npm', 'run', 'dev']
+
+  client2:
+    image: f375d8c72152c9258c63f0c12fd98cd39c2a30b0d5a1927f3c4292de1126fd22
+    volumes:
+      - type: volume
+        source: build
+        target: /app/build
+    networks:
+      - nightfall_network
+    ports:
+      - 27018:27017
+      - 8084:80
+    depends_on:
+      - deployer
+      - worker
+      - timber2
+      - rabbitmq2
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: admin
+      MONGO_INITDB_ROOT_PASSWORD: admin
+      LOG_LEVEL: error
+      BLOCKCHAIN_WS_HOST: blockchain1
+      BLOCKCHAIN_PORT: 8546
+      ZOKRATES_WORKER_HOST: worker
+      RABBITMQ_HOST: amqp://rabbitmq2
+      RABBITMQ_PORT: 5672
+      TIMBER_HOST: timber2
+      TIMBER_PORT: 80
+      ENABLE_QUEUE: 1
+      OPTIMIST_HOST: optimist2
+      OPTIMIST_PORT: 80
+      USE_STUBS: 'false' # make sure this flag is the same as in deployer service
+    command: ['npm', 'run', 'dev']
+
+  worker:
+    image: c7dd75e375928295d32f646f83a57ff6812c508e027de3bafa17591caaf03674
+    volumes:
+      - type: volume
+        source: ./proving_files
+        target: /app/output/
+    depends_on:
+      - deployer
+    networks:
+      - nightfall_network
+    environment:
+      LOG_LEVEL: info
+
+    # Temporary container to deploy contracts and circuits and populate volumes
+  deployer:
+    image: dac0ebfb1c2343a08286dfa9747fac67ab3de9777a097571ae38709c08188482
+    volumes:
+      - type: volume
+        source: build
+        target: /app/build/
+      # - type: bind
+      #   source: ./config/default.js
+      #   target: /app/config/default.js
+    networks:
+      - nightfall_network
+    environment:
+      LOG_LEVEL: debug
+      # ETH_NETWORK sets the network selected by Truffle from truffle-config.js
+      # startup routines will wait for a blockchain client to be reachable on this network
+      ETH_NETWORK: blockchain1
+      BLOCKCHAIN_WS_HOST: blockchain1
+      BLOCKCHAIN_PORT: 8546
+      ZOKRATES_WORKER_HOST: worker
+      # TIMBER_HOST: timber1
+      # TIMBER_PORT: 80
+      USE_STUBS: 'false'
+
+  # Timber service, configured for nightfall
+  timber1:
+    build:
+      dockerfile: Dockerfile
+      context: ./timber
+    restart: on-failure
+    depends_on:
+      - deployer
+      - timber-database1
+    networks:
+      - nightfall_network
+    ports:
+      - 8083:80
+    volumes:
+      - type: volume
+        source: build
+        target: /app/build/
+      - type: bind
+        source: ./timber/src
+        target: /app/src/
+      - type: bind
+        source: ./config/timber.js
+        target: /app/config/default.js
+      - type: bind
+        source: ./timber/entrypoint.sh
+        target: /app/entrypoint.sh
+    environment:
+      BLOCKCHAIN_WS_HOST: blockchain1
+      BLOCKCHAIN_PORT: 8546
+      MONGO_HOST: timber-database1
+      MONGO_PORT: 27017
+      MONGO_NAME: merkle_tree
+      HASH_TYPE: mimc
+      LOG_LEVEL: info
+      AUTOSTART: enabled
+
+  # Timber service, configured for nightfall
+  timber2:
+    build:
+      dockerfile: Dockerfile
+      context: ./timber
+    restart: on-failure
+    depends_on:
+      - deployer
+      - timber-database2
+    networks:
+      - nightfall_network
+    ports:
+      - 8087:80
+    volumes:
+      - type: volume
+        source: build
+        target: /app/build/
+      - type: bind
+        source: ./timber/src
+        target: /app/src/
+      - type: bind
+        source: ./config/timber.js
+        target: /app/config/default.js
+    environment:
+      BLOCKCHAIN_WS_HOST: blockchain1
+      BLOCKCHAIN_PORT: 8546
+      MONGO_HOST: timber-database2
+      MONGO_PORT: 27017
+      MONGO_NAME: merkle_tree
+      HASH_TYPE: mimc
+      LOG_LEVEL: error
+      AUTOSTART: enabled
+
+  #The database storing the merkle tree
+  timber-database1:
+    image: mongo
+    environment:
+      - MONGO_INITDB_DATABASE=merkle_tree
+    volumes:
+      - type: volume
+        source: timber-database-volume1
+        target: /data/db
+    networks:
+      - nightfall_network
+
+  #The database storing the merkle tree
+  timber-database2:
+    image: mongo
+    environment:
+      - MONGO_INITDB_DATABASE=merkle_tree
+    volumes:
+      - type: volume
+        source: timber-database-volume2
+        target: /data/db
+    networks:
+      - nightfall_network
+
+  rabbitmq1:
+    image: rabbitmq
+    ports:
+      - '15674:15674'
+      - '5672:5672'
+    networks:
+      - nightfall_network
+
+  rabbitmq2:
+    image: rabbitmq
+    ports:
+      - '15675:15674'
+      - '5673:5672'
+    networks:
+      - nightfall_network
+
+  optimist1:
+    image: bc840d1516ad957af9d51ebed66b4de119dcb6eb22fa7465c38edcdc81be022f
+    depends_on:
+      - timber1
+      - deployer
+    networks:
+      - nightfall_network
+    ports:
+      - 8081:80
+      # websocket port for Optimist is on localhost:8082
+      - 8082:8080
+    volumes:
+      - type: volume
+        source: build
+        target: /app/build/
+    environment:
+      WEBSOCKET_PORT: 8080
+      BLOCKCHAIN_WS_HOST: blockchain1
+      BLOCKCHAIN_PORT: 8546
+      HASH_TYPE: mimc
+      LOG_LEVEL: debug
+      IS_CHALLENGER: 'true'
+      TRANSACTIONS_PER_BLOCK: ${TRANSACTIONS_PER_BLOCK:-2}
+      TIMBER_HOST: timber1
+      TIMBER_PORT: 80
+    command: ['npm', 'run', 'dev']
+
+  optimist2:
+    image: bc840d1516ad957af9d51ebed66b4de119dcb6eb22fa7465c38edcdc81be022f
+    depends_on:
+      - timber2
+      - deployer
+    networks:
+      - nightfall_network
+    ports:
+      - 8085:80
+      # websocket port for Optimist is on localhost:8086
+      - 8086:8080
+    volumes:
+      - type: volume
+        source: build
+        target: /app/build/
+      # - type: bind
+    environment:
+      WEBSOCKET_PORT: 8080
+      BLOCKCHAIN_WS_HOST: blockchain1
+      BLOCKCHAIN_PORT: 8546
+      HASH_TYPE: mimc
+      LOG_LEVEL: error
+      IS_CHALLENGER: 'true'
+      TRANSACTIONS_PER_BLOCK: ${TRANSACTIONS_PER_BLOCK:-2}
+      TIMBER_HOST: timber2
+      TIMBER_PORT: 80
+    command: ['npm', 'run', 'dev']
+
+volumes:
+  mongodb1:
+  mongodb2:
+  proving_files:
+  build:
+  timber-database-volume1:
+  timber-database-volume2:
+
+networks:
+  nightfall_network:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.16.238.0/24
+          gateway: 172.16.238.1

--- a/optimist.Dockerfile
+++ b/optimist.Dockerfile
@@ -1,0 +1,33 @@
+FROM mongo:4.4.1-bionic
+
+# install node
+RUN apt-get update
+
+# TEMPORARY WORKAROUND FOR ISSUE https://github.com/nodesource/distributions/issues/1266
+RUN apt-get install -y ca-certificates
+
+RUN apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt-get install -y nodejs
+RUN apt-get install -y netcat
+
+WORKDIR /
+COPY common-files common-files
+COPY config/default.js app/config/default.js
+
+WORKDIR /app
+RUN mkdir /app/mongodb
+
+COPY nightfall-optimist/src src
+COPY nightfall-optimist/docker-entrypoint.sh nightfall-optimist/pre-start-script.sh nightfall-optimist/package*.json ./
+
+RUN npm ci
+
+EXPOSE 80
+
+# websocket port 8080
+EXPOSE 8080
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+
+CMD ["npm", "start"]

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -1,0 +1,26 @@
+FROM zokrates/zokrates:0.6.4 as builder
+
+FROM node:14.17
+
+WORKDIR /app
+
+COPY config/default.js config/default.js
+COPY /nightfall-deployer/circuits circuits
+COPY ./zokrates-worker/package.json ./zokrates-worker/package-lock.json ./
+COPY --from=builder /home/zokrates/.zokrates/bin/zokrates /app/zokrates
+COPY --from=builder /home/zokrates/.zokrates/stdlib /app/stdlib/
+COPY ./zokrates-worker/src ./src
+COPY ./zokrates-worker/circuits ./circuits
+COPY ./zokrates-worker/start-script ./start-script
+COPY ./zokrates-worker/start-dev ./start-dev
+
+RUN apt-get update -y
+RUN apt-get install -y netcat
+
+ENV ZOKRATES_HOME /app
+ENV ZOKRATES_STDLIB /app/stdlib
+
+RUN npm ci
+
+EXPOSE 80
+CMD npm start


### PR DESCRIPTION
This PR adds Dockerfiles copying local dependencies into build images and github actions to push that image to the new github repo, `ghcr.io`. I removed binds where possible, but shared volumes (e.g. `build`, `proving-files`) are still required.
I've already pushed the images manually and created `docker-compose.images.example.yml`, which uses them. If you replace `docker-compose.yml` with this file everything should still work.

Note that the actions file is not tested, however a test run failed on the actions tab of the repo on a previous push. Hopefully it will run on this PR creation...

Closes #273.