### PR TITLE
fix: get proposers collection and register proposer

### DIFF
--- a/nightfall-deployer/contracts/Proposers.sol
+++ b/nightfall-deployer/contracts/Proposers.sol
@@ -53,9 +53,14 @@ contract Proposers is Stateful, Structures, Config {
       // updated the pulled state
       proposersPrevious.nextAddress = proposer.thisAddress; // X: (u,v,B)
       proposersCurrent.previousAddress = proposer.thisAddress; // current: (B,A,z)
+      if (proposersPrevious.thisAddress == proposersCurrent.thisAddress) { // case register second proposer
+        proposersCurrent.nextAddress = proposer.thisAddress; // previous and next Address is the second proposer
+      }
       currentProposer = proposersCurrent; // ensure sync: currentProposer: (B,A,z)
       // set global state to new values
-      state.setProposer(proposersPrevious.thisAddress, proposersPrevious);
+      if (proposersPrevious.thisAddress != proposersCurrent.thisAddress) { // not case register second proposer
+        state.setProposer(proposersPrevious.thisAddress, proposersPrevious);
+      }
       state.setProposer(proposersCurrent.thisAddress, proposersCurrent);
       state.setProposer(msg.sender, proposer);
     }

--- a/nightfall-optimist/src/routes/proposer.mjs
+++ b/nightfall-optimist/src/routes/proposer.mjs
@@ -60,7 +60,7 @@ router.get('/proposers', async (req, res, next) => {
       // eslint-disable-next-line no-await-in-loop
       const proposer = await proposersContractInstance.methods.proposers(thisPtr).call();
       proposers.push(proposer);
-      thisPtr = proposer.thisAddress;
+      thisPtr = proposer.nextAddress;
     } while (thisPtr !== currentProposer.thisAddress);
 
     logger.debug('returning raw transaction data');


### PR DESCRIPTION
Get proposers endpoint only was always getting one proposer, instead of all proposers. Fix with `nextAddress` property in the loop going one by one proposers in cycle way until the same current proposer again.
In the Proposers.sol contract `nextAddress` was wrong for the current proposer in the case of registering second proposer.