### PR TITLE
Timber updates sibling paths using incoming leaves.

### DIFF
--- a/common-files/classes/timber.mjs
+++ b/common-files/classes/timber.mjs
@@ -57,6 +57,36 @@ const _insertLeaf = (leafVal, tree, path) => {
 };
 
 /**
+This function is like _insertLeaf but it doesnt prune children on insertion
+@function _safeInsertLeaf
+@param {string} leafVal - The commitment hash to be inserted into the tree
+@param {object} tree - The tree where leafVal will be inserted
+@param {string} path - The path down tree that leafVal will be inserted into
+@returns {object} An updated tree post-insertion but deepest branches are preserved.
+*/
+const _safeInsertLeaf = (leafVal, tree, path) => {
+  if (path.length === 0) {
+    if (tree.value === '0') return Leaf(leafVal);
+    return tree;
+  }
+  switch (tree.tag) {
+    // If we are at a branch, we use the next element in path to decide if we go down the left or right subtree.
+    case 'branch':
+      return path[0] === '0'
+        ? Branch(_safeInsertLeaf(leafVal, tree.left, path.slice(1)), tree.right)
+        : Branch(tree.left, _safeInsertLeaf(leafVal, tree.right, path.slice(1)));
+    // If we are at a leaf AND path.length > 0, we need to expand the undeveloped subtree
+    // We then use the next element in path to decided which subtree to traverse
+    case 'leaf':
+      return path[0] === '0'
+        ? Branch(_safeInsertLeaf(leafVal, Leaf('0'), path.slice(1)), Leaf('0'))
+        : Branch(Leaf('0'), _safeInsertLeaf(leafVal, Leaf('0'), path.slice(1)));
+    default:
+      return tree;
+  }
+};
+
+/**
 This function is called recursively to traverse down the tree to find check set membership
 @function _checkMembership
 @param {string} leafVal - The commitment hash that is being checked
@@ -141,6 +171,30 @@ const frontierToTree = timber => {
   return timber.frontier.reduce((acc, curr, index) => {
     return _insertLeaf(curr, acc, frontierPaths[index]);
   }, timber.tree);
+};
+
+/**
+ This function converts a siblingPath into a tree-like structure.
+ @function
+ * @param {object} tree - The tree this sibling path will be inserted into.
+ * @param {object} siblingPath - The sibling path to be inserted.
+ * @param {number} index - The leafIndex corresponding to this valid sibling path.
+ * @param {string} value - The leafValue corresponding to this valid sibling path.
+ * @returns A tree object updated with this sibling path.
+ */
+const insertSiblingPath = (tree, siblingPath, index, value) => {
+  const pathToIndex = Number(index).toString(2).padStart(TIMBER_HEIGHT, '0');
+  const siblingIndexPath = siblingPath.path
+    .filter(s => s.value !== '0')
+    .map((s, idx) =>
+      s.dir === 'left'
+        ? { value: s.value, path: `${pathToIndex.slice(0, TIMBER_HEIGHT - idx - 1)}0` }
+        : { value: s.value, path: `${pathToIndex.slice(0, TIMBER_HEIGHT - idx - 1)}1` },
+    );
+  const allPaths = [{ value, path: pathToIndex }].concat(siblingIndexPath);
+  return allPaths.reduce((acc, curr) => {
+    return _safeInsertLeaf(curr.value, acc, curr.path);
+  }, tree);
 };
 
 /**
@@ -630,6 +684,29 @@ class Timber {
   toArray() {
     if (this.leafCount === 0) return [];
     return Timber.reduceTree((a, b) => [].concat([a, b]).flat(), this.tree);
+  }
+
+  /**
+   @method
+   Updates a sibling path statelessly, given the previous path and a set of leaves to update the tree.
+   * @param {object} timber - The timber instance that contains the frontier and leafCount.
+   * @param {Array<string>} leaves - The elements that will be inserted.
+   * @param {number} leafIndex - The index in leaves that the sibling path will be calculated for.
+   * @param {string} leafValue - The value of the leaf sibling path will be calculated for.
+   * @param {object} siblingPath - The latest sibling path that for leafIndex that will be updated.
+   * @returns {object} - Updated siblingPath for leafIndex with leafValue.
+   */
+  static statelessIncrementSiblingPath(timber, leaves, leafIndex, leafValue, siblingPath) {
+    if (leaves.length === 0 || leafIndex < 0 || leafIndex >= timber.leafCount) return siblingPath;
+
+    const leavesInsertOrder = batchLeaves(timber.leafCount, leaves, []);
+    const newTree = frontierToTree(timber);
+    const siblingTree = insertSiblingPath(newTree, siblingPath, leafIndex, leafValue);
+    const finalTree = leavesInsertOrder.reduce(
+      (acc, curr) => acc.insertLeaves(curr),
+      new Timber(timber.root, timber.frontier, timber.leafCount, siblingTree),
+    );
+    return finalTree.getSiblingPath(leafValue, leafIndex);
   }
 }
 

--- a/common-files/classes/timber.mjs
+++ b/common-files/classes/timber.mjs
@@ -700,12 +700,16 @@ class Timber {
     if (leaves.length === 0 || leafIndex < 0 || leafIndex >= timber.leafCount) return siblingPath;
 
     const leavesInsertOrder = batchLeaves(timber.leafCount, leaves, []);
+    // Turn the frontier into a tree-like structure
     const newTree = frontierToTree(timber);
+    // Add the sibling path to the frontier tree-like structure
     const siblingTree = insertSiblingPath(newTree, siblingPath, leafIndex, leafValue);
+    // Add all the new incoming leaves to this tree-like structure
     const finalTree = leavesInsertOrder.reduce(
       (acc, curr) => acc.insertLeaves(curr),
       new Timber(timber.root, timber.frontier, timber.leafCount, siblingTree),
     );
+    // Get the sibling path for leafIndex from this tree.
     return finalTree.getSiblingPath(leafValue, leafIndex);
   }
 }

--- a/wallet/src/common-files/classes/timber.js
+++ b/wallet/src/common-files/classes/timber.js
@@ -698,12 +698,16 @@ class Timber {
     if (leaves.length === 0 || leafIndex < 0 || leafIndex >= timber.leafCount) return siblingPath;
 
     const leavesInsertOrder = batchLeaves(timber.leafCount, leaves, []);
+    // Turn the frontier into a tree-like structure
     const newTree = frontierToTree(timber);
+    // Add the sibling path to the frontier tree-like structure
     const siblingTree = insertSiblingPath(newTree, siblingPath, leafIndex, leafValue);
+    // Add all the new incoming leaves to this tree-like structure
     const finalTree = leavesInsertOrder.reduce(
       (acc, curr) => acc.insertLeaves(curr),
       new Timber(timber.root, timber.frontier, timber.leafCount, siblingTree),
     );
+    // Get the sibling path for leafIndex from this tree.
     return finalTree.getSiblingPath(leafValue, leafIndex);
   }
 }


### PR DESCRIPTION
This closes #581 and is proof that #540 can be solved statelessly. Activating this functionality across `client`, `optimist` and `wallet` is sufficiently large and complex to warrant another PR.

This PR allows Timber to statelessly update a sibling path for a leaf index to account for the insertion of new leaves. This removes the restriction that spending commitments must reference the block these commitments were "mined" in.

Unit/Property tests (`Check Sibling Path Increment`) are included and can be run using 
`npx mocha --timeout 0 --bail --exit test/timber.test.mjs`


**Note** There is duplication as the common-files update must also happen in the `wallet` directory. These can't share the same `timber` file due to a restriction in `create-react-app` including files outside of `wallet/src`