### PR TITLE
Integrating PoS proposal: Weighted Round Robin proposers selection

### DIFF
--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -580,7 +580,7 @@ class Nf3 {
     const res = await axios.get(`${this.optimistBaseUrl}/proposer/change`, {
       address: this.ethereumAddress,
     });
-    return this.submitTransaction(res.data.txDataToSign, this.proposersContractAddress, 0);
+    return this.submitTransaction(res.data.txDataToSign, this.stateContractAddress, 0);
   }
 
   /**

--- a/nightfall-deployer/contracts/Config.sol
+++ b/nightfall-deployer/contracts/Config.sol
@@ -8,4 +8,7 @@ contract Config {
   uint256 constant ROTATE_PROPOSER_BLOCKS = 4;
   uint256 constant CHALLENGE_PERIOD = 1 weeks;
   bytes32 constant ZERO = bytes32(0);
+  uint256 constant VALUE_PER_SLOT = 1000; // amount of value of a slot
+  uint256 constant PROPOSER_SET_COUNT = 5; // number of slots to pop after shuffling slots that will build the proposer set
+  uint256 constant SPRINTS_IN_SPAN = 5; // number of sprints of a span
 }

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -183,6 +183,7 @@ contract State is Structures, Config {
     address previousAddress = proposers[proposer].previousAddress;
     address nextAddress = proposers[proposer].nextAddress;
     delete proposers[proposer];
+    numProposers--;
     proposers[previousAddress].nextAddress = proposers[nextAddress].thisAddress;
     proposers[nextAddress].previousAddress = proposers[previousAddress].thisAddress;
 
@@ -246,8 +247,8 @@ contract State is Structures, Config {
     "Proposers: Too soon to rotate proposer");
   
     address addressBestPeer;
-
-    if( numProposers == 1 ){
+    
+    if( numProposers <= 1 ){
         currentSprint = 0; // We don't have sprints because always same proposer
         addressBestPeer = currentProposer.thisAddress;
     } else {

--- a/nightfall-deployer/contracts/Structures.sol
+++ b/nightfall-deployer/contracts/Structures.sol
@@ -7,44 +7,44 @@ pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 contract Structures {
-    enum TransactionTypes {DEPOSIT, SINGLE_TRANSFER, DOUBLE_TRANSFER, WITHDRAW}
+  enum TransactionTypes {DEPOSIT, SINGLE_TRANSFER, DOUBLE_TRANSFER, WITHDRAW}
 
-    enum TokenType {ERC20, ERC721, ERC1155}
+  enum TokenType {ERC20, ERC721, ERC1155}
 
-    event Rollback(bytes32 indexed blockHash, uint256 blockNumberL2, uint256 leafCount);
+  event Rollback(bytes32 indexed blockHash, uint256 blockNumberL2, uint256 leafCount);
 
-    event BlockProposed();
+  event BlockProposed();
 
-    event TransactionSubmitted();
+  event TransactionSubmitted();
 
-    event NewCurrentProposer(address proposer);
+  event NewCurrentProposer(address proposer);
 
-    event CommittedToChallenge(bytes32 commitHash, address sender);
+  event CommittedToChallenge(bytes32 commitHash, address sender);
 
-    event InstantWithdrawalRequested(bytes32 withdrawTransactionHash, address paidBy, uint256 amount);
+  event InstantWithdrawalRequested(bytes32 withdrawTransactionHash, address paidBy, uint256 amount);
 
-    /**
+  /**
   These events are what the merkle-tree microservice's filters will listen for.
   */
-    event NewLeaf(uint256 leafIndex, bytes32 leafValue, bytes32 root);
-    event NewLeaves(uint256 minLeafIndex, bytes32[] leafValues, bytes32 root);
+  event NewLeaf(uint256 leafIndex, bytes32 leafValue, bytes32 root);
+  event NewLeaves(uint256 minLeafIndex, bytes32[] leafValues, bytes32 root);
 
-    // a struct representing a generic transaction, some of these data items
-    // will hold default values for any specific tranaction, e.g. there are no
-    // nullifiers for a Deposit transaction.
-    struct Transaction {
-        uint64 value;
-        uint64[2] historicRootBlockNumberL2; // number of L2 block containing historic root
-        TransactionTypes transactionType;
-        TokenType tokenType;
-        bytes32 tokenId;
-        bytes32 ercAddress;
-        bytes32 recipientAddress;
-        bytes32[2] commitments;
-        bytes32[2] nullifiers;
-        bytes32[8] compressedSecrets;
-        uint256[4] proof;
-    }
+  // a struct representing a generic transaction, some of these data items
+  // will hold default values for any specific tranaction, e.g. there are no
+  // nullifiers for a Deposit transaction.
+  struct Transaction {
+    uint64 value;
+    uint64[2] historicRootBlockNumberL2; // number of L2 block containing historic root
+    TransactionTypes transactionType;
+    TokenType tokenType;
+    bytes32 tokenId;
+    bytes32 ercAddress;
+    bytes32 recipientAddress;
+    bytes32[2] commitments;
+    bytes32[2] nullifiers;
+    bytes32[8] compressedSecrets;
+    uint256[4] proof;
+  }
 
   struct Block {
     uint48 leafCount; // note this is defined to be the number of leaves BEFORE the commitments in this block are added
@@ -59,15 +59,27 @@ contract Structures {
     uint256 time; // time the block was created
   }
 
-    struct LinkedAddress {
-        address thisAddress;
-        address previousAddress;
-        address nextAddress;
-    }
+  struct LinkedAddress {
+      address thisAddress;
+      address previousAddress;
+      address nextAddress;
+      bool inProposerSet;
+      uint256 indexProposerSet;
+  }
 
-    struct TimeLockedStake {
-        uint256 amount; // The amount held
-        uint256 challengeLocked; // The amount locked by block proposed still in CHALLENGE_PERIOD and not claimed
-        uint256 time; // The time the funds were locked from
-    }
+  struct TimeLockedStake {
+      uint256 amount; // The amount held
+      uint256 challengeLocked; // The amount locked by block proposed still in CHALLENGE_PERIOD and not claimed
+      uint256 time; // The time the funds were locked from
+  }
+  
+  /**
+   * @dev Element of the proposer set for next span
+   */
+  struct ProposerSet {
+      address thisAddress;
+      uint256 weight;
+      int256 currentWeight;
+      uint256 effectiveWeight;
+  }
 }

--- a/nightfall-optimist/src/routes/proposer.mjs
+++ b/nightfall-optimist/src/routes/proposer.mjs
@@ -241,10 +241,8 @@ router.post('/propose', async (req, res, next) => {
 router.get('/change', async (req, res, next) => {
   logger.debug(`proposer/change endpoint received GET ${JSON.stringify(req.body, null, 2)}`);
   try {
-    const proposersContractInstance = await getContractInstance(PROPOSERS_CONTRACT_NAME);
-    const txDataToSign = await proposersContractInstance.methods
-      .changeCurrentProposer()
-      .encodeABI();
+    const stateContractInstance = await getContractInstance(STATE_CONTRACT_NAME);
+    const txDataToSign = await stateContractInstance.methods.changeCurrentProposer().encodeABI();
     logger.debug('returning raw transaction data');
     logger.silly(`raw transaction is ${JSON.stringify(txDataToSign, null, 2)}`);
     res.json({ txDataToSign });

--- a/test/pos.test.mjs
+++ b/test/pos.test.mjs
@@ -224,12 +224,15 @@ describe('Testing the http API', () => {
 
       let proposers;
       ({ proposers } = await nf3Proposer2.getProposers());
+      let thisProposer;
+      thisProposer = proposers.filter(p => p.thisAddress === nf3Proposer3.ethereumAddress);
+      expect(thisProposer.length).to.be.equal(0);
       const stakeAccount1 = await getStakeAccount(nf3Proposer2.ethereumAddress);
       const res = await nf3Proposer2.stakeProposer(MINIMUM_STAKE);
       expectTransaction(res);
       const stakeAccount2 = await getStakeAccount(nf3Proposer2.ethereumAddress);
       ({ proposers } = await nf3Proposer2.getProposers());
-      const thisProposer = proposers.filter(p => p.thisAddress === nf3Proposer2.ethereumAddress);
+      thisProposer = proposers.filter(p => p.thisAddress === nf3Proposer2.ethereumAddress);
       expect(thisProposer.length).to.be.equal(1);
       expect(Number(stakeAccount2.amount)).equal(
         Number(stakeAccount1.amount) + Number(MINIMUM_STAKE),
@@ -248,14 +251,15 @@ describe('Testing the http API', () => {
 
       let proposers;
       ({ proposers } = await nf3Proposer2.getProposers());
-
+      let thisProposer;
+      thisProposer = proposers.filter(p => p.thisAddress === nf3Proposer3.ethereumAddress);
+      expect(thisProposer.length).to.be.equal(0);
       const stakeAccount1 = await getStakeAccount(nf3Proposer3.ethereumAddress);
       const res = await nf3Proposer3.stakeProposer(MINIMUM_STAKE);
       expectTransaction(res);
       const stakeAccount2 = await getStakeAccount(nf3Proposer3.ethereumAddress);
       ({ proposers } = await nf3Proposer3.getProposers());
-      console.log('PROPOSERS: ', proposers);
-      const thisProposer = proposers.filter(p => p.thisAddress === nf3Proposer3.ethereumAddress);
+      thisProposer = proposers.filter(p => p.thisAddress === nf3Proposer3.ethereumAddress);
       expect(thisProposer.length).to.be.equal(1);
       expect(Number(stakeAccount2.amount)).equal(
         Number(stakeAccount1.amount) + Number(MINIMUM_STAKE),
@@ -266,6 +270,7 @@ describe('Testing the http API', () => {
       try {
         await nf3Proposer3.unstakeProposer();
         await nf3Proposer2.unstakeProposer();
+        await nf3Proposer1.unstakeProposer();
       } catch (e) {
         console.log(e);
       }


### PR DESCRIPTION
Fix #475 

- Implement weighted round robin algorithm based on the proposer staking for proposer selection
- changeCurrentProposer will be based on this new proposer selection
- Define first approach with a set of parameter numbers for testnet (minimum stake, proposer count, number of springs in a span, ...) that we should analyze the suitable numbers for mainnet.