### PR TITLE
Stop Proposing on top of bad blocks and clean up on proposer rotation

### DIFF
--- a/common-files/utils/event-queue.mjs
+++ b/common-files/utils/event-queue.mjs
@@ -26,7 +26,8 @@ import logger from 'common-files/utils/logger.mjs';
 const { MAX_QUEUE } = config;
 const fastQueue = new Queue({ autostart: true, concurrency: 1 });
 const slowQueue = new Queue({ autostart: true, concurrency: 1 });
-export const queues = [fastQueue, slowQueue];
+const stopQueue = new Queue({ autostart: false, concurrency: 1 });
+export const queues = [fastQueue, slowQueue, stopQueue];
 
 /**
 This function will return a promise that resolves to true when the next highest
@@ -68,6 +69,10 @@ async function enqueueEvent(callback, priority, args) {
   });
 }
 
+async function dequeueEvent(priority) {
+  queues[priority].shift();
+}
+
 async function queueManager(eventObject, eventArgs) {
   // First element of eventArgs must be the eventHandlers object
   const [eventHandlers, ...args] = eventArgs;
@@ -105,4 +110,4 @@ async function queueManager(eventObject, eventArgs) {
 }
 
 /* ignore unused exports */
-export { flushQueue, enqueueEvent, queueManager };
+export { flushQueue, enqueueEvent, dequeueEvent, queueManager };

--- a/nightfall-optimist/src/event-handlers/block-proposed.mjs
+++ b/nightfall-optimist/src/event-handlers/block-proposed.mjs
@@ -39,7 +39,7 @@ async function blockProposedEventHandler(data) {
     );
     // mark transactions so that they are out of the mempool,
     // so we don't try to use them in a block which we're proposing.
-    await removeTransactionsFromMemPool(block); // TODO is await needed?
+    await removeTransactionsFromMemPool(block.transactionHashes, block.blockNumberL2); // TODO is await needed?
 
     const latestTree = await getLatestTree();
     const blockCommitments = transactions.map(t => t.commitments.filter(c => c !== ZERO)).flat();

--- a/nightfall-optimist/src/event-handlers/block-proposed.mjs
+++ b/nightfall-optimist/src/event-handlers/block-proposed.mjs
@@ -1,6 +1,7 @@
 import logger from 'common-files/utils/logger.mjs';
 import Timber from 'common-files/classes/timber.mjs';
 import config from 'config';
+import { enqueueEvent } from 'common-files/utils/event-queue.mjs';
 import checkBlock from '../services/check-block.mjs';
 import BlockError from '../classes/block-error.mjs';
 import { createChallenge } from '../services/challenges.mjs';
@@ -33,13 +34,7 @@ async function blockProposedEventHandler(data) {
     // asociated with a failed block, and we can't do that if we haven't
     // associated them with a blockHash.
     await stampNullifiers(
-      transactions
-        .map(tx =>
-          tx.nullifiers.filter(
-            nulls => nulls !== '0x0000000000000000000000000000000000000000000000000000000000000000',
-          ),
-        )
-        .flat(Infinity),
+      transactions.map(tx => tx.nullifiers.filter(nulls => nulls !== ZERO)).flat(Infinity),
       block.blockHash,
     );
     // mark transactions so that they are out of the mempool,
@@ -59,6 +54,11 @@ async function blockProposedEventHandler(data) {
   } catch (err) {
     if (err instanceof BlockError) {
       logger.warn(`Block Checker - Block invalid, with code ${err.code}! ${err.message}`);
+      logger.info(`Block is invalid, stopping any block production`);
+      // We enqueue an event onto the stopQueue to halt block production.
+      // This message will not be printed because event dequeuing does not run the job.
+      // This is fine as we are just using it to stop running.
+      await enqueueEvent(() => logger.info('Stop Until Rollback'), 2);
       await createChallenge(block, transactions, err);
     } else {
       logger.error(err.stack);

--- a/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
+++ b/nightfall-optimist/src/event-handlers/new-current-proposer.mjs
@@ -1,4 +1,5 @@
 import logger from 'common-files/utils/logger.mjs';
+import Block from '../classes/block.mjs';
 import {
   isRegisteredProposerAddressMine,
   resetUnsuccessfulBlockProposedTransactions,
@@ -24,10 +25,9 @@ async function newCurrentProposerEventHandler(data, args) {
     // If we were the last proposer return any transactions that were removed from the mempool
     // because they were included in proposed blocks that did not eventually make it on chain.
     if (weWereLastProposer) {
-      logger.info(`Resetting Transactions`);
+      Block.rollback();
       await resetUnsuccessfulBlockProposedTransactions();
     }
-
     // !! converts this to a "is not null" check - i.e. false if is null
     // are we the next proposer?
     proposer.isMe = !!(await isRegisteredProposerAddressMine(currentProposer));

--- a/nightfall-optimist/src/index.mjs
+++ b/nightfall-optimist/src/index.mjs
@@ -30,8 +30,11 @@ const main = async () => {
       await startEventQueue(queueManager, eventHandlers, proposer);
       queues[0].on('end', () => {
         // We do the proposer isMe check here to fail fast instead of re-enqueing.
-        logger.info('Queue has emptied. Queueing block assembler.');
-        if (proposer.isMe) return enqueueEvent(conditionalMakeBlock, 0, proposer);
+        // We check if the queue[2] is empty, this is safe it is manually enqueued/dequeued.
+        if (proposer.isMe && queues[2].length === 0) {
+          logger.info('Queue has emptied. Queueing block assembler.');
+          return enqueueEvent(conditionalMakeBlock, 0, proposer);
+        }
         // eslint-disable-next-line no-void, no-useless-return
         return void false; // This is here to satisfy consistent return rules, we do nothing.
       });

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -70,7 +70,7 @@ export async function conditionalMakeBlock(proposer) {
       logger.debug('Send unsigned block-assembler transaction to ws client');
       // remove the transactiosn from the mempool so we don't keep making new
       // blocks with them
-      await removeTransactionsFromMemPool(block);
+      await removeTransactionsFromMemPool(block.transactionHashes);
     }
   }
   // Let's slow down here so we don't slam the database.

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -449,14 +449,13 @@ export async function getBlocks() {
     .toArray();
 }
 
-/**
-Function to add a set of transactions from the layer 2 mempool once a block has been rolled back
-*/
-export async function addTransactionsToMemPoolFromBlockNumberL2(blockNumberL2) {
+// This function is useful in resetting transacations that have been marked out of the mempool because
+// we have included them in blocks, but those blocks did not end up being mined on-chain.
+export async function resetUnsuccessfulBlockProposedTransactions() {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
-  const query = { blockNumberL2: { $gte: Number(blockNumberL2) } };
-  const update = { $set: { mempool: true, blockNumberL2: -1 } };
+  const query = { blockNumberL2: -1, mempool: false }; // Transactions out of mempool but not yet on chain
+  const update = { $set: { mempool: true } };
   return db.collection(TRANSACTIONS_COLLECTION).updateMany(query, update);
 }
 

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -298,11 +298,11 @@ export async function addTransactionsToMemPool(block) {
 Function to remove a set of transactions from the layer 2 mempool once they've
 been processed into a block
 */
-export async function removeTransactionsFromMemPool(block) {
+export async function removeTransactionsFromMemPool(transactionHashes, blockNumberL2 = -1) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
-  const query = { transactionHash: { $in: block.transactionHashes }, blockNumberL2: -1 };
-  const update = { $set: { mempool: false, blockNumberL2: block.blockNumberL2 } };
+  const query = { transactionHash: { $in: transactionHashes }, blockNumberL2: -1 };
+  const update = { $set: { mempool: false, blockNumberL2 } };
   return db.collection(TRANSACTIONS_COLLECTION).updateMany(query, update);
 }
 
@@ -455,7 +455,7 @@ export async function resetUnsuccessfulBlockProposedTransactions() {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   const query = { blockNumberL2: -1, mempool: false }; // Transactions out of mempool but not yet on chain
-  const update = { $set: { mempool: true } };
+  const update = { $set: { mempool: true, blockNumberL2: -1 } };
   return db.collection(TRANSACTIONS_COLLECTION).updateMany(query, update);
 }
 

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -282,11 +282,7 @@ describe('Testing the challenge http API', () => {
             // console.log('tx hash of challenge block is', txReceipt.transactionHash);
           } else throw new Error(`Unhandled transaction type: ${type}`);
         } catch (err) {
-          console.error(
-            `neg-http.mjs onmessage error: ${err}, block is : ${JSON.stringify(
-              msg.block,
-            )} / ${JSON.stringify(msg.transactions)} /  ${msg.type}`,
-          );
+          console.error(`neg-http.mjs onmessage error: ${err}`);
         }
       });
     };
@@ -495,47 +491,6 @@ describe('Testing the challenge http API', () => {
         ]);
         const res = await chai
           .request(url)
-          .post('/deposit')
-          .send({ ercAddress, tokenId, tokenType, value, pkd: pkd1, nsk: nsk1, fee });
-        // now we need to sign the transaction and send it to the blockchain
-        await submitTransaction(res.body.txDataToSign, privateKey, shieldAddress, gas, fee);
-      });
-    });
-    describe('Challenge 3: Invalid transaction submitted', () => {
-      it('Should delete the flawed block and rollback the leaves', async () => {
-        await testForEvents(stateAddress, [
-          web3.eth.abi.encodeEventSignature('Rollback(bytes32,uint256,uint256)'),
-          web3.eth.abi.encodeParameter('bytes32', topicsBlockHashInvalidTransaction),
-        ]);
-
-        const res = await chai
-          .request(url)
-          .post('/transfer')
-          .send({
-            ercAddress,
-            tokenId,
-            recipientData: {
-              values: [value],
-              recipientPkds: [pkd1],
-            },
-            nsk: nsk1,
-            ask: ask1,
-            fee,
-          });
-        // now we need to sign the transaction and send it to the blockchain
-        await submitTransaction(res.body.txDataToSign, privateKey, shieldAddress, gas, fee);
-      });
-    });
-
-    describe('Challenge 4: Challenge historic root used in a transaction', () => {
-      it('Should delete the wrong block', async () => {
-        await testForEvents(stateAddress, [
-          web3.eth.abi.encodeEventSignature('Rollback(bytes32,uint256,uint256)'),
-          web3.eth.abi.encodeParameter('bytes32', topicsBlockHashesIncorrectHistoricRoot),
-        ]);
-
-        const res = await chai
-          .request(url)
           .post('/transfer')
           .send({
             ercAddress,
@@ -549,8 +504,24 @@ describe('Testing the challenge http API', () => {
             fee,
           });
         const { txDataToSign } = res.body;
-        expect(txDataToSign).to.be.a('string');
         await submitTransaction(txDataToSign, privateKey, shieldAddress, gas);
+      });
+    });
+    describe('Challenge 3: Invalid transaction submitted', () => {
+      it('Should delete the flawed block and rollback the leaves', async () => {
+        await testForEvents(stateAddress, [
+          web3.eth.abi.encodeEventSignature('Rollback(bytes32,uint256,uint256)'),
+          web3.eth.abi.encodeParameter('bytes32', topicsBlockHashInvalidTransaction),
+        ]);
+      });
+    });
+
+    describe('Challenge 4: Challenge historic root used in a transaction', () => {
+      it('Should delete the wrong block', async () => {
+        await testForEvents(stateAddress, [
+          web3.eth.abi.encodeEventSignature('Rollback(bytes32,uint256,uint256)'),
+          web3.eth.abi.encodeParameter('bytes32', topicsBlockHashesIncorrectHistoricRoot),
+        ]);
       });
     });
 
@@ -562,17 +533,22 @@ describe('Testing the challenge http API', () => {
         ]);
 
         // create another transaction to trigger NO's block assembly
-        const res = await chai.request(url).post('/deposit').send({
-          ercAddress,
-          tokenId,
-          tokenType,
-          value,
-          pkd: pkd1,
-          nsk: nsk1,
-          fee,
-        });
+        const res = await chai
+          .request(url)
+          .post('/transfer')
+          .send({
+            ercAddress,
+            tokenId,
+            recipientData: {
+              values: [value],
+              recipientPkds: [pkd1],
+            },
+            nsk: nsk1,
+            ask: ask1,
+            fee,
+          });
         const { txDataToSign } = res.body;
-        await submitTransaction(txDataToSign, privateKey, shieldAddress, gas, fee);
+        await submitTransaction(txDataToSign, privateKey, shieldAddress, gas);
       });
     });
 
@@ -582,18 +558,6 @@ describe('Testing the challenge http API', () => {
           web3.eth.abi.encodeEventSignature('Rollback(bytes32,uint256,uint256)'),
           web3.eth.abi.encodeParameter('bytes32', topicsBlockHashIncorrectProof),
         ]);
-        // create another transaction to trigger NO's block assembly
-        const res = await chai.request(url).post('/deposit').send({
-          ercAddress,
-          tokenId,
-          tokenType,
-          value,
-          pkd: pkd1,
-          nsk: nsk1,
-          fee,
-        });
-        const { txDataToSign } = res.body;
-        await submitTransaction(txDataToSign, privateKey, shieldAddress, gas, fee);
       });
     });
 
@@ -603,17 +567,22 @@ describe('Testing the challenge http API', () => {
           web3.eth.abi.encodeEventSignature('Rollback(bytes32,uint256,uint256)'),
           web3.eth.abi.encodeParameter('bytes32', topicsBlockHashDuplicateNullifier),
         ]);
-        const res = await chai.request(url).post('/deposit').send({
-          ercAddress,
-          tokenId,
-          tokenType,
-          value,
-          pkd: pkd1,
-          nsk: nsk1,
-          fee,
-        });
+        const res = await chai
+          .request(url)
+          .post('/transfer')
+          .send({
+            ercAddress,
+            tokenId,
+            recipientData: {
+              values: [value],
+              recipientPkds: [pkd1],
+            },
+            nsk: nsk1,
+            ask: ask1,
+            fee,
+          });
         const { txDataToSign } = res.body;
-        await submitTransaction(txDataToSign, privateKey, shieldAddress, gas, fee);
+        await submitTransaction(txDataToSign, privateKey, shieldAddress, gas);
       });
     });
 
@@ -623,23 +592,6 @@ describe('Testing the challenge http API', () => {
           web3.eth.abi.encodeEventSignature('Rollback(bytes32,uint256,uint256)'),
           web3.eth.abi.encodeParameter('bytes32', topicsBlockHashIncorrectLeafCount),
         ]);
-        for (let i = 0; i < 2; i++) {
-          const res = await chai // eslint-disable-line no-await-in-loop
-            .request(url)
-            .post('/deposit')
-            .send({
-              ercAddress,
-              tokenId,
-              tokenType,
-              value,
-              pkd: pkd1,
-              nsk: nsk1,
-              fee,
-            });
-          const { txDataToSign } = res.body;
-          // eslint-disable-next-line no-await-in-loop
-          await submitTransaction(txDataToSign, privateKey, shieldAddress, gas, fee);
-        }
       });
     });
   });

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -282,7 +282,11 @@ describe('Testing the challenge http API', () => {
             // console.log('tx hash of challenge block is', txReceipt.transactionHash);
           } else throw new Error(`Unhandled transaction type: ${type}`);
         } catch (err) {
-          console.error(`neg-http.mjs onmessage error: ${err}`);
+          console.error(
+            `neg-http.mjs onmessage error: ${err}, block is : ${JSON.stringify(
+              msg.block,
+            )} / ${JSON.stringify(msg.transactions)} /  ${msg.type}`,
+          );
         }
       });
     };

--- a/test/rollback-resync.test.mjs
+++ b/test/rollback-resync.test.mjs
@@ -259,9 +259,19 @@ describe('Running rollback and resync test', () => {
         }
       });
     });
+
+    it('compare the mempools', async () => {
+      await new Promise(resolve => setTimeout(resolve, 50000));
+      const optimistMempool = (
+        await chai.request(optimistUrl).get('/proposer/mempool')
+      ).body.result.filter(m => m.mempool);
+      expect(optimistMempool.map(o => o.transactionHash)).eql(
+        validTransactions.map(v => v.transaction.transactionHash),
+      );
+    });
   });
 
-  describe('Make a bad block that is not on the chain tip', () => {
+  describe.skip('Make a bad block that is not on the chain tip', () => {
     it('should re-register ourselves as a proposer and reopen the websocket', async function () {
       // Need to wait for the resync process to finish processing
       await new Promise(resolve => setTimeout(resolve, 25000));
@@ -352,7 +362,7 @@ describe('Running rollback and resync test', () => {
     });
   });
 
-  describe('Perform a final full resync and compare the results', () => {
+  describe.skip('Perform a final full resync and compare the results', () => {
     it('should drop everything in the database', async () => {
       // We need to wait here so we do not drop tables before the rollback is finished
       await new Promise(resolve => setTimeout(resolve, 15000));


### PR DESCRIPTION
This PR closes #139 and #266. These are combined as a single PR because the former will not past tests without the latter. This is not due to the PR itself but the way that `neg-http` is written - leaving the database in a non-valid state causes unintended errors.

1) To prevent the block-assembler from running, we introduce a new queue (`stopQueue`). This is a manual queue so does not automatically run queued jobs.  Before running the `block-assembler`, not only do we check that the `stateQueue` (i.e. queue[0]) is empty - but also that there is nothing queued in the `stopQueue`.

Elements are enqueued into `stopQueue` when a bad block is detected in the `blockProposeHandler`. Finally, they are dequeued at the completion of `rollbackHandler`.

2) To clean up the proposer, we modify `removeTransactionsFromMempool` such that it accepts the `transactionHashes` and the `blockNumberL2`.  When we assemble blocks locally we mark transactions as `mempool': false` and `blockNumberL2:-1`. We will update the `blockNumberL2` when we call the same function in `blockProposeHandler`.

Thus, we have a way to tell identify transactions that are included in blocks but have not been mined on the Ethereum mainnet. When the proposer is rotated and we were the last proposer, we reset these transactions as we know they will not find their way into the L2 Block chain.

### Tests
We skip the deep rollbacks in the `rollback-resync` tests as we can no longer create bad blocks that deeper than the chain tip at this point in time.

Finally, we also strip back neg-tests as the speed of ganache, coupled with our testing methods means that we need to minimise excessive transactions to ensure we have the correct, specific transaction types for a given test (e.g. Test 7 requires a `single_transfer`).