### PR TITLE
Use Transaction Hash when deciding if client should save blocks

### DIFF
--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -7,6 +7,7 @@ import {
   storeCommitment,
   countCommitments,
   setSiblingInfo,
+  countTransactionHashes,
 } from '../services/commitment-storage.mjs';
 import getProposeBlockCalldata from '../services/process-calldata.mjs';
 import Secrets from '../classes/secrets.mjs';
@@ -26,7 +27,7 @@ async function blockProposedEventHandler(data) {
   const latestTree = await getLatestTree();
   const blockCommitments = transactions.map(t => t.commitments.filter(c => c !== ZERO)).flat();
 
-  if ((await countCommitments(blockCommitments)) > 0) {
+  if ((await countTransactionHashes(block.transactionHashes)) > 0) {
     await saveBlock({ blockNumber: currentBlockCount, transactionHashL1, ...block });
     await Promise.all(transactions.map(t => saveTransaction({ transactionHashL1, ...t })));
   }

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -55,6 +55,15 @@ export async function countCommitments(commitments) {
   return db.collection(COMMITMENTS_COLLECTION).countDocuments(query);
 }
 
+// function to get count of transaction hashes. Used to decide if we should store
+// incoming blocks or transactions.
+export async function countTransactionHashes(transactionHashes) {
+  const connection = await mongo.connection(MONGO_URL);
+  const query = { transactionHash: { $in: transactionHashes } };
+  const db = connection.db(COMMITMENTS_DB);
+  return db.collection(COMMITMENTS_COLLECTION).countDocuments(query);
+}
+
 // function to mark a commitments as on chain for a mongo db
 export async function markOnChain(
   commitments,


### PR DESCRIPTION
This PR closes #360.

Previously, we used commitments to decide if we should store block and transaction information of transactions we care about in `client`. However, when a withdrawal transaction is made - it does not have commitments. Therefore, we do not store it when we should. 

This PR changes this behaviour so that we use `transactionHash` to decide if we should store a block and its transactions.

This can be tested in the following way (you may need to rebuild containers and purge volumes if you are from master): 

1. Fetch `daveroga/test-bug-instant-withdraw` and `./start-nightfall` - stubs circuits can be used.
2. Run `npm run test-e2e`, which should fail at `should allow instant withdraw of existing withdraw`.
3. Cherry-pick this commit onto the branch using `git cherry-pick <this commit sha>`
4. `npm run test-e2e` should now pass.



