### PR TITLE
remove ERC addresses from transfer

### DIFF
--- a/nightfall-client/src/services/transfer.mjs
+++ b/nightfall-client/src/services/transfer.mjs
@@ -31,6 +31,7 @@ const {
   SHIELD_CONTRACT_NAME,
   PROTOCOL,
   USE_STUBS,
+  ZERO,
 } = config;
 const { generalise, GN } = gen;
 
@@ -204,7 +205,7 @@ async function transfer(transferParams) {
     historicRootBlockNumberL2: blockNumberL2s,
     transactionType,
     publicInputs,
-    ercAddress,
+    ercAddress: ZERO, // we don't want to expose the ERC address during a transfer
     commitments: newCommitments,
     nullifiers,
     compressedSecrets,

--- a/nightfall-deployer/circuits/double_transfer.zok
+++ b/nightfall-deployer/circuits/double_transfer.zok
@@ -43,7 +43,7 @@ struct Secrets {
 }
 
 def main(\
-	field[2] fErcAddress,\
+	private field[2] fErcAddress,\
 	private OldCommitmentPreimage[2] oldCommitment,\
 	private NewCommitmentPreimage[2] newCommitment,\
 	field[2] fNewCommitmentHash,\

--- a/nightfall-deployer/circuits/double_transfer_stub.zok
+++ b/nightfall-deployer/circuits/double_transfer_stub.zok
@@ -26,7 +26,7 @@ struct Secrets {
 }
 
 def main(\
-	field[2] fErcAddress,\
+	private field[2] fErcAddress,\
 	private OldCommitmentPreimage[2] oldCommitment,\
 	private NewCommitmentPreimage[2] newCommitment,\
 	field[2] fNewCommitmentHash,\

--- a/nightfall-deployer/circuits/single_transfer.zok
+++ b/nightfall-deployer/circuits/single_transfer.zok
@@ -43,7 +43,7 @@ struct Secrets {
 }
 
 def main(\
-	field fErcAddress,\
+	private field fErcAddress,\
 	private OldCommitmentPreimage oldCommitment,\
 	private NewCommitmentPreimage newCommitment,\
 	field fNewCommitmentHash,\

--- a/nightfall-deployer/circuits/single_transfer_stub.zok
+++ b/nightfall-deployer/circuits/single_transfer_stub.zok
@@ -25,7 +25,7 @@ struct Secrets {
 }
 
 def main(\
-	field fErcAddress,\
+	private field fErcAddress,\
 	private OldCommitmentPreimage oldCommitment,\
 	private NewCommitmentPreimage newCommitment,\
 	field fNewCommitmentHash,\

--- a/nightfall-optimist/src/services/transaction-checker.mjs
+++ b/nightfall-optimist/src/services/transaction-checker.mjs
@@ -66,7 +66,7 @@ async function checkTransactionType(transaction) {
       if (
         transaction.tokenId !== ZERO ||
         Number(transaction.value) !== 0 ||
-        transaction.ercAddress === ZERO ||
+        transaction.ercAddress !== ZERO ||
         transaction.recipientAddress !== ZERO ||
         transaction.commitments[0] === ZERO ||
         transaction.commitments[1] !== ZERO ||
@@ -87,7 +87,7 @@ async function checkTransactionType(transaction) {
       if (
         transaction.tokenId !== ZERO ||
         Number(transaction.value) !== 0 ||
-        transaction.ercAddress === ZERO ||
+        transaction.ercAddress !== ZERO ||
         transaction.recipientAddress !== ZERO ||
         transaction.commitments.some(c => c === ZERO) ||
         transaction.commitments.length !== 2 ||
@@ -173,7 +173,7 @@ async function verifyProof(transaction) {
       break;
     case 1: // single transfer transaction
       inputs = new PublicInputs([
-        transaction.ercAddress,
+        // transaction.ercAddress,
         transaction.commitments[0], // not truncating here as we already ensured hash < group order
         generalise(transaction.nullifiers[0]).hex(32, 31),
         historicRootFirst.root,
@@ -184,8 +184,8 @@ async function verifyProof(transaction) {
       break;
     case 2: // double transfer transaction
       inputs = new PublicInputs([
-        transaction.ercAddress, // this is correct; ercAddress appears twice
-        transaction.ercAddress, // in a double-transfer public input hash
+        // transaction.ercAddress, // this is correct; ercAddress appears twice
+        // transaction.ercAddress, // in a double-transfer public input hash
         transaction.commitments, // not truncating here as we already ensured hash < group order
         transaction.nullifiers.map(nullifier => generalise(nullifier).hex(32, 31)),
         historicRootFirst.root,


### PR DESCRIPTION
fixes #497

This fixes a bug whereby transfer transactions advertise the ERCAddress of the token being transferred.  Allowing this would greatly reduce the size of the annonymity set, and it's unnecessary because the Shield contract doesn't need to know it. Hence we make ERCAddress a private variable in the ZKP circuit.

To test: testing is the conventional `./start-nightfall -g [-s]`, `npm t` approach *BUT* because the circuits have changed, you must delete your `proving_files` volume to force a new trusted setup and to start using the new circuits. 

When the test has run, and before you stop nightfall, you can do `docker-compose logs | grep -A 4 'transactionType": "1"'` to see the single transfer transactions and the ERCAddress contained therein (should be zeroed out).  Replace "1" with "2" to see the double transfers.