### PR TITLE
Increased timings 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       OPTIMIST_HOST: optimist1
       OPTIMIST_PORT: 80
       USE_STUBS: 'false' # make sure this flag is the same as in deployer service
+      RETRIES: 80
     command: ['npm', 'run', 'dev']
 
   client2:

--- a/wallet/test/tx_test.py
+++ b/wallet/test/tx_test.py
@@ -110,7 +110,7 @@ def waitBalanceChange(l1Balance, l2Balance, txParams, nTx, findElementsInstance)
     "tokenAddress": tokens['erc20'],
   }
   while True:
-    sleep(5)
+    sleep(10)
     tokenRefresh(txTestParams,findElementsInstance)
     if niter == 15:
       errorMsg = "FAILED - waited too long\n"


### PR DESCRIPTION
When a block is submitted, now clients may wait up to 12 blocks for confirmation. This has an impact on wallet transaction tests, which expected results much earlier. 

Additionally, i have seen that when launching `./start-nightfall -wt -s` (running wallet tests), nightfall-client used to timed out waiting for some contract to be deployed. I have increased RETRIEs from 50 to 80.

Also, i have seen that wallet tests could start before all contracts were deployed. I have added a new synchronization mechanism to prevent this from happening.

Finally, in order to provide simpler debugging with wallet tests, i now display information about proposer and liquidity provider.