### PR TITLE
Add ERC721 and ERC1155 SDK tests to e2e tests

### DIFF
--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -258,11 +258,14 @@ class Nf3 {
         tokenType,
         value,
         this.web3,
+        !!this.ethereumSigningKey,
       );
     } catch (err) {
       throw new Error(err);
     }
-    if (txDataToSign) await this.submitTransaction(txDataToSign, ercAddress, 0);
+    if (txDataToSign) {
+      await this.submitTransaction(txDataToSign, ercAddress, 0);
+    }
     const res = await axios.post(`${this.clientBaseUrl}/deposit`, {
       ercAddress,
       tokenId,

--- a/cli/lib/tokens.mjs
+++ b/cli/lib/tokens.mjs
@@ -13,7 +13,15 @@ Sends an approve transaction to an ERC20/ERC721/ERC1155 contract for a certain a
 * @param {object} provider  - web3 provider
 * @returns {Promise} transaction
 */
-async function approve(ercAddress, ownerAddress, spenderAddress, tokenType, value, provider) {
+async function approve(
+  ercAddress,
+  ownerAddress,
+  spenderAddress,
+  tokenType,
+  value,
+  provider,
+  encodeABI,
+) {
   const abi = getAbi(tokenType);
   const ercContract = new provider.eth.Contract(abi, ercAddress);
 
@@ -23,7 +31,7 @@ async function approve(ercAddress, ownerAddress, spenderAddress, tokenType, valu
       const allowanceBN = new Web3.utils.BN(allowance);
       const valueBN = new Web3.utils.BN(value);
       if (allowanceBN.lt(valueBN)) {
-        if (process.env.USER_ETHEREUM_SIGNING_KEY)
+        if (process.env.USER_ETHEREUM_SIGNING_KEY || encodeABI)
           return ercContract.methods.approve(spenderAddress, APPROVE_AMOUNT).encodeABI();
         await ercContract.methods
           .approve(spenderAddress, APPROVE_AMOUNT)
@@ -35,7 +43,7 @@ async function approve(ercAddress, ownerAddress, spenderAddress, tokenType, valu
     case TOKEN_TYPE.ERC721:
     case TOKEN_TYPE.ERC1155: {
       if (!(await ercContract.methods.isApprovedForAll(ownerAddress, spenderAddress).call())) {
-        if (process.env.USER_ETHEREUM_SIGNING_KEY)
+        if (process.env.USER_ETHEREUM_SIGNING_KEY || encodeABI)
           return ercContract.methods.setApprovalForAll(spenderAddress, true).encodeABI();
         await ercContract.methods
           .setApprovalForAll(spenderAddress, true)

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -224,14 +224,13 @@ export async function getWalletBalance() {
     .map(e => ({
       ercAddress: `0x${BigInt(e.preimage.ercAddress).toString(16).padStart(40, '0')}`, // Pad this to actual address length
       compressedPkd: e.preimage.compressedPkd,
-      tokenId: !!BigInt(e.preimage.tokenId),
       value: Number(BigInt(e.preimage.value)),
     }))
-    .filter(e => e.tokenId || e.value > 0) // there should be no commitments with tokenId and value of ZERO
+    .filter(e => e.value > 0) // there should be no commitments with value of ZERO
     .map(e => ({
       compressedPkd: e.compressedPkd,
       ercAddress: e.ercAddress,
-      balance: e.tokenId ? 1 : e.value,
+      balance: e.value,
     }))
     .reduce((acc, e) => {
       if (!acc[e.compressedPkd]) acc[e.compressedPkd] = {};
@@ -267,36 +266,29 @@ export async function getWalletBalanceDetails(compressedPkd, ercList) {
     .map(e => ({
       ercAddress: `0x${BigInt(e.preimage.ercAddress).toString(16).padStart(40, '0')}`, // Pad this to actual address length
       compressedPkd: e.preimage.compressedPkd,
-      tokenId: !!BigInt(e.preimage.tokenId),
+      tokenId: Number(BigInt(e.preimage.tokenId)),
       value: Number(BigInt(e.preimage.value)),
-      id: Number(BigInt(e.preimage.tokenId)),
     }))
     .filter(
       e =>
-        (e.tokenId || e.value > 0) &&
+        e.value > 0 &&
         e.compressedPkd === compressedPkd &&
         (ercAddressList.length === 0 || ercAddressList.includes(e.ercAddress.toUpperCase())),
     ) // there should be no commitments with tokenId and value of ZERO
     .map(e => ({
       compressedPkd: e.compressedPkd,
       ercAddress: e.ercAddress,
-      balance: e.tokenId && e.value === 0 ? 1 : e.value, // ERC20 and ERC1155 should get the value
-      tokenId: e.id,
-      erc1155: !!(e.tokenId && e.value > 0),
+      balance: e.value,
+      tokenId: e.tokenId,
     }))
     .reduce((acc, e) => {
       if (!acc[e.compressedPkd]) acc[e.compressedPkd] = {};
       if (!acc[e.compressedPkd][e.ercAddress]) acc[e.compressedPkd][e.ercAddress] = [];
-      if (e.tokenId === 0 && acc[e.compressedPkd][e.ercAddress].length > 0) {
-        acc[e.compressedPkd][e.ercAddress][0].balance += e.balance;
-      } else if (e.erc1155) {
-        const list = acc[e.compressedPkd][e.ercAddress];
-        const tokenIdIndex = list.findIndex(c => c.tokenId === e.tokenId);
-        if (tokenIdIndex >= 0) {
-          list[tokenIdIndex].balance += e.balance;
-        } else {
-          acc[e.compressedPkd][e.ercAddress].push({ balance: e.balance, tokenId: e.tokenId });
-        }
+
+      const list = acc[e.compressedPkd][e.ercAddress];
+      const tokenIdIndex = list.findIndex(c => c.tokenId === e.tokenId);
+      if (tokenIdIndex >= 0) {
+        list[tokenIdIndex].balance += e.balance;
       } else {
         acc[e.compressedPkd][e.ercAddress].push({ balance: e.balance, tokenId: e.tokenId });
       }
@@ -329,14 +321,14 @@ export async function getWalletCommitments() {
     .map(e => ({
       ercAddress: `0x${BigInt(e.preimage.ercAddress).toString(16).padStart(40, '0')}`,
       compressedPkd: e.preimage.compressedPkd,
-      tokenId: !!BigInt(e.preimage.tokenId),
+      tokenId: Number(BigInt(e.preimage.tokenId)),
       value: Number(BigInt(e.preimage.value)),
     }))
     .filter(e => e.tokenId || e.value > 0) // there should be no commitments with tokenId and value of ZERO
     .map(e => ({
       compressedPkd: e.compressedPkd,
       ercAddress: e.ercAddress,
-      balance: e.tokenId ? 1 : e.value,
+      balance: e.value,
     }))
     .reduce((acc, e) => {
       if (!acc[e.compressedPkd]) acc[e.compressedPkd] = {};

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -185,7 +185,7 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
           uint256(t.value)
         );
     } else if(t.tokenType == TokenType.ERC721) {
-      if (t.value != 0 || t.tokenId == ZERO) // value should always be equal to 0 and tokenId cannot be equal to ZERO
+      if (t.value != 1) // value should always be equal to 1
         revert("Invalid inputs for ERC721 deposit");
       else
         tokenContract.safeTransferFrom(
@@ -195,7 +195,7 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
           ''
         );
     } else if (t.tokenType == TokenType.ERC1155) {
-      if (t.tokenId == ZERO && t.value == 0) // disallow this corner case
+      if (t.value == 0) // disallow this corner case
         revert("Depositing zero-value ERC1155 tokens is not allowed");
       else
         tokenContract.safeTransferFrom(
@@ -221,7 +221,7 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
       else
         tokenContract.transferFrom(msg.sender, address(this), uint256(t.value));
     } else if(t.tokenType == TokenType.ERC721) {
-      if (t.value != 0 || t.tokenId == ZERO) // value should always be equal to 0 and tokenId cannot be equal to ZERO
+      if (t.value != 1) // value should always be equal to 1
         revert("Invalid inputs for ERC721 deposit");
       else
         tokenContract.safeTransferFrom(
@@ -231,7 +231,7 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
           ''
         );
     } else if (t.tokenType == TokenType.ERC1155) {
-      if (t.tokenId == ZERO && t.value == 0) // disallow this corner case
+      if (t.value == 0) // disallow this corner case
         revert("Depositing zero-value ERC1155 tokens is not allowed");
       else
         tokenContract.safeTransferFrom(

--- a/test/constants.mjs
+++ b/test/constants.mjs
@@ -1,5 +1,7 @@
 export const tokenId = '0x00';
 export const tokenType = 'ERC20'; // it can be 'ERC721' or 'ERC1155'
+export const tokenTypeERC721 = 'ERC721';
+export const tokenTypeERC1155 = 'ERC1155';
 export const value = 10;
 // this is the etherum private key for accounts[0]
 export const privateKey = '0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69e';

--- a/test/e2e/nightfall-sdk.test.mjs
+++ b/test/e2e/nightfall-sdk.test.mjs
@@ -447,9 +447,9 @@ describe('Testing the Nightfall SDK', () => {
         balanceBefore = 0;
       }
       // We create enough transactions to fill numDeposits blocks full of deposits.
-      let res = await nf3User1.deposit(erc721Address, tokenTypeERC721, 0, 1, fee);
+      let res = await nf3User1.deposit(erc721Address, tokenTypeERC721, 1, 1, fee);
       expectTransaction(res);
-      res = await nf3User1.deposit(erc721Address, tokenTypeERC721, 0, 2, fee);
+      res = await nf3User1.deposit(erc721Address, tokenTypeERC721, 1, 2, fee);
       expectTransaction(res);
       stateBalance += fee * 2 + BLOCK_STAKE;
       // Wait until we see the right number of blocks appear
@@ -476,7 +476,6 @@ describe('Testing the Nightfall SDK', () => {
         balanceBefore = 0;
         balanceBefore2 = 0;
       }
-
       // We create enough transactions to fill numDeposits blocks full of deposits.
       let res = await nf3User1.deposit(erc1155Address, tokenTypeERC1155, value, 1, fee);
       expectTransaction(res);
@@ -526,9 +525,9 @@ describe('Testing the Nightfall SDK', () => {
       const currentPkdBalance = balances[nf3User1.zkpKeys.compressedPkd][erc721Address];
 
       // We create enough transactions to fill numDeposits blocks full of deposits.
-      let res = await nf3User1.deposit(erc721Address, tokenTypeERC721, 0, 3, fee);
+      let res = await nf3User1.deposit(erc721Address, tokenTypeERC721, 1, 3, fee);
       expectTransaction(res);
-      res = await nf3User1.deposit(erc721Address, tokenTypeERC721, 0, 4, fee);
+      res = await nf3User1.deposit(erc721Address, tokenTypeERC721, 1, 4, fee);
       expectTransaction(res);
       stateBalance += fee * 2 + BLOCK_STAKE;
       // Wait until we see the right number of blocks appear
@@ -555,7 +554,6 @@ describe('Testing the Nightfall SDK', () => {
         beforePkdBalance1 = 0;
         beforePkdBalance2 = 0;
       }
-
       // We create enough transactions to fill numDeposits blocks full of deposits.
       let res = await nf3User1.deposit(erc1155Address, tokenTypeERC1155, value, Id1, fee);
       expectTransaction(res);
@@ -644,9 +642,9 @@ describe('Testing the Nightfall SDK', () => {
     it('should decrement the balance after transfer ERC721 to other wallet and increment the other wallet', async function () {
       let balances = await nf3User1.getLayer2Balances();
       // We create enough transactions to fill block full of deposits.
-      let res = await nf3User1.deposit(erc721Address, tokenTypeERC721, 0, 5, fee);
+      let res = await nf3User1.deposit(erc721Address, tokenTypeERC721, 1, 5, fee);
       expectTransaction(res);
-      res = await nf3User1.deposit(erc721Address, tokenTypeERC721, 0, 6, fee);
+      res = await nf3User1.deposit(erc721Address, tokenTypeERC721, 1, 6, fee);
       expectTransaction(res);
       stateBalance += fee * 2 + BLOCK_STAKE;
       // Wait until we see the right number of blocks appear
@@ -666,7 +664,7 @@ describe('Testing the Nightfall SDK', () => {
         false,
         erc721Address,
         tokenTypeERC721,
-        0,
+        1,
         5,
         nf3User2.zkpKeys.pkd,
         fee,
@@ -677,7 +675,7 @@ describe('Testing the Nightfall SDK', () => {
         false,
         erc721Address,
         tokenTypeERC721,
-        0,
+        1,
         6,
         nf3User2.zkpKeys.pkd,
         fee,

--- a/test/e2e/nightfall-sdk.test.mjs
+++ b/test/e2e/nightfall-sdk.test.mjs
@@ -1126,7 +1126,6 @@ describe('Testing the Nightfall SDK', () => {
       // now we need to sign the transaction and send it to the blockchain
       // this will only work if we're using Ganache, otherwiise expect failure
       startBalance = await getBalance(nf3User1.ethereumAddress);
-      console.log('STARTBALANCE:', startBalance);
       if (nodeInfo.includes('TestRPC')) {
         let res = await nf3User1.finaliseWithdrawal(withdrawTransactions[0]);
         stateBalance += fee;
@@ -1151,7 +1150,6 @@ describe('Testing the Nightfall SDK', () => {
         this.skip();
       }
       endBalance = await getBalance(nf3User1.ethereumAddress);
-      console.log('ENDBALANCE:', endBalance);
     });
 
     it('should create a passing ERC721 finalise-withdrawal with a time-jump capable test client (because sufficient time has passed)', async function () {

--- a/test/e2e/nightfall-sdk.test.mjs
+++ b/test/e2e/nightfall-sdk.test.mjs
@@ -174,19 +174,27 @@ describe('Testing the Nightfall SDK', () => {
         web3,
       );
       // approve tokens to be advanced by liquidity provider in the instant withdraw
+      let txDataToSign;
       try {
-        await approve(
+        txDataToSign = await approve(
           erc20Address,
           nf3LiquidityProvider.ethereumAddress,
           nf3LiquidityProvider.shieldContractAddress,
           tokenType,
           value,
           web3,
+          !!nf3LiquidityProvider.ethereumSigningKey,
         );
+        if (txDataToSign) {
+          await nf3LiquidityProvider.submitTransaction(txDataToSign, erc20Address, 0);
+        }
         await nf3LiquidityProvider.advanceInstantWithdrawal(withdrawTransactionHash);
       } catch (e) {
         console.log(e);
       }
+
+      console.log(`     Serviced instant-withdrawal request from ${paidBy}, with fee ${amount}`);
+
       await new Promise(resolve => setTimeout(resolve, 5000));
       const balancesAfter = await getERCInfo(
         erc20Address,
@@ -201,7 +209,6 @@ describe('Testing the Nightfall SDK', () => {
       // difference in balance in L1 account to check instant withdraw is ok
       diffBalanceInstantWithdraw = Number(balancesBefore.balance) - Number(balancesAfter.balance);
       logCounts.instantWithdaw += 1;
-      console.log(`     Serviced instant-withdrawal request from ${paidBy}, with fee ${amount}`);
     });
 
     nodeInfo = await web3.eth.getNodeInfo();

--- a/test/e2e/nightfall-sdk.test.mjs
+++ b/test/e2e/nightfall-sdk.test.mjs
@@ -210,7 +210,6 @@ describe('Testing the Nightfall SDK', () => {
       }
       stateBalance += fee + BLOCK_STAKE;
       eventLogs = await waitForEvent(eventLogs, ['blockProposed'], 3);
-
       const balancesAfter = await getERCInfo(
         erc20Address,
         nf3LiquidityProvider.ethereumAddress,

--- a/test/e2e/nightfall-sdk.test.mjs
+++ b/test/e2e/nightfall-sdk.test.mjs
@@ -709,7 +709,7 @@ describe('Testing the Nightfall SDK', () => {
       const afterPkdBalancePkd = balances[nf3User1.zkpKeys.compressedPkd][erc721Address];
       const afterPkdBalancePkd2 = balances[nf3User2.zkpKeys.compressedPkd][erc721Address];
       expect(afterPkdBalancePkd - beforePkdBalance).to.be.equal(-2);
-      expect(afterPkdBalancePkd2 - beforePkdBalance2).to.be.equal(2); 
+      expect(afterPkdBalancePkd2 - beforePkdBalance2).to.be.equal(2);
     });
 
     it('should decrement the balance after transfer ERC1155 to other wallet and increment the other wallet', async function () {


### PR DESCRIPTION
Now we have some tests about ERC20 in e2e test. This PR will add different tests for ERC721 and ERC1155 and will correct issues we could find during testing. 

- Remove restrictions in Shield contract about tokenId in ERC721 and ERC1155. Now tokenId = 0 is allowed. 
- Calculation of balances in `commitments-storage.mjs` from commitment value and tokenId now for an ercAddress. If it's an ERC20 tokenId will be 0.  (Ex.: [ { balance: 60, tokenId: 0 } ])
- Fix nonce error when changing deposit from ERC20 to ERC721. Approve transaction with missing encodeABI was the cause.

To test the PR `npm run test-e2e`

Fixes issues #385 , #384 , #381 , #379 .
