### PR TITLE
faster zokrates build

### DIFF
--- a/.github/workflows/check-PRs.yml
+++ b/.github/workflows/check-PRs.yml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Start Containers
         run: |
+          docker build --no-cache	-t ghcr.io/eyblockchain/local-zokrates -f zokrates.Dockerfile .
           docker-compose build
           ./start-nightfall -wt -s &
 
@@ -105,6 +106,7 @@ jobs:
 
       - name: Start Containers with ganache
         run: |
+          docker build --no-cache	-t ghcr.io/eyblockchain/local-zokrates -f zokrates.Dockerfile .
           docker-compose build
           ./start-nightfall -g &> test-gas.log &disown
         env:

--- a/.github/workflows/check-PRs.yml
+++ b/.github/workflows/check-PRs.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           npm ci
           npm run lint
-         
+
   ganache-test:
     runs-on: ubuntu-18.04
     steps:
@@ -28,6 +28,7 @@ jobs:
 
       - name: Start Containers
         run: |
+          docker build --no-cache	-t ghcr.io/eyblockchain/local-zokrates -f zokrates.Dockerfile .
           docker-compose build
           ./start-nightfall -g &> ganache-test.log &disown
 
@@ -75,7 +76,7 @@ jobs:
         run: sleep 2500
 
       - name: Retrieve Wallet test logs
-        run: docker logs $(docker ps -aqf "name=wallet-test") > wallet-test.log; cat wallet-test.log; 
+        run: docker logs $(docker ps -aqf "name=wallet-test") > wallet-test.log; cat wallet-test.log;
 
       - name: debug logs - after container startup
         if: always()

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -26,6 +26,13 @@ jobs:
 
     - run: echo ${{ steps.semantic.outputs.release-version }}
 
+    - name: Docker push latest
+      run: |
+        docker build -t ghcr.io/eyblockchain/local-zokrates . -f zokrates.Dockerfile
+        docker push ghcr.io/eyblockchain/local-zokrates
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Docker push version
       if: steps.semantic.outputs.new-release-published == 'true'
       run: |

--- a/nightfall-optimist/Dockerfile
+++ b/nightfall-optimist/Dockerfile
@@ -1,13 +1,5 @@
 # build zokrates from source for local verify
-FROM rust:1.53.0 as builder
-WORKDIR /app
-COPY . .
-# Zokrates 0.7.10
-RUN git clone --depth 1 --branch 0.7.10 https://github.com/Zokrates/ZoKrates.git
-WORKDIR /app/ZoKrates
-# For Mac Silicon this will default to aarch64-unknown-linux-gnu
-RUN rustup toolchain install nightly
-RUN cargo +nightly build --release
+FROM ghcr.io/eyblockchain/local-zokrates as builder
 
 FROM mongo:focal
 

--- a/optimist.Dockerfile
+++ b/optimist.Dockerfile
@@ -1,13 +1,5 @@
 # build zokrates from source for local verify
-FROM rust:1.53.0 as builder
-WORKDIR /app
-COPY . .
-# Zokrates 0.7.10
-RUN git clone --depth 1 --branch 0.7.10 https://github.com/Zokrates/ZoKrates.git
-WORKDIR /app/ZoKrates
-# For Mac Silicon this will default to aarch64-unknown-linux-gnu
-RUN rustup toolchain install nightly
-RUN cargo +nightly build --release
+FROM ghcr.io/eyblockchain/local-zokrates as builder
 
 FROM mongo:focal
 # install node

--- a/setup-nightfall
+++ b/setup-nightfall
@@ -2,5 +2,5 @@
 
 # Install node dependencies
 npm ci
-
+docker build --no-cache	-t ghcr.io/eyblockchain/local-zokrates -f zokrates.Dockerfile .
 docker-compose build --no-cache

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -1,11 +1,5 @@
 # build zokrates from source for local verify
-FROM rust:1.53.0 as builder
-WORKDIR /app
-COPY . .
-RUN git clone --depth 1 --branch 0.7.10 https://github.com/Zokrates/ZoKrates.git
-WORKDIR /app/ZoKrates
-RUN rustup toolchain install nightly
-RUN cargo +nightly build --release
+FROM ghcr.io/eyblockchain/local-zokrates as builder
 
 FROM ubuntu:20.04
 WORKDIR /app

--- a/zokrates-worker/Dockerfile
+++ b/zokrates-worker/Dockerfile
@@ -1,11 +1,5 @@
 # build zokrates from source for local verify
-FROM rust:1.53.0 as builder
-WORKDIR /app
-COPY . .
-RUN git clone --depth 1 --branch 0.7.10 https://github.com/Zokrates/ZoKrates.git
-WORKDIR /app/ZoKrates
-RUN rustup toolchain install nightly
-RUN cargo +nightly build --release
+FROM ghcr.io/eyblockchain/local-zokrates as builder
 
 FROM ubuntu:20.04
 WORKDIR /app

--- a/zokrates.Dockerfile
+++ b/zokrates.Dockerfile
@@ -1,0 +1,10 @@
+# build zokrates from source for local verify
+FROM rust:1.53.0 as builder
+WORKDIR /app
+COPY . .
+# Zokrates 0.7.10
+RUN git clone --depth 1 --branch 0.7.10 https://github.com/Zokrates/ZoKrates.git
+WORKDIR /app/ZoKrates
+# For Mac Silicon this will default to aarch64-unknown-linux-gnu
+RUN rustup toolchain install nightly
+RUN cargo +nightly build --release


### PR DESCRIPTION
This tweak builds a separate zokrates container image, from which optimist and worker copy the zokrates binary. That means we only compile zokrates once, which saves about 10 mins of build time on PR #404 