### PR TITLE
docs: add g16 malleability write up

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ npm test-chain-reorg
 
 The script `./geth-standalone` will run up a private blockchain consisting of a bootnode, two client nodes and two miners.  This is required for testing chain reorganisations (Ganache does not simulate a chain-reorg) but can be used for other tests or general running.  It's slower than using Ganache but it does provide a more real-life test. Note also that the private chain exposes a client on `host.docker.internal:8546`.  On a Mac this will map to `localhost` but it won't work on any other machine. If you aren't on a Mac then you can do one of these 3 options:
 - If you are on a Linux you can edit `/etc/hosts` file and add a map from your private IP address of your connected interface to the domain `host.docker.internal`. In this case `127.0.0.1` is not valid. You can check your private IP address with `ip address`.  
-- Edit `nightfall-deployer/truffle-config.js` to point to the IP of your `localhost` 
+- Edit `nightfall-deployer/truffle-config.js` to point to the IP of your `localhost`
 - Use the docker-compose line `external_servers` to inject a hostname into the containers host file (see the Github workflows for further clues about how to do that).
 
 To use the private blockchain:
@@ -165,6 +165,8 @@ More information can be found [here](https://github.com/EYBlockchain/nightfall_3
 - Direct transactions are not implemented
 - Instant withdraw is selected when doing a withdraw only. Once submitted the instant withdraw request,the wallet requests a simple withdraw and inmediatelly after converts this withdraw into an instant withdraw. Wallet will attempt to send the instant withdraw request up to 10 times, once every 10 seconds. It is likely that during this period, you need to request a simpler transaction (deposit, withdraw or transfer) so that the original withdraw is processed by the processor and the instant withdraw can be carried out.
 - Tested with node version v14.18.0
+
+Nightfall uses the G16 proof system, and we believe it is [not vulnerable](./doc/G16-malleability.md) to its malleability. 
 
 # Acknowledgements
 

--- a/doc/G16-malleability.md
+++ b/doc/G16-malleability.md
@@ -1,0 +1,31 @@
+# G16 Simulation Extractability
+
+## What is it?
+
+The Groth-16 Zero-Knowledge Proof system has a malleability which allows an observer, given a valid proof, to create a different but also valid proof without knowing the witness.
+
+For example, say one user claims a token by providing a G16 proof demonstrating they have completed some challenge. An attacker could use this malleability to provide another valid proof without completing the challenge. Ensuring that users do not replay proofs does _not_ protect against this kind of attack.
+
+The proof system GM17 addresses this malleability but at the cost of longer computation time and higher verification gas usage. We previously used GM17 for Nightfall, but switched to G16 for efficiency.
+
+## Attack prevention
+
+As ZoKrates [suggests](https://zokrates.github.io/toolbox/proving_schemes.html?#g16-malleability), requiring signed proofs would protect against this attack. Since an adversary cannot change the witness, they cannot change a signing public key (assuming it is part of that witness) and hence have no way to create a valid signed proof. Similarly, using the prover's Ethereum address as a public input prevents other users from exploiting their proofs. However, that user could still malleate their _own_ proofs.
+
+Nullifiers by design prevent double spending and replaying certain data. As long as the proof's witness contains a unique piece of data, nullifying it ensures G16 proofs cannot be exploited.
+
+## Application to Nightfall
+
+In short, Nightfall's design means it cannot be attacked with the G16 malleability. The use of nullifiers means that an attacker is prevented from spending any commitments they don't own, and having separate circuits for minting and spending means maliciously 'replaying' a deposit transaction is fruitless.
+
+To explain in a bit more detail, an attacker _could_ use the malleability to create a valid but different proof for transferring or withdrawing commitments. However, they cannot change the commitments' nullifiers, and so their transaction will fail.
+
+They additionally can't front-run a malleated withdraw transaction with their own address since the recipient address is part of the witness. Similarly, they cannot change any details of a transfer, so front-running it would only allow the original recipient access to their commitment faster.
+
+A deposit proof has no nullifiers, but an attacker cannot force an innocent user to deposit twice or claim any deposited tokens.
+
+While there is no check against duplicate commitments, all an attacker could do with a malleated deposit proof is create an identical commitment they cannot spend and deposit their own tokens for it!
+
+---
+
+Thanks to @dwebchapey for research into this topic. More discussion can be found [here](https://github.com/EYBlockchain/nightfall_3/issues/298).  


### PR DESCRIPTION
Added some documentation to explain how NF is not vulnerable to the G16 malleability. Closes #298.