### PR TITLE
bug - proposers can register twice

### DIFF
--- a/nightfall-deployer/contracts/Proposers.sol
+++ b/nightfall-deployer/contracts/Proposers.sol
@@ -31,6 +31,7 @@ contract Proposers is Stateful, Structures, Config {
   //add the proposer to the circular linked list
   function registerProposer() external payable {
     require(REGISTRATION_BOND <= msg.value, 'The registration payment is incorrect');
+    require(state.getProposer(msg.sender).thisAddress == address(0), 'This proposer is already registered');
     payable(address(state)).transfer(REGISTRATION_BOND);
     state.setBondAccount(msg.sender,REGISTRATION_BOND);
     LinkedAddress memory currentProposer = state.getCurrentProposer();

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -192,10 +192,15 @@ describe('Testing the challenge http API', () => {
     // should register a proposer
     const myAddress = (await getAccounts())[0];
     const bond = 10;
-    res = await chai.request(optimistUrl).post('/proposer/register').send({ address: myAddress });
-    txToSign = res.body.txDataToSign;
-    await submitTransaction(txToSign, privateKey, proposersAddress, gas, bond);
-
+    try {
+      res = await chai.request(optimistUrl).post('/proposer/register').send({ address: myAddress });
+      txToSign = res.body.txDataToSign;
+      await submitTransaction(txToSign, privateKey, proposersAddress, gas, bond);
+    } catch (err) {
+      // an EVM revert almost certainly indicates that the proposer is already registered.  That's
+      // fine, it's ok to continue
+      if (!err.message.includes('Transaction has been reverted by the EVM')) throw new Error(err);
+    }
     // should subscribe to block proposed event with the provided incoming viewing key
     await chai
       .request(url)


### PR DESCRIPTION
fixes #494.

Currently, a proposer can register twice.  This causes the circular linked-list of proposers to break and the proposer registering twice then becomes the only proposer.  This PR fixes that bug by simply reverting if `registerProposer` is called with a pre-existing proposer address.

How to test:  A test case has been added to `http.mjs` and so this PR is tested by the normal CI tests.