### PR TITLE
Integrating PoS proposal: proposers staking

### DIFF
--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -584,14 +584,14 @@ class Nf3 {
   }
 
   /**
-  Withdraw the bond left by the proposer.
-  It will use the address of the Ethereum Signing key that is holds to withdraw the bond.
+  Withdraw the stake left by the proposer.
+  It will use the address of the Ethereum Signing key that is holds to withdraw the stake.
   @method
   @async
   @returns {Promise} A promise that resolves to the Ethereum transaction receipt.
   */
-  async withdrawBond() {
-    const res = await axios.post(`${this.optimistBaseUrl}/proposer/withdrawBond`, {
+  async withdrawStake() {
+    const res = await axios.post(`${this.optimistBaseUrl}/proposer/withdrawStake`, {
       address: this.ethereumAddress,
     });
     return this.submitTransaction(res.data.txDataToSign, this.proposersContractAddress, 0);

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -611,6 +611,21 @@ class Nf3 {
   }
 
   /**
+  Get all the list of existing proposers.
+  @method
+  @async
+  @returns {array} A promise that resolves to the Ethereum transaction receipt.
+  */
+  async getProposerPendingPayments() {
+    const res = await axios.get(`${this.optimistBaseUrl}/proposer/pending-payments`, {
+      params: {
+        proposer: this.ethereumAddress,
+      },
+    });
+    return res.data;
+  }
+
+  /**
   Adds a new Proposer peer to a list of proposers that are available for accepting
   offchain (direct) transfers and withdraws. The client will submit direct transfers
   and withdraws to all of these peers.

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -539,34 +539,30 @@ class Nf3 {
   }
 
   /**
-  Registers a new proposer and pays the Bond required to register.
+  Stakes as a proposer the amount passed.
   It will use the address of the Ethereum Signing key that is holds to register
   the proposer.
   @method
   @async
   @returns {Promise} A promise that resolves to the Ethereum transaction receipt.
   */
-  async registerProposer() {
-    const res = await axios.post(`${this.optimistBaseUrl}/proposer/register`, {
+  async stakeProposer(amount) {
+    const res = await axios.post(`${this.optimistBaseUrl}/proposer/stake`, {
       address: this.ethereumAddress,
     });
-    return this.submitTransaction(
-      res.data.txDataToSign,
-      this.proposersContractAddress,
-      this.PROPOSER_BOND,
-    );
+    return this.submitTransaction(res.data.txDataToSign, this.proposersContractAddress, amount);
   }
 
   /**
-  De-registers an existing proposer.
-  It will use the address of the Ethereum Signing key that is holds to de-register
+  Unstake an existing proposer.
+  It will use the address of the Ethereum Signing key that is holds to unstake
   the proposer.
   @method
   @async
   @returns {Promise} A promise that resolves to the Ethereum transaction receipt.
   */
-  async deregisterProposer() {
-    const res = await axios.post(`${this.optimistBaseUrl}/proposer/de-register`, {
+  async unstakeProposer() {
+    const res = await axios.post(`${this.optimistBaseUrl}/proposer/unstake`, {
       address: this.ethereumAddress,
     });
     return this.submitTransaction(res.data.txDataToSign, this.proposersContractAddress, 0);

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -626,6 +626,20 @@ class Nf3 {
   }
 
   /**
+  Request block payment.
+  @method
+  @async
+  @return {Promise} A promise that resolves to an axios response.
+  */
+  async requestBlockPayment(blockHash) {
+    const res = await axios.post(`${this.optimistBaseUrl}/proposer/payment`, {
+      address: this.ethereumAddress,
+      blockHash,
+    });
+    return this.submitTransaction(res.data.txDataToSign, this.shieldContractAddress, 0);
+  }
+
+  /**
   Adds a new Proposer peer to a list of proposers that are available for accepting
   offchain (direct) transfers and withdraws. The client will submit direct transfers
   and withdraws to all of these peers.

--- a/cli/src/proposer.mjs
+++ b/cli/src/proposer.mjs
@@ -36,7 +36,7 @@ async function startProposer(testEnvironment) {
   await nf3.init(defaultMnemonic);
   if (await nf3.healthcheck('optimist')) console.log('Healthcheck passed');
   else throw new Error('Healthcheck failed');
-  await nf3.registerProposer();
+  await nf3.stakeProposer(1000);
   console.log('Proposer registration complete');
   // TODO subscribe to layer 1 blocks and call change proposer
   nf3.startProposer();

--- a/doc/api.md
+++ b/doc/api.md
@@ -123,9 +123,9 @@ the calling application, along with the fee for the Proposer (as `msg.value`).
 
 # nightfall-optimist
 
-## POST /proposer/register
+## POST /proposer/stake
 
-Creates a transaction to register a Proposer, so that they can start producing blocks.
+Creates a transaction to stake a Proposer, so that they can start producing blocks.
 
 ## Parameters
 

--- a/doc/lib/Nf3.html
+++ b/doc/lib/Nf3.html
@@ -4299,7 +4299,7 @@
     
 
     
-    <h4 class="name" id="withdrawBond"><span class="type-signature">(async) </span>withdrawBond<span class="signature">()</span><span class="type-signature"> &rarr; {Promise}</span></h4>
+    <h4 class="name" id="withdrawStake"><span class="type-signature">(async) </span>withdrawStake<span class="signature">()</span><span class="type-signature"> &rarr; {Promise}</span></h4>
     
 
     

--- a/doc/lib/nf3.mjs.html
+++ b/doc/lib/nf3.mjs.html
@@ -502,21 +502,21 @@ class Nf3 {
   }
 
   /**
-  Registers a new proposer and pays the Bond required to register.
+  Registers a new proposer and pays a stake.
   It will use the address of the Ethereum Signing key that is holds to register
   the proposer.
   @method
   @async
   @returns {Promise} A promise that resolves to the Ethereum transaction receipt.
   */
-  async registerProposer() {
-    const res = await axios.post(`${this.optimistBaseUrl}/proposer/register`, {
+  async stakeProposer(amount) {
+    const res = await axios.post(`${this.optimistBaseUrl}/proposer/stake`, {
       address: this.ethereumAddress,
     });
     return this.submitTransaction(
       res.data.txDataToSign,
       this.proposersContractAddress,
-      this.PROPOSER_BOND,
+      amount,
     );
   }
 

--- a/doc/lib/nf3.mjs.html
+++ b/doc/lib/nf3.mjs.html
@@ -551,14 +551,14 @@ class Nf3 {
   }
 
   /**
-  Withdraw the bond left by the proposer.
-  It will use the address of the Ethereum Signing key that is holds to withdraw the bond.
+  Withdraw the stake left by the proposer.
+  It will use the address of the Ethereum Signing key that is holds to withdraw the stake.
   @method
   @async
   @returns {Promise} A promise that resolves to the Ethereum transaction receipt.
   */
-  async withdrawBond() {
-    const res = await axios.post(`${this.optimistBaseUrl}/proposer/withdrawBond`, {
+  async withdrawStake() {
+    const res = await axios.post(`${this.optimistBaseUrl}/proposer/withdrawStake`, {
       address: this.ethereumAddress,
     });
     return this.submitTransaction(res.data.txDataToSign, this.proposersContractAddress, 0);

--- a/nightfall-deployer/contracts/Config.sol
+++ b/nightfall-deployer/contracts/Config.sol
@@ -3,9 +3,9 @@
 pragma solidity ^0.8.0;
 
 contract Config {
-  uint constant REGISTRATION_BOND = 10 wei; // TODO owner can update
-  uint constant BLOCK_STAKE = 1 wei;
-  uint constant ROTATE_PROPOSER_BLOCKS = 4;
-  uint constant COOLING_OFF_PERIOD = 1 weeks;
+  uint256 constant MINIMUM_STAKE = 10 wei; // TODO owner can update
+  uint256 constant BLOCK_STAKE = 1 wei;
+  uint256 constant ROTATE_PROPOSER_BLOCKS = 4;
+  uint256 constant CHALLENGE_PERIOD = 1 weeks;
   bytes32 constant ZERO = bytes32(0);
 }

--- a/nightfall-deployer/contracts/Proposers.sol
+++ b/nightfall-deployer/contracts/Proposers.sol
@@ -10,8 +10,6 @@ import './Structures.sol';
 import './Stateful.sol';
 
 contract Proposers is Stateful, Structures, Config {
-  // mapping(address => TimeLockedBond) public bondAccounts;
-
   /**
   * Each proposer gets a chance to propose blocks for a certain time, defined
   * in Ethereum blocks.  After a certain number of blocks has passed, the
@@ -20,21 +18,25 @@ contract Proposers is Stateful, Structures, Config {
   */
   function changeCurrentProposer() external {
     require(block.number - state.getProposerStartBlock() > ROTATE_PROPOSER_BLOCKS,
-    "It's too soon to rotate the proposer");
+    "Proposers: Too soon to rotate proposer");
     state.setProposerStartBlock(block.number);
     LinkedAddress memory currentProposer = state.getCurrentProposer();
     state.setCurrentProposer(currentProposer.nextAddress);
-    emit NewCurrentProposer(currentProposer.nextAddress);
+    emit NewCurrentProposer(currentProposer.nextAddress);    
   }
 
-
-  //add the proposer to the circular linked list
-  function registerProposer() external payable {
-    require(REGISTRATION_BOND <= msg.value, 'The registration payment is incorrect');
-    payable(address(state)).transfer(REGISTRATION_BOND);
-    state.setBondAccount(msg.sender,REGISTRATION_BOND);
+  /**
+   * @dev increment stake for proposer
+   */
+  function stakeProposer() external payable {
+    TimeLockedStake memory stake = state.getStakeAccount(msg.sender);
+    stake.amount += msg.value;
+    require(MINIMUM_STAKE <= stake.amount, 'Proposers: Need MINIMUM_STAKE');
+    payable(address(state)).transfer(msg.value);
+    state.setStakeAccount(msg.sender, stake.amount, stake.challengeLocked);
     LinkedAddress memory currentProposer = state.getCurrentProposer();
-    // cope with this being the first proposer
+
+   // cope with this being the first proposer
     if (currentProposer.thisAddress == address(0)) {
       currentProposer = LinkedAddress(msg.sender, msg.sender, msg.sender);
       state.setProposer(msg.sender, currentProposer);
@@ -68,21 +70,22 @@ contract Proposers is Stateful, Structures, Config {
   }
 
   // Proposers are allowed to deregister themselves at any point (even if they are the current proposer)
-  // However, their bond is only withdrawable after the COOLING_OFF_PERIOD has passed. This ensures
+  // However, their stake is only withdrawable after the CHALLENGE_PERIOD has passed. This ensures
   // they are not the proposer of any blocks that could be challenged.
-  function deRegisterProposer() external {
-    require(state.getProposer(msg.sender).thisAddress != address(0), 'This proposer is not registered or you are not that proposer');
+  function unstakeProposer() external {
+    require(state.getProposer(msg.sender).thisAddress != address(0), 'Proposers: Not a proposer');
     state.removeProposer(msg.sender);
-    // The msg.sender has to wait a COOLING_OFF_PERIOD from current block.timestamp
-    state.updateBondAccountTime(msg.sender, block.timestamp);
+    // The msg.sender has to wait a CHALLENGE_PERIOD from current block.timestamp
+    state.updateStakeAccountTime(msg.sender, block.timestamp);
   }
 
-  function withdrawBond() external {
-    TimeLockedBond memory bond = state.getBondAccount(msg.sender);
-    require(bond.time + COOLING_OFF_PERIOD < block.timestamp, 'It is too soon to withdraw your bond');
-    require(state.getProposer(msg.sender).thisAddress == address(0), 'Cannot withdraw bond while a registered proposer');
-    // Zero out the entry in the bond escrow
-    state.setBondAccount(msg.sender,0);
-    state.addPendingWithdrawal(msg.sender,bond.amount);
+  function withdrawStake() external {
+    TimeLockedStake memory stake = state.getStakeAccount(msg.sender);
+    require(stake.time + CHALLENGE_PERIOD < block.timestamp, 'Proposers: Too soon to withdraw the stake');
+    require(state.getProposer(msg.sender).thisAddress == address(0), 'Proposers: Cannot withdraw while staking as proposer');
+    // Zero out the entry in the stake escrow
+    state.setStakeAccount(msg.sender, 0, 0);
+    // We have waited a CHALLENGE_PERIOD so we can also withdraw the pending challengeLocked still pending
+    state.addPendingWithdrawal(msg.sender, stake.amount + stake.challengeLocked);
   }
 }

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -61,6 +61,7 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
     stake.amount += BLOCK_STAKE;
     stake.challengeLocked -= BLOCK_STAKE;
     state.setStakeAccount(msg.sender, stake.amount, stake.challengeLocked);
+    state.setBlockStakeWithdrawn(blockHash);
 
     state.addPendingWithdrawal(msg.sender, payment);
   }

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -40,22 +40,28 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
   }
 
   // function to enable a proposer to get paid for proposing a block
-  function requestBlockPayment(Block memory b, uint blockNumberL2, Transaction[] memory ts) external {
+  function requestBlockPayment(Block memory b, uint256 blockNumberL2, Transaction[] memory ts) external {
     bytes32 blockHash = Utils.hashBlock(b, ts);
     state.isBlockReal(b, ts, blockNumberL2);
     // check that the block has been finalised
-    uint time = state.getBlockData(blockNumberL2).time;
-    require(time + COOLING_OFF_PERIOD < block.timestamp, 'It is too soon to get paid for this block');
-    require(b.proposer == msg.sender, 'You are not the proposer of this block');
-    require(state.isBlockStakeWithdrawn(blockHash) == false, 'The block stake for this block is already claimed');
+    uint256 time = state.getBlockData(blockNumberL2).time;
+    require(time + CHALLENGE_PERIOD < block.timestamp, 'Shield: Too soon to get paid for this block');
+    require(b.proposer == msg.sender, 'Shield: Not the proposer of this block');
+    require(state.isBlockStakeWithdrawn(blockHash) == false, 'Shield: Block stake for this block already claimed');
     // add up how much the proposer is owed.
-    uint payment;
-    for (uint i = 0; i < ts.length; i++) {
+    uint256 payment;
+    for (uint256 i = 0; i < ts.length; i++) {
       bytes32 transactionHash = Utils.hashTransaction(ts[i]);
       payment += feeBook[transactionHash];
       feeBook[transactionHash] = 0; // clear the payment
     }
-    payment += BLOCK_STAKE;
+    
+    // recover the stake for that block
+    TimeLockedStake memory stake = state.getStakeAccount(msg.sender);
+    stake.amount += BLOCK_STAKE;
+    stake.challengeLocked -= BLOCK_STAKE;
+    state.setStakeAccount(msg.sender, stake.amount, stake.challengeLocked);
+
     state.addPendingWithdrawal(msg.sender, payment);
   }
 
@@ -74,16 +80,16 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
   @param ts - array of the transactions contained in the block
   @param index - the index of the transaction that locates it in the array of Transactions in Block b
   */
-  function isValidWithdrawal(Block memory b, uint blockNumberL2, Transaction[] memory ts, uint index) view external returns(bool) {    
+  function isValidWithdrawal(Block memory b, uint256 blockNumberL2, Transaction[] memory ts, uint256 index) view external returns(bool) {    
     // check this block is a real one, in the queue, not something made up.
     state.isBlockReal(b, ts, blockNumberL2);
     // check that the block has been finalised
-    uint time = state.getBlockData(blockNumberL2).time;
-    require(time + COOLING_OFF_PERIOD < block.timestamp, 'It is too soon to withdraw funds from this block');
+    uint256 time = state.getBlockData(blockNumberL2).time;
+    require(time + CHALLENGE_PERIOD < block.timestamp, 'Shield: Too soon to withdraw funds from this block');
     
     bytes32 transactionHash = Utils.hashTransaction(ts[index]);
-    require(!withdrawn[transactionHash], 'This transaction has already paid out');
-    require(ts[index].transactionType == TransactionTypes.WITHDRAW, 'This transaction is not a valid WITHDRAW');
+    require(!withdrawn[transactionHash], 'Shield: Transaction already paid out');
+    require(ts[index].transactionType == TransactionTypes.WITHDRAW, 'Shield: Transaction is not a valid WITHDRAW');
    
     return true;
   }
@@ -95,14 +101,14 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
   @param index - the index of the transaction that locates it in the array of Transactions in Block b
   TODO do we need to pass in  all the block data?
   */
-  function finaliseWithdrawal(Block memory b, uint blockNumberL2, Transaction[] memory ts, uint index) external {
+  function finaliseWithdrawal(Block memory b, uint256 blockNumberL2, Transaction[] memory ts, uint256 index) external {
     // check this block is a real one, in the queue, not something made up.
     state.isBlockReal(b, ts, blockNumberL2);
     // check that the block has been finalised
-    uint time = state.getBlockData(blockNumberL2).time;
-    require(time + COOLING_OFF_PERIOD < block.timestamp, 'It is too soon to withdraw funds from this block');
+    uint256 time = state.getBlockData(blockNumberL2).time;
+    require(time + CHALLENGE_PERIOD < block.timestamp, 'Shield: Too soon to withdraw funds from this block');
     bytes32 transactionHash = Utils.hashTransaction(ts[index]);
-    require(!withdrawn[transactionHash], 'This transaction has already paid out');
+    require(!withdrawn[transactionHash], 'Shield: Transaction already paid out');
     withdrawn[transactionHash] = true;
     if (ts[index].transactionType == TransactionTypes.WITHDRAW) {
       address originalRecipientAddress = address(uint160(uint256(ts[index].recipientAddress)));
@@ -119,10 +125,10 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
     bytes32 withdrawTransactionHash = Utils.hashTransaction(withdrawTransaction);
 
     // if no fee is set, then the withdrawal is not tagged as advanceable - else someone could just steal withdrawals
-    require(advancedFeeWithdrawals[withdrawTransactionHash] > 0, 'No advanced fee has been set for this withdrawal');
-    require(withdrawTransaction.tokenType == TokenType.ERC20, 'Can only advance withdrawals for fungible tokens');
+    require(advancedFeeWithdrawals[withdrawTransactionHash] > 0, 'Shield: No advanced fee has been set for this withdrawal');
+    require(withdrawTransaction.tokenType == TokenType.ERC20, 'Shield: Can only advance withdrawals for fungible tokens');
     // The withdrawal has not been withdrawn
-    require(!withdrawn[withdrawTransactionHash], 'Cannot double withdraw');
+    require(!withdrawn[withdrawTransactionHash], 'Shield: Cannot double withdraw');
 
     // TODO should we check if the withdrawal is not in a finalised block
     // this might incentives sniping freshly finalised blocks by liquidity providers
@@ -135,7 +141,7 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
 
     // Send the token from the msg.sender to the receipient
     if (withdrawTransaction.tokenId != ZERO)
-      revert("ERC20 deposit should have tokenId equal to ZERO");
+      revert("Shield: ERC20 deposit should have tokenId equal to ZERO");
     else {
       tokenContract.transferFrom(
         address(msg.sender),
@@ -150,20 +156,20 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
   }
 
   // TODO Is there a better way to set this fee, e.g. at the point of making a transaction.
-  function setAdvanceWithdrawalFee(Block memory b, uint256 blockNumberL2, Transaction[] memory ts, uint index) external payable {
+  function setAdvanceWithdrawalFee(Block memory b, uint256 blockNumberL2, Transaction[] memory ts, uint256 index) external payable {
     // The transaction is a withdrawal transaction
-    require(ts[index].transactionType == TransactionTypes.WITHDRAW, 'Can only advance withdrawals');
+    require(ts[index].transactionType == TransactionTypes.WITHDRAW, 'Shield: Can only advance withdrawals');
     // The block and transactions are real
     state.isBlockReal(b,ts,blockNumberL2);
 
     bytes32 withdrawTransactionHash = Utils.hashTransaction(ts[index]);
     // The withdrawal has not been withdrawn
-    require(!withdrawn[withdrawTransactionHash], 'Cannot double withdraw');
+    require(!withdrawn[withdrawTransactionHash], 'Shield: Cannot double withdraw');
     address originalRecipientAddress =  address(uint160(uint256(ts[index].recipientAddress)));
     address currentOwner = advancedWithdrawals[withdrawTransactionHash] == address(0) ? originalRecipientAddress : advancedWithdrawals[withdrawTransactionHash];
 
     // Only the owner of the withdraw can set the advanced withdrawal
-    require(msg.sender == currentOwner, 'You are not the current owner of this withdrawal');
+    require(msg.sender == currentOwner, 'Shield: Not the current owner of this withdrawal');
     advancedFeeWithdrawals[withdrawTransactionHash] = msg.value;
     payable(address(state)).transfer(msg.value);
     emit InstantWithdrawalRequested(withdrawTransactionHash, msg.sender, msg.value);
@@ -178,7 +184,7 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
 
     if(t.tokenType == TokenType.ERC20) {
       if (t.tokenId != ZERO)
-        revert("ERC20 deposit should have tokenId equal to ZERO");
+        revert("Shield: ERC20 deposit should have tokenId equal to ZERO");
       else
         tokenContract.transfer(
           recipientAddress,
@@ -186,7 +192,7 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
         );
     } else if(t.tokenType == TokenType.ERC721) {
       if (t.value != 0) // value should always be equal to 0
-        revert("Invalid inputs for ERC721 deposit");
+        revert("Shield: Invalid inputs for ERC721 deposit");
       else
         tokenContract.safeTransferFrom(
           address(this),
@@ -203,7 +209,7 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
           ''
         );
     } else {
-      revert("Invalid Token Type");
+      revert("Shield: Invalid Token Type");
     }
   }
 
@@ -214,12 +220,12 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
 
     if(t.tokenType == TokenType.ERC20) {
       if (t.tokenId != ZERO)
-        revert("ERC20 deposit should have tokenId equal to ZERO");
+        revert("Shield: ERC20 deposit should have tokenId equal to ZERO");
       else
         tokenContract.transferFrom(msg.sender, address(this), uint256(t.value));
     } else if(t.tokenType == TokenType.ERC721) {
       if (t.value != 0) // value should always be equal to 0
-        revert("Invalid inputs for ERC721 deposit");
+        revert("Shield: Invalid inputs for ERC721 deposit");
       else
         tokenContract.safeTransferFrom(
           msg.sender,
@@ -236,7 +242,7 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
           ''
         );
     } else {
-      revert("Invalid Token Type");
+      revert("Shield: Invalid Token Type");
     }
   }
 }

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -65,6 +65,17 @@ contract Shield is Stateful, Structures, Config, Key_Registry {
     state.addPendingWithdrawal(msg.sender, payment);
   }
 
+  /** 
+   * @dev Check if a block has been paid to the proposer
+   */
+  function isBlockPaymentPending(bytes32 blockHash, uint256 blockNumberL2) view external returns(bool) {
+    uint256 time = state.getBlockData(blockNumberL2).time;
+    require(time + CHALLENGE_PERIOD < block.timestamp, 'Shield: Too soon to get paid for this block');
+    require(state.isBlockStakeWithdrawn(blockHash) == false, 'Shield: Block stake for this block already claimed');
+
+    return true;
+  }
+
   function onERC721Received(address, address _from, uint256 _tokenId, bytes calldata) external returns(bytes4) {
 
     return 0x150b7a02;

--- a/nightfall-deployer/contracts/Structures.sol
+++ b/nightfall-deployer/contracts/Structures.sol
@@ -21,7 +21,7 @@ contract Structures {
 
     event CommittedToChallenge(bytes32 commitHash, address sender);
 
-    event InstantWithdrawalRequested(bytes32 withdrawTransactionHash, address paidBy, uint amount);
+    event InstantWithdrawalRequested(bytes32 withdrawTransactionHash, address paidBy, uint256 amount);
 
     /**
   These events are what the merkle-tree microservice's filters will listen for.
@@ -65,8 +65,9 @@ contract Structures {
         address nextAddress;
     }
 
-    struct TimeLockedBond {
+    struct TimeLockedStake {
         uint256 amount; // The amount held
+        uint256 challengeLocked; // The amount locked by block proposed still in CHALLENGE_PERIOD and not claimed
         uint256 time; // The time the funds were locked from
     }
 }

--- a/nightfall-optimist/src/routes/proposer.mjs
+++ b/nightfall-optimist/src/routes/proposer.mjs
@@ -91,14 +91,14 @@ router.post('/unstake', async (req, res, next) => {
 });
 
 /**
- * Function to withdraw bond for a de-registered proposer
+ * Function to withdraw stake for a unstaked proposer
  */
 
-router.post('/withdrawBond', async (req, res, next) => {
-  logger.debug(`withdrawBond endpoint received GET`);
+router.post('/withdrawStake', async (req, res, next) => {
+  logger.debug(`withdrawStake endpoint received GET`);
   try {
     const stateContractInstance = await getContractInstance(PROPOSERS_CONTRACT_NAME);
-    const txDataToSign = await stateContractInstance.methods.withdrawBond().encodeABI();
+    const txDataToSign = await stateContractInstance.methods.withdrawStake().encodeABI();
     res.json({ txDataToSign });
   } catch (error) {
     logger.error(error);

--- a/nightfall-optimist/src/routes/proposer.mjs
+++ b/nightfall-optimist/src/routes/proposer.mjs
@@ -11,7 +11,7 @@ import { getContractInstance } from 'common-files/utils/contract.mjs';
 import Block from '../classes/block.mjs';
 import { Transaction, TransactionError } from '../classes/index.mjs';
 import {
-  setRegisteredProposerAddress,
+  setStakeProposerAddress,
   getMempoolTransactions,
   getLatestTree,
 } from '../services/database.mjs';
@@ -27,16 +27,16 @@ const { STATE_CONTRACT_NAME, PROPOSERS_CONTRACT_NAME, SHIELD_CONTRACT_NAME, ZERO
  * amount.  The user must post the address being registered.  This is for the
  * Optimist app to use for it to decide when to start proposing blocks.  It is * not part of the unsigned blockchain transaction that is returned.
  */
-router.post('/register', async (req, res, next) => {
-  logger.debug(`register proposer endpoint received POST ${JSON.stringify(req.body, null, 2)}`);
+router.post('/stake', async (req, res, next) => {
+  logger.debug(`stake proposer endpoint received POST ${JSON.stringify(req.body, null, 2)}`);
   try {
     const { address } = req.body;
     const proposersContractInstance = await getContractInstance(PROPOSERS_CONTRACT_NAME);
-    const txDataToSign = await proposersContractInstance.methods.registerProposer().encodeABI();
+    const txDataToSign = await proposersContractInstance.methods.stakeProposer().encodeABI();
     logger.debug('returning raw transaction data');
     logger.silly(`raw transaction is ${JSON.stringify(txDataToSign, null, 2)}`);
     res.json({ txDataToSign });
-    setRegisteredProposerAddress(address); // save the registration address
+    setStakeProposerAddress(address); // save the stake address
   } catch (err) {
     logger.error(err);
     next(err);
@@ -76,11 +76,11 @@ router.get('/proposers', async (req, res, next) => {
  * Function to return a raw transaction that de-registers a proposer.  This just
  * provides the tx data. The user has to call the blockchain client.
  */
-router.post('/de-register', async (req, res, next) => {
-  logger.debug(`de-register proposer endpoint received POST ${JSON.stringify(req.body, null, 2)}`);
+router.post('/unstake', async (req, res, next) => {
+  logger.debug(`unstake proposer endpoint received POST ${JSON.stringify(req.body, null, 2)}`);
   try {
     const proposersContractInstance = await getContractInstance(PROPOSERS_CONTRACT_NAME);
-    const txDataToSign = await proposersContractInstance.methods.deRegisterProposer().encodeABI();
+    const txDataToSign = await proposersContractInstance.methods.unstakeProposer().encodeABI();
     logger.debug('returning raw transaction data');
     logger.silly(`raw transaction is ${JSON.stringify(txDataToSign, null, 2)}`);
     res.json({ txDataToSign });

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -214,7 +214,7 @@ current (active) proposer, at which point it will automatically start to
 assemble blocks on behalf of the proposer. It listens for the NewCurrentProposer
 event to determine who is the current proposer.
 */
-export async function setRegisteredProposerAddress(address) {
+export async function setStakeProposerAddress(address) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   logger.debug(`Saving proposer address ${address}`);

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -208,6 +208,19 @@ export async function findBlocksFromBlockNumberL2(blockNumberL2) {
 }
 
 /**
+function to find blocks produced by a proposer
+*/
+export async function findBlocksByProposer(proposer) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  const query = { proposer };
+  return db
+    .collection(SUBMITTED_BLOCKS_COLLECTION)
+    .find(query, { sort: { blockNumberL2: 1 } })
+    .toArray();
+}
+
+/**
 function to store addresses of proposers that are registered through this
 app. These are needed because the app needs to know when one of them is the
 current (active) proposer, at which point it will automatically start to

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test-e2e": "mocha --timeout 0 --bail test/e2e/nightfall-sdk.test.mjs",
     "test-e2e-ropsten": "env network=ropsten mocha --timeout 0 --bail test/e2e/nightfall-sdk.test.mjs",
     "test-ercmocks": "mocha --timeout 0 --bail test/e2e/ercmocks.test.mjs",
+    "test-pos": "mocha --timeout 0 --bail test/pos.test.mjs",
     "lint": "eslint . --ext js,mjs,jsx && find-unused-exports",
     "prepare": "husky install",
     "doc:build:sdk": "jsdoc -c jsdoc.json cli/lib/nf3.mjs"

--- a/test/chain-reorg.mjs
+++ b/test/chain-reorg.mjs
@@ -223,7 +223,7 @@ describe('Testing the http API', () => {
       const myAddress = (await getAccounts())[0];
       const res = await chai
         .request(optimistUrl)
-        .post('/proposer/register')
+        .post('/proposer/stake')
         .send({ address: myAddress });
       txDataToSign = res.body.txDataToSign;
       expect(txDataToSign).to.be.a('string');

--- a/test/e2e/ercmocks.test.mjs
+++ b/test/e2e/ercmocks.test.mjs
@@ -40,7 +40,7 @@ describe('Testing the Nightfall ERCMocks', () => {
     await nf3.init();
     if (!(await nf3.healthcheck('optimist'))) throw new Error('Healthcheck failed');
     // Proposer registration
-    await nf3.registerProposer();
+    await nf3.stakeProposer(1000);
     // Proposer listening for incoming events
     nf3.startProposer();
     // Challenger registration

--- a/test/e2e/nightfall-sdk.test.mjs
+++ b/test/e2e/nightfall-sdk.test.mjs
@@ -192,8 +192,8 @@ describe('Testing the Nightfall SDK', () => {
     console.log('     User1 address: ', nf3User1.ethereumAddress);
     console.log('     User2 address: ', nf3User2.ethereumAddress);
 
-    // Proposer registration
-    await nf3Proposer1.registerProposer();
+    // Proposer staking
+    await nf3Proposer1.stakeProposer(1000);
     stateBalance += bond;
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer1.startProposer();
@@ -332,7 +332,7 @@ describe('Testing the Nightfall SDK', () => {
       ({ proposers } = await nf3Proposer2.getProposers());
       // we have to pay 10 ETH to be registered
       const startBalance = await getBalance(nf3Proposer2.ethereumAddress);
-      const res = await nf3Proposer2.registerProposer();
+      const res = await nf3Proposer2.stakeProposer(1000);
       stateBalance += bond;
       expectTransaction(res);
       ({ proposers } = await nf3Proposer2.getProposers());
@@ -347,7 +347,7 @@ describe('Testing the Nightfall SDK', () => {
       ({ proposers } = await nf3Proposer1.getProposers());
       let thisProposer = proposers.filter(p => p.thisAddress === nf3Proposer1.ethereumAddress);
       expect(thisProposer.length).to.be.equal(1);
-      const res = await nf3Proposer1.deregisterProposer();
+      const res = await nf3Proposer1.unstakeProposer();
       expectTransaction(res);
       ({ proposers } = await nf3Proposer1.getProposers());
       thisProposer = proposers.filter(p => p.thisAddress === nf3Proposer1.ethereumAddress);
@@ -387,8 +387,8 @@ describe('Testing the Nightfall SDK', () => {
 
     after(async () => {
       // After the proposer tests, re-register proposers
-      await nf3Proposer2.deregisterProposer();
-      await nf3Proposer1.registerProposer();
+      await nf3Proposer2.unstakeProposer();
+      await nf3Proposer1.stakeProposer(1000);
       stateBalance += bond;
     });
   });

--- a/test/e2e/nightfall-sdk.test.mjs
+++ b/test/e2e/nightfall-sdk.test.mjs
@@ -342,7 +342,7 @@ describe('Testing the Nightfall SDK', () => {
       expect(thisProposer.length).to.be.equal(1);
     });
 
-    it('should de-register a proposer', async () => {
+    it('should unstake a proposer', async () => {
       let proposers;
       ({ proposers } = await nf3Proposer1.getProposers());
       let thisProposer = proposers.filter(p => p.thisAddress === nf3Proposer1.ethereumAddress);
@@ -354,10 +354,10 @@ describe('Testing the Nightfall SDK', () => {
       expect(thisProposer.length).to.be.equal(0);
     });
 
-    it('Should create a failing withdrawBond (because insufficient time has passed)', async () => {
+    it('Should create a failing withdrawStake (because insufficient time has passed)', async () => {
       let error = null;
       try {
-        await nf3Proposer1.withdrawBond();
+        await nf3Proposer1.withdrawStake();
       } catch (err) {
         error = err;
       }
@@ -369,15 +369,15 @@ describe('Testing the Nightfall SDK', () => {
       );
     });
 
-    it('Should create a passing withdrawBond (because sufficient time has passed)', async () => {
+    it('Should create a passing withdrawStake (because sufficient time has passed)', async () => {
       if (nodeInfo.includes('TestRPC')) await timeJump(3600 * 24 * 10); // jump in time by 7 days
       if (nodeInfo.includes('TestRPC')) {
-        const res = await nf3Proposer1.withdrawBond();
+        const res = await nf3Proposer1.withdrawStake();
         expectTransaction(res);
       } else {
         let error = null;
         try {
-          await nf3Proposer1.withdrawBond();
+          await nf3Proposer1.withdrawStake();
         } catch (err) {
           error = err;
         }

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -70,7 +70,7 @@ describe('Testing the http API', () => {
   let stateBalance = 0;
   const logCounts = {
     deposit: 0,
-    registerProposer: 0,
+    stakeProposer: 0,
   };
 
   const holdupTxQueue = async (txType, waitTillCount) => {
@@ -151,7 +151,7 @@ describe('Testing the http API', () => {
       .address;
     web3.eth.subscribe('logs', { address: proposersAddress }).on('data', log => {
       if (log.topics[0] === web3.eth.abi.encodeEventSignature('NewCurrentProposer(address)')) {
-        logCounts.registerProposer += 1;
+        logCounts.stakeProposer += 1;
       }
     });
 
@@ -261,29 +261,29 @@ describe('Testing the http API', () => {
       const myAddress = (await getAccounts())[0];
       const res = await chai
         .request(optimistUrl)
-        .post('/proposer/register')
+        .post('/proposer/stake')
         .send({ address: myAddress });
       const { txDataToSign } = res.body;
       expect(txDataToSign).to.be.a('string');
       const bond = 10;
-      const count = logCounts.registerProposer;
+      const count = logCounts.stakeProposer;
       await submitTransaction(txDataToSign, privateKey, proposersAddress, gas, bond);
-      await waitForTxExecution(count, 'registerProposer');
+      await waitForTxExecution(count, 'stakeProposer');
       stateBalance += bond;
     });
 
-    it('should register a proposer', async () => {
+    it('should stake a proposer', async () => {
       const myAddress = (await getAccounts())[0];
       const res = await chai
         .request(optimistUrl)
-        .post('/proposer/register')
+        .post('/proposer/stake')
         .send({ address: myAddress });
       const { txDataToSign } = res.body;
       expect(txDataToSign).to.be.a('string');
       // we have to pay 10 ETH to be registered
       const bond = 10;
       const startBalance = await getBalance(myAddress);
-      const count = logCounts.registerProposer;
+      const count = logCounts.stakeProposer;
       // now we need to sign the transaction and send it to the blockchain
       console.log('submitting tx');
       const receipt = await submitTransaction(
@@ -294,7 +294,7 @@ describe('Testing the http API', () => {
         bond,
       );
       console.log('waiting for execution');
-      await waitForTxExecution(count, 'registerProposer');
+      await waitForTxExecution(count, 'stakeProposer');
       console.log('executed');
       const endBalance = await getBalance(myAddress);
       expect(receipt).to.have.property('transactionHash');

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -306,9 +306,9 @@ describe('Testing the http API', () => {
       });
     });
 
-    it('should de-register a proposer', async () => {
+    it('should unstake a proposer', async () => {
       const myAddress = (await getAccounts())[0];
-      const res = await chai.request(optimistUrl).post('/proposer/de-register');
+      const res = await chai.request(optimistUrl).post('/proposer/unstake');
       const { txDataToSign } = res.body;
       expect(txDataToSign).to.be.a('string');
       const receipt = await submitTransaction(txDataToSign, privateKey, proposersAddress, gas);
@@ -318,8 +318,8 @@ describe('Testing the http API', () => {
       const thisProposer = proposers.filter(p => p.thisAddresss === myAddress);
       expect(thisProposer.length).to.be.equal(0);
     });
-    it('Should create a failing withdrawBond (because insufficient time has passed)', async () => {
-      const res = await chai.request(optimistUrl).post('/proposer/withdrawBond');
+    it('Should create a failing withdrawStake (because insufficient time has passed)', async () => {
+      const res = await chai.request(optimistUrl).post('/proposer/withdrawStake');
       const { txDataToSign } = res.body;
       expect(txDataToSign).to.be.a('string');
       await expect(
@@ -328,9 +328,9 @@ describe('Testing the http API', () => {
         /Returned error: VM Exception while processing transaction: revert It is too soon to withdraw your bond|Transaction has been reverted by the EVM/,
       );
     });
-    it('Should create a passing withdrawBond (because sufficient time has passed)', async () => {
+    it('Should create a passing withdrawStake (because sufficient time has passed)', async () => {
       if (nodeInfo.includes('TestRPC')) await timeJump(3600 * 24 * 10); // jump in time by 7 days
-      const res = await chai.request(optimistUrl).post('/proposer/withdrawBond');
+      const res = await chai.request(optimistUrl).post('/proposer/withdrawStake');
       const { txDataToSign } = res.body;
       expect(txDataToSign).to.be.a('string');
       if (nodeInfo.includes('TestRPC')) {

--- a/test/instant-withdrawal.mjs
+++ b/test/instant-withdrawal.mjs
@@ -98,7 +98,7 @@ describe('Test instant withdrawals', () => {
     // register a proposer d
     const res = await chai
       .request(optimistUrl)
-      .post('/proposer/register')
+      .post('/proposer/stake')
       .send({ address: myAddress });
     const propRegTxDataToSign = res.body.txDataToSign;
     const bond = 10000000000000000000;

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -67,7 +67,7 @@ describe('Testing the challenge http API', () => {
   let web3;
   const logCounts = {
     txSubmitted: 0,
-    registerProposer: 0,
+    stakeProposer: 0,
     challenge: 0,
   };
 
@@ -155,7 +155,7 @@ describe('Testing the challenge http API', () => {
     proposersAddress = res.body.address;
     web3.eth.subscribe('logs', { address: proposersAddress }).on('data', log => {
       if (log.topics[0] === web3.eth.abi.encodeEventSignature('NewCurrentProposer(address)')) {
-        logCounts.registerProposer += 1;
+        logCounts.stakeProposer += 1;
       }
     });
 
@@ -192,7 +192,7 @@ describe('Testing the challenge http API', () => {
     // should register a proposer
     const myAddress = (await getAccounts())[0];
     const bond = 10;
-    res = await chai.request(optimistUrl).post('/proposer/register').send({ address: myAddress });
+    res = await chai.request(optimistUrl).post('/proposer/stake').send({ address: myAddress });
     txToSign = res.body.txDataToSign;
     await submitTransaction(txToSign, privateKey, proposersAddress, gas, bond);
 
@@ -302,12 +302,12 @@ describe('Testing the challenge http API', () => {
             // When a challenge succeeds, the challenger is removed. We are adding them back for subsequent for challenges
             const result = await chai
               .request(optimistUrl)
-              .post('/proposer/register')
+              .post('/proposer/stake')
               .send({ address: myAddress });
             txToSign = result.body.txDataToSign;
-            const count = logCounts.registerProposer;
+            const count = logCounts.stakeProposer;
             await submitTransaction(txToSign, privateKey, proposersAddress, gas, bond);
-            await waitForTxExecution(count, 'registerProposer');
+            await waitForTxExecution(count, 'stakeProposer');
             // console.log('tx hash of challenge block is', txReceipt.transactionHash);
           } else throw new Error(`Unhandled transaction type: ${type}`);
         } catch (err) {

--- a/test/ping-pong/proposer/src/index.mjs
+++ b/test/ping-pong/proposer/src/index.mjs
@@ -20,7 +20,7 @@ async function startProposer() {
   await nf3.init(undefined, 'optimist');
   if (await nf3.healthcheck('optimist')) logger.info('Healthcheck passed');
   else throw new Error('Healthcheck failed');
-  await nf3.registerProposer();
+  await nf3.stakeProposer(1000);
   logger.debug('Proposer registration complete');
   // TODO subscribe to layer 1 blocks and call change proposer
   nf3.startProposer();

--- a/test/pos.test.mjs
+++ b/test/pos.test.mjs
@@ -108,7 +108,7 @@ describe('Testing the http API', () => {
   });
 
   describe('Basic Proposer staking tests', () => {
-    it('should accept stake as a proposer', async () => {
+    it('should accept proposer stake', async () => {
       let proposers;
       ({ proposers } = await nf3Proposer1.getProposers());
       const currentProposer = proposers.filter(p => p.thisAddress === nf3Proposer1.ethereumAddress);

--- a/test/pos.test.mjs
+++ b/test/pos.test.mjs
@@ -1,0 +1,155 @@
+/**
+Test suite for measuring the gas per transaction
+*/
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import chaiAsPromised from 'chai-as-promised';
+import {
+  ethereumSigningKeyUser1,
+  ethereumSigningKeyProposer1,
+  mnemonicUser1,
+  mnemonicProposer,
+  tokenType,
+  value,
+  tokenId,
+  fee,
+  BLOCK_STAKE,
+} from './constants.mjs';
+import Nf3 from '../cli/lib/nf3.mjs';
+import {
+  closeWeb3Connection,
+  connectWeb3,
+  getCurrentEnvironment,
+  expectTransaction,
+} from './utils.mjs';
+
+const { expect } = chai;
+chai.use(chaiHttp);
+chai.use(chaiAsPromised);
+const environment = getCurrentEnvironment();
+const { web3WsUrl } = process.env;
+
+const TRANSACTIONS_PER_BLOCK = 2;
+const MINIMUM_STAKE = 10;
+let currentGasCostPerTx = 0;
+let web3;
+let stateAddress;
+
+const miniStateABI = [
+  {
+    inputs: [{ internalType: 'address', name: 'addr', type: 'address' }],
+    name: 'getStakeAccount',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'uint256',
+            name: 'amount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'challengeLocked',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'time',
+            type: 'uint256',
+          },
+        ],
+        internalType: 'struct Structures.TimeLockedStake',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+describe('Testing the http API', () => {
+  let ercAddress;
+
+  console.log('ENVIRONMENT: ', environment);
+  const nf3User1 = new Nf3(web3WsUrl, ethereumSigningKeyUser1, environment);
+  const nf3Proposer1 = new Nf3(web3WsUrl, ethereumSigningKeyProposer1, environment);
+
+  const getStakeAccount = async ethAccount => {
+    const stateContractInstance = new web3.eth.Contract(miniStateABI, stateAddress);
+    const stakeAccount = await stateContractInstance.methods.getStakeAccount(ethAccount).call();
+    return stakeAccount;
+  };
+
+  before(async () => {
+    web3 = await connectWeb3();
+
+    stateAddress = await nf3User1.getContractAddress('State');
+    ercAddress = await nf3User1.getContractAddress('ERC20Mock');
+
+    await nf3User1.init(mnemonicUser1);
+    await nf3Proposer1.init(mnemonicProposer);
+    // Proposer listening for incoming events
+    const newGasBlockEmitter = await nf3Proposer1.startProposer();
+    newGasBlockEmitter.on('gascost', async gasUsed => {
+      currentGasCostPerTx = gasUsed / TRANSACTIONS_PER_BLOCK;
+      console.log(
+        `Block proposal gas cost was ${gasUsed}, cost per transaction was ${currentGasCostPerTx}`,
+      );
+    });
+  });
+
+  describe('Basic Proposer staking tests', () => {
+    it('should accept stake as a proposer', async () => {
+      let proposers;
+      ({ proposers } = await nf3Proposer1.getProposers());
+      const currentProposer = proposers.filter(p => p.thisAddress === nf3Proposer1.ethereumAddress);
+      // In order to begin from 0 producing L2 blocks
+      if (currentProposer.length === 1) {
+        console.log('Unstaking proposer...');
+        nf3Proposer1.unstakeProposer();
+      }
+
+      const stakeAccount1 = await getStakeAccount(nf3Proposer1.ethereumAddress);
+      const res = await nf3Proposer1.stakeProposer(MINIMUM_STAKE);
+      expectTransaction(res);
+      const stakeAccount2 = await getStakeAccount(nf3Proposer1.ethereumAddress);
+      ({ proposers } = await nf3Proposer1.getProposers());
+      const thisProposer = proposers.filter(p => p.thisAddress === nf3Proposer1.ethereumAddress);
+      expect(thisProposer.length).to.be.equal(1);
+      expect(Number(stakeAccount2.amount)).equal(
+        Number(stakeAccount1.amount) + Number(MINIMUM_STAKE),
+      );
+    });
+
+    it('should increase stake for the same proposer', async () => {
+      const stakeAccount1 = await getStakeAccount(nf3Proposer1.ethereumAddress);
+      const res = await nf3Proposer1.stakeProposer(MINIMUM_STAKE);
+      expectTransaction(res);
+      const stakeAccount2 = await getStakeAccount(nf3Proposer1.ethereumAddress);
+      expect(Number(stakeAccount2.amount)).equal(
+        Number(stakeAccount1.amount) + Number(MINIMUM_STAKE),
+      );
+    });
+
+    it('should increase stake locked for challenge period and decrease the stake amount', async () => {
+      const stakeAccount1 = await getStakeAccount(nf3Proposer1.ethereumAddress);
+      for (let i = 0; i < TRANSACTIONS_PER_BLOCK * 2; i++) {
+        // eslint-disable-next-line no-await-in-loop
+        const res = await nf3User1.deposit(ercAddress, tokenType, value, tokenId, fee);
+        expectTransaction(res);
+      }
+      const stakeAccount2 = await getStakeAccount(nf3Proposer1.ethereumAddress);
+      expect(Number(stakeAccount2.amount)).equal(Number(stakeAccount1.amount) - 2 * BLOCK_STAKE);
+      expect(Number(stakeAccount2.challengeLocked)).equal(
+        Number(stakeAccount1.challengeLocked) + 2 * BLOCK_STAKE,
+      );
+    });
+  });
+
+  after(() => {
+    closeWeb3Connection();
+    nf3User1.close();
+    nf3Proposer1.close();
+  });
+});

--- a/test/pos.test.mjs
+++ b/test/pos.test.mjs
@@ -32,7 +32,6 @@ const { expect } = chai;
 chai.use(chaiHttp);
 chai.use(chaiAsPromised);
 const environment = getCurrentEnvironment();
-const { web3WsUrl } = process.env;
 
 const TRANSACTIONS_PER_BLOCK = 2;
 const MINIMUM_STAKE = 10;
@@ -79,8 +78,8 @@ describe('Testing the http API', () => {
   let nodeInfo;
 
   console.log('ENVIRONMENT: ', environment);
-  const nf3User1 = new Nf3(web3WsUrl, ethereumSigningKeyUser1, environment);
-  const nf3Proposer1 = new Nf3(web3WsUrl, ethereumSigningKeyProposer1, environment);
+  const nf3User1 = new Nf3(environment.web3WsUrl, ethereumSigningKeyUser1, environment);
+  const nf3Proposer1 = new Nf3(environment.web3WsUrl, ethereumSigningKeyProposer1, environment);
 
   const getStakeAccount = async ethAccount => {
     const stateContractInstance = new web3.eth.Contract(miniStateABI, stateAddress);

--- a/test/pos.test.mjs
+++ b/test/pos.test.mjs
@@ -1,20 +1,10 @@
 /**
 Test suite for measuring the gas per transaction
 */
+import config from 'config';
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import chaiAsPromised from 'chai-as-promised';
-import {
-  ethereumSigningKeyUser1,
-  ethereumSigningKeyProposer1,
-  mnemonicUser1,
-  mnemonicProposer,
-  tokenType,
-  value,
-  tokenId,
-  fee,
-  BLOCK_STAKE,
-} from './constants.mjs';
 import Nf3 from '../cli/lib/nf3.mjs';
 import {
   closeWeb3Connection,
@@ -25,6 +15,18 @@ import {
   topicEventMapping,
   timeJump,
 } from './utils.mjs';
+
+const {
+  ethereumSigningKeyUser1,
+  ethereumSigningKeyProposer1,
+  mnemonicUser1,
+  mnemonicProposer,
+  tokenType,
+  value,
+  tokenId,
+  fee,
+  BLOCK_STAKE,
+} = config.TEST_OPTIONS;
 
 const { expect } = chai;
 chai.use(chaiHttp);

--- a/test/rollback-resync.test.mjs
+++ b/test/rollback-resync.test.mjs
@@ -143,7 +143,7 @@ describe('Running rollback and resync test', () => {
     };
     const res = await chai
       .request(environment.optimistApiUrl)
-      .post('/proposer/register')
+      .post('/proposer/stake')
       .send({ address: myAddress });
     const { txDataToSign } = res.body;
     await submitTransaction(txDataToSign, privateKey, proposersAddress, gas, bond);
@@ -306,7 +306,7 @@ describe('Running rollback and resync test', () => {
 
       const res = await chai
         .request(environment.optimistApiUrl)
-        .post('/proposer/register')
+        .post('/proposer/stake')
         .send({ address: myAddress });
       const { txDataToSign } = res.body;
       expect(txDataToSign).to.be.a('string');

--- a/test/tx-gas.mjs
+++ b/test/tx-gas.mjs
@@ -82,10 +82,10 @@ describe('Testing the http API', () => {
   });
 
   describe('Basic Proposer tests', () => {
-    it('should register a proposer', async () => {
+    it('should stake a proposer', async () => {
       let proposers;
       ({ proposers } = await nf3Proposer1.getProposers());
-      const res = await nf3Proposer1.registerProposer();
+      const res = await nf3Proposer1.stakeProposer();
       expectTransaction(res);
       ({ proposers } = await nf3Proposer1.getProposers());
       const thisProposer = proposers.filter(p => p.thisAddress === nf3Proposer1.ethereumAddress);

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -382,6 +382,18 @@ export const waitForEvent = async (eventLogs, expectedEvents, count = 1) => {
     eventLogs.shift();
   }
 
+  const em = web3.eth.subscribe('newBlockHeaders');
+  let blockCounter = 0;
+  // eslint-disable-next-line no-loop-func
+  em.on('data', () => {
+    blockCounter++;
+  });
+  console.log('waitForEvent - Waiting for 12 blocks confirmation...');
+  while (blockCounter < 12) {
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise(resolve => setTimeout(resolve, 3000));
+  }
+  em.unsubscribe();
   // Have to wait here as client block proposal takes longer now
   await new Promise(resolve => setTimeout(resolve, 3000));
   return eventLogs;


### PR DESCRIPTION
Feat #474, #488 

- `registerProposer` moved to `stakeProposer(amount)`. This registers the proposer and if the proposer is already registered it increases the proposer stake amount.
- `deregisterProposer` moved to `unstakeProposer`. 
- No `REGISTRATION_BOND` now but a `MINIMUM_STAKE` (10 wei for testing now).
- `COOLING_OFF_PERIOD` moved to `CHALLENGE_PERIOD` (1 week).
- Changed messages from `require` statements in contracts to best practices used by Openzeppelin. `<contract name>: <message>`. So you know the contract where the message has been thrown. Useful now when debugging.
- `withdrawBond` moved to `withdrawStake` and used in the same way but with the stake of the proposer instead of the bond, so the proposer can do the withdraw of their stake. Previously to that, the proposer should call `unstakeProposer` to stop being proposer and wait this `CHALLENGE_PERIOD` to be allowed to do the withdraw.
- Moved `uint` to `uint256` in contracts to avoid errors and follow the same guide in all the contracts.
- `TimeLockedBond` moved to `TimeLockedStake` and added `challengeLocked` to store the amount locked by blocks proposed still in `CHALLENGE_PERIOD` and not claimed yet.
```
    struct TimeLockedStake {
        uint256 amount; // The amount held
        uint256 challengeLocked; // The amount locked by block proposed still in CHALLENGE_PERIOD
        uint256 time; // The time the funds were locked from
    }
```
- Need to request block payment for proposers. (#488).
- Created test for testing PoS features. `npm run test-pos`


Questions:
- Tx fee payments could go to proposer's stake instead of adding it to proposer pending withdrawal.

This PR is included in #499 .