### PR TITLE
Add platform keyword to build on M1 Macs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
     command: ['npm', 'run', 'dev']
 
   worker:
+    platform: linux/amd64
     #  image: 3800decac71d
     build:
       dockerfile: Dockerfile
@@ -178,6 +179,7 @@ services:
       - nightfall_network
 
   optimist1:
+    platform: linux/amd64
     build:
       context: ./nightfall-optimist
     depends_on:
@@ -212,6 +214,7 @@ services:
     command: ['npm', 'run', 'dev']
 
   optimist2:
+    platform: linux/amd64
     build:
       context: ./nightfall-optimist
     depends_on:


### PR DESCRIPTION
By default, `docker` builds images based on the underlying OS of the host machine that calls `build`. New M1 Macs have an arm-based CPU compared to the x86-based CPU of previous Intel Macs.

While most packages have an arm compatible package, `zokrates 0.7.7` does not. (Note that `zokrates 0.7.10` has a arm-package, although it is not currently available as an image).

Both `worker` and `optimist` are built from this image and thus fail to properly run as critical linking libraries are not available. To get around this we explicitly set the platform that these should be built to.

An alternative solution would be to set `DEFAULT_DOCKER_PLATFORM`, however this Multi-platform build feature requires the semi-experimental `docker buildx` workflow.