### PR TITLE
(nightfall-browser) update e2e-test run on generic ENV

### DIFF
--- a/.github/workflows/browser-e2e-test.yml
+++ b/.github/workflows/browser-e2e-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Start Containers
         run: |
           npm ci
-          docker-compose build
+          docker-compose -f docker-compose.dev.yml build
           ./start-nightfall -g -d -s &> docker-compose.log &disown
 
       - name: wait 1000s for Containers startup and setup completion
@@ -75,8 +75,15 @@ jobs:
         if: always()
         run: cat wallet/browser-app.log
 
+      # in local machine
+      # NETWORK_NAME=ganache-nightfall RPC_URL=http://localhost:8546 CHAIN_ID=1337 PRIVATE_KEY=0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69e npm run e2e-test
       - name: Run e2e test
         run: cd wallet && npm run e2e-test
+        env:
+          NETWORK_NAME: 'ganache-nightfall'
+          RPC_URL: 'http://localhost:8546'
+          CHAIN_ID: 1337
+          PRIVATE_KEY: '0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69e'
 
       - name: test video
         if: always()

--- a/wallet/package.json
+++ b/wallet/package.json
@@ -49,7 +49,7 @@
     "deploy": "npm run build && aws s3 sync build s3://pnf-dev-browser --cache-control max-age=172800 --delete && aws configure set preview.cloudfront true && aws cloudfront create-invalidation --distribution-id ENV3X13MLR5YT --paths \"/*\"",
     "test": "craco test --env=jsdom",
     "eject": "craco eject",
-    "e2e-test": "NETWORK_NAME=ganache-nightfall RPC_URL=http://localhost:8546 CHAIN_ID=1337 PRIVATE_KEY=0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69e npx synpress run --env TRANSACTIONS_PER_BLOCK=2"
+    "e2e-test": "npx synpress run --env TRANSACTIONS_PER_BLOCK=2"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
with synpress we cannot import 'config' module and use config from there.
I will keep trying some other way to pass config in subsequent PR on e2e test