### PR TITLE
bug - submitTransaction in SDK not getting confirmations when revert

### DIFF
--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -210,7 +210,7 @@ class Nf3 {
       // rather than waiting until we have a receipt, wait until we have enough confirmation blocks
       // then return the receipt.
       // TODO does this still work if there is a chain reorg or do we have to handle that?
-      return new Promise(resolve => {
+      return new Promise((resolve, reject) => {
         console.log(`Confirming transaction ${signed.transactionHash}`);
         this.notConfirmed++;
         this.web3.eth
@@ -224,6 +224,9 @@ class Nf3 {
               );
               resolve(receipt);
             }
+          })
+          .on('error', function (error) {
+            reject(error);
           });
       });
     }


### PR DESCRIPTION
Fixes #504 

Currently, when calling submitTransaction in the SDK and a revert from the contract is thrown then confirmations are not being received. This is caused because the promise is not resolving or rejecting in that case. This PR fixes that bug by simply adding reject param and on 'error' when calling this.web3.eth.sendSignedTransactionsendSignedTransaction.

```
      return new Promise((resolve, reject) => {
        console.log(`Confirming transaction ${signed.transactionHash}`);
        this.notConfirmed++;
        this.web3.eth
          .sendSignedTransaction(signed.rawTransaction)
          .on('confirmation', (number, receipt) => {
            if (number === 12) {
              this.notConfirmed--;
              console.log(
                `Transaction ${receipt.transactionHash} has been confirmed ${number} times.`,
                `Number of unconfirmed transactions is ${this.notConfirmed}`,
              );
              resolve(receipt);
            }
          })
          .on('error', function (error) {
            reject(error);
          });
      });
```

Detected in other PR and a test has not being added in this PR as there is the PR #490  that should add a revert test tot test it.


