### PR TITLE
Balance L2 tokens non ERC20 in SDK

### DIFF
--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -710,13 +710,15 @@ class Nf3 {
   Returns the balance details of tokens held in layer 2
   @method
   @async
+  @param {Array} ercList - list of erc contract addresses to filter.
   @returns {Promise} This promise rosolves into an object whose properties are the
   addresses of the ERC contracts of the tokens held by this account in Layer 2. The
   value of each propery is the number of tokens originating from that contract.
   */
-  async getLayer2BalancesDetails() {
+  async getLayer2BalancesDetails(ercList) {
     const res = await axios.post(`${this.clientBaseUrl}/commitment/balance-details`, {
       compressedPkd: this.zkpKeys.compressedPkd,
+      ercList,
     });
     return res.data.balance;
   }

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -707,6 +707,21 @@ class Nf3 {
   }
 
   /**
+  Returns the balance details of tokens held in layer 2
+  @method
+  @async
+  @returns {Promise} This promise rosolves into an object whose properties are the
+  addresses of the ERC contracts of the tokens held by this account in Layer 2. The
+  value of each propery is the number of tokens originating from that contract.
+  */
+  async getLayer2BalancesDetails() {
+    const res = await axios.post(`${this.clientBaseUrl}/commitment/balance-details`, {
+      compressedPkd: this.zkpKeys.compressedPkd,
+    });
+    return res.data.balance;
+  }
+
+  /**
   Returns the commitments of tokens held in layer 2
   @method
   @async

--- a/nightfall-client/src/routes/commitment.mjs
+++ b/nightfall-client/src/routes/commitment.mjs
@@ -42,8 +42,8 @@ router.get('/balance', async (req, res, next) => {
 router.post('/balance-details', async (req, res, next) => {
   logger.debug('commitment/balance details endpoint received GET');
   try {
-    const { compressedPkd } = req.body;
-    const balance = await getWalletBalanceDetails(compressedPkd);
+    const { compressedPkd, ercList } = req.body;
+    const balance = await getWalletBalanceDetails(compressedPkd, ercList);
     res.json({ balance });
   } catch (err) {
     logger.error(err);

--- a/nightfall-client/src/routes/commitment.mjs
+++ b/nightfall-client/src/routes/commitment.mjs
@@ -9,6 +9,7 @@ import {
   getWalletBalance,
   getWalletCommitments,
   getWithdrawCommitments,
+  getWalletBalanceDetails,
 } from '../services/commitment-storage.mjs';
 
 const router = express.Router();
@@ -31,6 +32,18 @@ router.get('/balance', async (req, res, next) => {
   logger.debug('commitment/balance endpoint received GET');
   try {
     const balance = await getWalletBalance();
+    res.json({ balance });
+  } catch (err) {
+    logger.error(err);
+    next(err);
+  }
+});
+
+router.post('/balance-details', async (req, res, next) => {
+  logger.debug('commitment/balance details endpoint received GET');
+  try {
+    const { compressedPkd } = req.body;
+    const balance = await getWalletBalanceDetails(compressedPkd);
     res.json({ balance });
   } catch (err) {
     logger.error(err);

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -241,6 +241,55 @@ export async function getWalletBalance() {
     }, {});
 }
 
+// function to get the balance of commitments for each ERC address
+export async function getWalletBalanceDetails(compressedPkd) {
+  console.log('COMPRESSEDPKD: ', compressedPkd);
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(COMMITMENTS_DB);
+  const query = { isNullified: false, isOnChain: { $gte: 0 } };
+  const options = {
+    projection: {
+      preimage: { ercAddress: 1, compressedPkd: 1, tokenId: 1, value: 1 },
+      _id: 0,
+    },
+  };
+  const wallet = await db.collection(COMMITMENTS_COLLECTION).find(query, options).toArray();
+  // the below is a little complex.  First we extract the ercAddress, tokenId and value
+  // from the preimage.  Then we format them nicely. We don't care about the value of the
+  // tokenId, other than if it's zero or not (indicating the token type). Then we filter
+  // any commitments of zero value and tokenId (meaningless commitments), then we
+  // work out the balance contribution of each commitment  - a 721 token has no value field in the
+  // commitment but each 721 token counts as a balance of 1. Then finally add up the individual
+  // commitment balances to get a balance for each erc address.
+  const res = wallet
+    .map(e => ({
+      ercAddress: `0x${BigInt(e.preimage.ercAddress).toString(16).padStart(40, '0')}`, // Pad this to actual address length
+      compressedPkd: e.preimage.compressedPkd,
+      tokenId: !!BigInt(e.preimage.tokenId),
+      value: Number(BigInt(e.preimage.value)),
+      id: Number(BigInt(e.preimage.tokenId)),
+    }))
+    .filter(e => (e.tokenId || e.value > 0) && e.compressedPkd === compressedPkd) // there should be no commitments with tokenId and value of ZERO
+    .map(e => ({
+      compressedPkd: e.compressedPkd,
+      ercAddress: e.ercAddress,
+      balance: e.tokenId ? 1 : e.value,
+      tokenId: e.id,
+    }))
+    .reduce((acc, e) => {
+      if (!acc[e.compressedPkd]) acc[e.compressedPkd] = {};
+      if (!acc[e.compressedPkd][e.ercAddress]) acc[e.compressedPkd][e.ercAddress] = [];
+      if (e.tokenId === 0 && acc[e.compressedPkd][e.ercAddress].length > 0) {
+        acc[e.compressedPkd][e.ercAddress][0].balance += e.balance;
+      } else {
+        acc[e.compressedPkd][e.ercAddress].push(e);
+      }
+      return acc;
+    }, {});
+
+  return res;
+}
+
 // function to get the commitments for each ERC address of a pkd
 export async function getWalletCommitments() {
   const connection = await mongo.connection(MONGO_URL);

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -242,8 +242,9 @@ export async function getWalletBalance() {
 }
 
 // function to get the balance of commitments for each ERC address
-export async function getWalletBalanceDetails(compressedPkd) {
-  console.log('COMPRESSEDPKD: ', compressedPkd);
+export async function getWalletBalanceDetails(compressedPkd, ercList) {
+  let ercAddressList = ercList || [];
+  ercAddressList = ercAddressList.map(e => e.toUpperCase());
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(COMMITMENTS_DB);
   const query = { isNullified: false, isOnChain: { $gte: 0 } };
@@ -261,6 +262,15 @@ export async function getWalletBalanceDetails(compressedPkd) {
   // work out the balance contribution of each commitment  - a 721 token has no value field in the
   // commitment but each 721 token counts as a balance of 1. Then finally add up the individual
   // commitment balances to get a balance for each erc address.
+  const res1 = wallet.map(e => ({
+    ercAddress: `0x${BigInt(e.preimage.ercAddress).toString(16).padStart(40, '0')}`, // Pad this to actual address length
+    compressedPkd: e.preimage.compressedPkd,
+    tokenId: !!BigInt(e.preimage.tokenId),
+    value: Number(BigInt(e.preimage.value)),
+    id: Number(BigInt(e.preimage.tokenId)),
+  }));
+  console.log('RES: ', res1);
+
   const res = wallet
     .map(e => ({
       ercAddress: `0x${BigInt(e.preimage.ercAddress).toString(16).padStart(40, '0')}`, // Pad this to actual address length
@@ -269,7 +279,12 @@ export async function getWalletBalanceDetails(compressedPkd) {
       value: Number(BigInt(e.preimage.value)),
       id: Number(BigInt(e.preimage.tokenId)),
     }))
-    .filter(e => (e.tokenId || e.value > 0) && e.compressedPkd === compressedPkd) // there should be no commitments with tokenId and value of ZERO
+    .filter(
+      e =>
+        (e.tokenId || e.value > 0) &&
+        e.compressedPkd === compressedPkd &&
+        (ercAddressList.length === 0 || ercAddressList.includes(e.ercAddress.toUpperCase())),
+    ) // there should be no commitments with tokenId and value of ZERO
     .map(e => ({
       compressedPkd: e.compressedPkd,
       ercAddress: e.ercAddress,
@@ -282,7 +297,7 @@ export async function getWalletBalanceDetails(compressedPkd) {
       if (e.tokenId === 0 && acc[e.compressedPkd][e.ercAddress].length > 0) {
         acc[e.compressedPkd][e.ercAddress][0].balance += e.balance;
       } else {
-        acc[e.compressedPkd][e.ercAddress].push(e);
+        acc[e.compressedPkd][e.ercAddress].push({ balance: e.balance, tokenId: e.tokenId });
       }
       return acc;
     }, {});


### PR DESCRIPTION
Create functionality in the SDK to provide the detailed information about tokenIds in ERC721 and ERC1155 tokens in L2.

- `getLayer2BalancesDetails(ercList)` where you can pass a list of ERC contract addresses to filter. If you don't pass parameters it doesn't filter and return all the ERC contracts balance.

```
const balances = await nf3User1.getLayer2BalancesDetails(['0x103ac4b398bca487df8b27fd484549e33c234b0d']);
```

Example where the first address is an ERC20 and the second is ERC721 with 2 tokenIds.
```
 {
  '0xb5acbe9a0f1f8b98f3fc04471f7fe5d2c222cb44': [ { balance: 60, tokenId: 0 } ],
  '0x103ac4b398bca487df8b27fd484549e33c234b0d': [ { balance: 1, tokenId: 1 }, { balance: 1, tokenId: 2 } ]
}
```