### PR TITLE
Local <> contract transaction hash mismatch

### DIFF
--- a/common-files/classes/transaction.mjs
+++ b/common-files/classes/transaction.mjs
@@ -18,7 +18,7 @@ function keccak(preimage) {
   // compute the solidity hash, using suitable type conversions
   return web3.utils.soliditySha3(
     { t: 'uint64', v: preimage.value },
-    ...preimage.historicRootBlockNumberL2.map(hi => ({ t: 'uint64', v: hi })),
+    ...preimage.historicRootBlockNumberL2.map(hi => ({ t: 'uint256', v: hi })),
     { t: 'uint8', v: preimage.transactionType },
     { t: 'uint8', v: preimage.tokenType },
     { t: 'bytes32', v: preimage.publicInputHash },


### PR DESCRIPTION
This [PR](https://github.com/EYBlockchain/nightfall_3/pull/278) that adds a second historic root has triggered a subtle bug that causes the local calculation of a transaction hash (via `Transaction.calcHash`) does not match the on-chain function `Utils.hashTransaction`.

This is only noticeable now when getting `instant-withdrawals.test` to run as the only time the local and contract values are compared in a test is in this `instant-withdrawal` interaction. 

The issue is that even though `historicRootBlockNumberL2` is of type `uint64[2]`,  the function `encodePacked` will pad any array values (see screenshot from docs) - this seems to be the only time it pads values that are < 32 bytes.  Therefore, locally, we need to change the type to `uint256` for the purposes of calculating the hash.

<img width="786" alt="Screen Shot 2021-11-18 at 14 25 48" src="https://user-images.githubusercontent.com/9293647/142368857-4eddf3ad-3a22-4249-842f-42285016ca2b.png">

