### PR TITLE
(nightfall-browser) bug fix on wallet page reload

### DIFF
--- a/wallet/src/views/wallet/index.jsx
+++ b/wallet/src/views/wallet/index.jsx
@@ -170,7 +170,7 @@ export default function Wallet() {
       });
       setTokens(newState.sort((a, b) => Number(a.order) - Number(b.order)));
     }
-  }, []);
+  }, [state.zkpKeys]);
 
   return (
     <>


### PR DESCRIPTION
this PR fixes a small, bug I create(may be), when wallet page is refreshed token balance is not parsed