### PR TITLE
fix: remove length check in invalid txn typecheck

### DIFF
--- a/nightfall-deployer/contracts/ChallengesUtil.sol
+++ b/nightfall-deployer/contracts/ChallengesUtil.sol
@@ -82,7 +82,7 @@ library ChallengesUtil {
                 transaction.commitments[1] != ZERO ||
                 transaction.nullifiers[0] != ZERO ||
                 transaction.nullifiers[1] != ZERO ||
-                transaction.compressedSecrets.length != nZeroCompressedSecrets ||
+                nZeroCompressedSecrets != 8 ||
                 nZeroProof == 4 || // We assume that 3 out of the 4 proof elements can be a valid ZERO. Deals with exception cases
                 transaction.historicRootBlockNumberL2[0] != 0 ||
                 transaction.historicRootBlockNumberL2[1] != 0,
@@ -168,7 +168,7 @@ library ChallengesUtil {
                 transaction.commitments[1] != ZERO ||
                 transaction.nullifiers[0] == ZERO ||
                 transaction.nullifiers[1] != ZERO ||
-                transaction.compressedSecrets.length != nZeroCompressedSecrets ||
+                nZeroCompressedSecrets != 8 ||
                 nZeroProof == 4 || // We assume that 3 out of the 4 proof elements can be a valid ZERO. Deals with exception cases
                 transaction.historicRootBlockNumberL2[1] != 0, // A withdraw has a similar constraint as a single transfer
             'This withdraw transaction type is valid'

--- a/nightfall-deployer/contracts/ChallengesUtil.sol
+++ b/nightfall-deployer/contracts/ChallengesUtil.sol
@@ -76,9 +76,6 @@ library ChallengesUtil {
                 transaction.recipientAddress != ZERO ||
                 transaction.commitments[0] == ZERO ||
                 transaction.commitments[1] != ZERO ||
-                transaction.commitments.length != 1 ||
-                transaction.nullifiers.length != 0 ||
-                transaction.compressedSecrets.length != 0 ||
                 nZeroProof == 4 || // We assume that 3 out of the 4 proof elements can be a valid ZERO. Deals with exception cases
                 transaction.historicRootBlockNumberL2[0] != 0 ||
                 transaction.historicRootBlockNumberL2[1] != 0,
@@ -106,10 +103,8 @@ library ChallengesUtil {
                 transaction.recipientAddress != ZERO ||
                 transaction.commitments[0] == ZERO ||
                 transaction.commitments[1] != ZERO ||
-                transaction.commitments.length != 1 ||
                 transaction.nullifiers[0] == ZERO ||
                 transaction.nullifiers[1] != ZERO ||
-                transaction.nullifiers.length != 1 ||
                 nZeroCompressedSecrets == 8 || // We assume that 7 out of the 8 compressed secrets elements can be a valid ZERO. Deals with exception cases
                 nZeroProof == 4 || // We assume that 3 out of the 4 proof elements can be a valid ZERO. Deals with exception cases
                 transaction.historicRootBlockNumberL2[1] != 0, // If this is a single, the second historicBlockNumber needs to be zero
@@ -137,10 +132,8 @@ library ChallengesUtil {
                 transaction.recipientAddress != ZERO ||
                 transaction.commitments[0] == ZERO ||
                 transaction.commitments[1] == ZERO ||
-                transaction.commitments.length != 2 ||
                 transaction.nullifiers[0] == ZERO ||
                 transaction.nullifiers[1] == ZERO ||
-                transaction.nullifiers.length != 2 ||
                 nZeroCompressedSecrets == 8 || // We assume that 7 out of the 8 compressed secrets elements can be a valid ZERO. Deals with exception cases
                 nZeroProof == 4, // We assume that 3 out of the 4 proof elements can be a valid ZERO. Deals with exception cases
             'This double transfer transaction type is valid'
@@ -160,11 +153,8 @@ library ChallengesUtil {
                 (transaction.tokenId == ZERO && transaction.value == 0) ||
                 transaction.ercAddress == ZERO ||
                 transaction.recipientAddress == ZERO ||
-                transaction.commitments.length != 0 ||
                 transaction.nullifiers[0] == ZERO ||
                 transaction.nullifiers[1] != ZERO ||
-                transaction.nullifiers.length != 1 ||
-                transaction.compressedSecrets.length != 0 ||
                 nZeroProof == 4 || // We assume that 3 out of the 4 proof elements can be a valid ZERO. Deals with exception cases
                 transaction.historicRootBlockNumberL2[1] != 0, // A withdraw has a similar constraint as a single transfer
             'This withdraw transaction type is valid'

--- a/nightfall-deployer/contracts/ChallengesUtil.sol
+++ b/nightfall-deployer/contracts/ChallengesUtil.sol
@@ -70,12 +70,19 @@ library ChallengesUtil {
         for (uint256 i = 0; i < transaction.proof.length; i++) {
             if (transaction.proof[i] == 0) nZeroProof++;
         }
+        uint256 nZeroCompressedSecrets;
+        for (uint256 i = 0; i < transaction.compressedSecrets.length; i++) {
+            if (transaction.compressedSecrets[i] == 0) nZeroCompressedSecrets++;
+        }
         require(
                 (transaction.tokenId == ZERO && transaction.value == 0) ||
                 transaction.ercAddress == ZERO ||
                 transaction.recipientAddress != ZERO ||
                 transaction.commitments[0] == ZERO ||
                 transaction.commitments[1] != ZERO ||
+                transaction.nullifiers[0] != ZERO ||
+                transaction.nullifiers[1] != ZERO ||
+                transaction.compressedSecrets.length != nZeroCompressedSecrets ||
                 nZeroProof == 4 || // We assume that 3 out of the 4 proof elements can be a valid ZERO. Deals with exception cases
                 transaction.historicRootBlockNumberL2[0] != 0 ||
                 transaction.historicRootBlockNumberL2[1] != 0,
@@ -149,12 +156,19 @@ library ChallengesUtil {
         for (uint256 i = 0; i < transaction.proof.length; i++) {
             if (transaction.proof[i] == 0) nZeroProof++;
         }
+        uint256 nZeroCompressedSecrets;
+        for (uint256 i = 0; i < transaction.compressedSecrets.length; i++) {
+            if (transaction.compressedSecrets[i] == 0) nZeroCompressedSecrets++;
+        }
         require(
                 (transaction.tokenId == ZERO && transaction.value == 0) ||
                 transaction.ercAddress == ZERO ||
                 transaction.recipientAddress == ZERO ||
+                transaction.commitments[0] != ZERO ||
+                transaction.commitments[1] != ZERO ||
                 transaction.nullifiers[0] == ZERO ||
                 transaction.nullifiers[1] != ZERO ||
+                transaction.compressedSecrets.length != nZeroCompressedSecrets ||
                 nZeroProof == 4 || // We assume that 3 out of the 4 proof elements can be a valid ZERO. Deals with exception cases
                 transaction.historicRootBlockNumberL2[1] != 0, // A withdraw has a similar constraint as a single transfer
             'This withdraw transaction type is valid'


### PR DESCRIPTION
This fixes #424 
Good blocks were successfully challenged previously because of the length checks in libChallengeTransactionType() . 
Fixing the transaction type checks in contract accordingly.