### PR TITLE
daveroga/blockProposedEventHandler not updating transfer commitment

### DIFF
--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -62,7 +62,9 @@ async function blockProposedEventHandler(data) {
         }
       });
     }
-    await Promise.all(storeCommitments);
+    await Promise.all(storeCommitments).catch(function (err) {
+      logger.info(err);
+    }); // control errors when storing commitments in order to ensure next Promise being executed
     return Promise.all([
       markOnChain(nonZeroCommitments, block.blockNumberL2, data.blockNumber, data.transactionHash),
       markNullifiedOnChain(

--- a/nightfall-client/src/services/keys.mjs
+++ b/nightfall-client/src/services/keys.mjs
@@ -75,7 +75,10 @@ export async function generateKeys(mnemonic, path) {
 }
 
 export function storeMemoryKeysForDecryption(ivk, nsk) {
-  return Promise.all([ivks.push(...ivk), nsks.push(...nsk)]);
+  return Promise.all([
+    ivks.includes(ivk[0]) ? ivks : ivks.push(...ivk),
+    nsks.includes(nsk[0]) ? nsk : nsks.push(...nsk),
+  ]);
 }
 
 export function calculateIvkPkdfromAskNsk(ask, nsk) {


### PR DESCRIPTION
Fix issue #388 .

It seems the problem is in nightfall-client in `block-proposed.mjs` when trying to store the commitment it throws an error of duplicate key for some reason.
- duplicate key error collection: nightfall_commitments.commitments index: _id_ dup key: { _id: "0x1259f9c3d5853a758c859eb274ca22c3019cea26f73e2318d1d90d4daf417792" } MongoError: E11000 duplicate key error collection: nightfall_commitments.commitments index: _id_ dup key: { _id: "0x1259f9c3d5853a758c859eb274ca22c3019cea26f73e2318d1d90d4daf417792" }


```
async function blockProposedEventHandler(data) {
...
  await Promise.all(storeCommitments);
  return Promise.all([
      markOnChain(nonZeroCommitments, block.blockNumberL2, data.blockNumber, data.transactionHash),
      markNullifiedOnChain(
        nonZeroNullifiers,
        block.blockNumberL2,
        data.blockNumber,
        data.transactionHash,
      ),
    ]);
...
}
```

This error is causing the second Promise.all that should mark the commitment as on chain and nullified on chain not being executed.
It can be solved by controlling the error in the first Promise as shown bellow.

```
async function blockProposedEventHandler(data) {
...
  await Promise.all(storeCommitments).catch(function (err) {
    logger.info(err);
  });
  return Promise.all([
      markOnChain(nonZeroCommitments, block.blockNumberL2, data.blockNumber, data.transactionHash),
      markNullifiedOnChain(
        nonZeroNullifiers,
        block.blockNumberL2,
        data.blockNumber,
        data.transactionHash,
      ),
    ]);
...
}
```

Other question is why here it throws the commitment as being duplicated and not in other transfer transactions that will be investigated later.