### PR TITLE
Encrypt Zkp Keys in browser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     'eslint:recommended',
     'plugin:react/recommended',
     'plugin:prettier/recommended',
+    'plugin:@typescript-eslint/recommended',
   ],
   rules: {
     'no-underscore-dangle': 'off',
@@ -35,5 +36,5 @@ module.exports = {
     node: true,
     jest: true,
   },
-  plugins: ['import'],
+  plugins: ['import', '@typescript-eslint'],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,6 @@ module.exports = {
     'eslint:recommended',
     'plugin:react/recommended',
     'plugin:prettier/recommended',
-    'plugin:@typescript-eslint/recommended',
   ],
   rules: {
     'no-underscore-dangle': 'off',
@@ -36,5 +35,5 @@ module.exports = {
     node: true,
     jest: true,
   },
-  plugins: ['import', '@typescript-eslint'],
+  plugins: ['import'],
 };

--- a/config/default.js
+++ b/config/default.js
@@ -233,4 +233,8 @@ module.exports = {
 
   eventWsUrl:
     process.env.LOCAL_PROPOSER === 'true' ? process.env.LOCAL_WS_URL : process.env.PROPOSER_WS_URL,
+
+  KEYS_COLLECTION: 'keys',
+  DEFAULT_ACCOUNT_NUM: 10,
+
 };

--- a/config/default.js
+++ b/config/default.js
@@ -236,5 +236,4 @@ module.exports = {
 
   KEYS_COLLECTION: 'keys',
   DEFAULT_ACCOUNT_NUM: 10,
-
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1187,18 +1187,6 @@
         "eslint-utils": "^2.0.0"
       }
     },
-    "@typescript-eslint/parser": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.24.0.tgz",
-      "integrity": "sha512-dj1ZIh/4QKeECLb2f/QjRwMmDArcwc2WorWPRlB8UNTZlY1KpTVsbX7e3ZZdphfRw29aTFUSNuGB8w9X5sS97w==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/scope-manager": "4.24.0",
-        "@typescript-eslint/types": "4.24.0",
-        "@typescript-eslint/typescript-estree": "4.24.0",
-        "debug": "^4.1.1"
-      }
-    },
     "@typescript-eslint/scope-manager": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.24.0.tgz",
@@ -3267,6 +3255,61 @@
         "read-pkg-up": "^7.0.1",
         "semver": "^7.3.5",
         "webpack": "^5.37.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/parser": {
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
+          "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/scope-manager": "4.33.0",
+            "@typescript-eslint/types": "4.33.0",
+            "@typescript-eslint/typescript-estree": "4.33.0",
+            "debug": "^4.3.1"
+          }
+        },
+        "@typescript-eslint/scope-manager": {
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
+          "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.33.0",
+            "@typescript-eslint/visitor-keys": "4.33.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
+          "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
+          "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.33.0",
+            "@typescript-eslint/visitor-keys": "4.33.0",
+            "debug": "^4.3.1",
+            "globby": "^11.0.3",
+            "is-glob": "^4.0.1",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
+          "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.33.0",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        }
       }
     },
     "eslint-config-prettier": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test-e2e-protocol": "LOG_LEVEL=debug mocha --timeout 0 --bail --exit test/e2e/protocol/*.test.mjs ",
     "test-gas": "mocha --timeout 0 --bail --exit test/e2e/gas.test.mjs ",
     "test-e2e-tokens": "LOG_LEVEL=error mocha --timeout 0 --bail --exit test/e2e/tokens/*.test.mjs ",
-    "lint": "eslint . --ext js,mjs,jsx && find-unused-exports",
+    "lint": " eslint . --ext js,mjs,jsx,ts,tsx && find-unused-exports",
     "prepare": "husky install",
     "doc:build:sdk": "jsdoc -c jsdoc.json cli/lib/nf3.mjs",
     "build-adversary": "node test/adversary/transpile-adversary.mjs",

--- a/wallet/.eslintrc.js
+++ b/wallet/.eslintrc.js
@@ -1,0 +1,76 @@
+module.exports = {
+  root: true,
+  extends: [
+    'codfish',
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:prettier/recommended',
+  ],
+  rules: {
+    'no-underscore-dangle': 'off',
+    'no-console': 'off',
+    'import/extensions': 'off',
+    'no-restricted-syntax': 'off',
+    'no-plusplus': 'off',
+    'func-names': 'off',
+  },
+  parser: 'babel-eslint', // Uses babel-eslint transforms.
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+    ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
+    sourceType: 'module', // Allows for the use of imports
+  },
+  settings: {
+    react: {
+      version: 'latest',
+    },
+    'import/resolver': {
+      node: {
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
+      },
+    },
+  },
+  globals: {
+    BigInt: 'true',
+  },
+  env: {
+    mocha: true,
+    browser: true,
+    node: true,
+    jest: true,
+  },
+  plugins: ['import'],
+  // Override for TS files
+  overrides: [
+    {
+      files: ['**/*.ts', '**/*.tsx'],
+      env: { browser: true, es6: true, node: true },
+      extends: [
+        'eslint:recommended',
+        'plugin:@typescript-eslint/eslint-recommended',
+        'plugin:@typescript-eslint/recommended',
+      ],
+      globals: { Atomics: 'readonly', SharedArrayBuffer: 'readonly' },
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+        ecmaVersion: 2018,
+        sourceType: 'module',
+        project: 'tsconfig.json',
+        tsconfigRootDir: __dirname,
+      },
+      plugins: ['@typescript-eslint'],
+      rules: {
+        indent: ['error', 2, { SwitchCase: 1 }],
+        'linebreak-style': ['error', 'unix'],
+        quotes: ['error', 'single'],
+        'comma-dangle': ['error', 'always-multiline'],
+        '@typescript-eslint/no-explicit-any': 0,
+        'no-use-before-define': 'off',
+        '@typescript-eslint/no-use-before-define': ['error'],
+      },
+    },
+  ],
+};

--- a/wallet/package-lock.json
+++ b/wallet/package-lock.json
@@ -1297,89 +1297,6 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
-    "@chainlink/contracts-0.0.10": {
-      "version": "npm:@chainlink/contracts@0.0.10",
-      "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.10.tgz",
-      "integrity": "sha512-ok+ucSQ+3mrR+zjbi6zIrdd5M9XymcqVcnXGVyqBVRYZp97jS2/rt/glP320JmHxmi4pacgDOg0Ux11xIr1S8Q==",
-      "dev": true,
-      "requires": {
-        "@truffle/contract": "^4.2.6",
-        "ethers": "^4.0.45"
-      },
-      "dependencies": {
-        "aes-js": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-          "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
-          "dev": true,
-          "optional": true
-        },
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-          "dev": true,
-          "optional": true
-        },
-        "ethers": {
-          "version": "4.0.49",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.49.tgz",
-          "integrity": "sha512-kPltTvWiyu+OktYy1IStSO16i2e7cS9D9OxZ81q2UUaiNPVrm/RTcbxamCXF9VUSKzJIdJV68EAIhTEVBalRWg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aes-js": "3.0.0",
-            "bn.js": "^4.11.9",
-            "elliptic": "6.5.4",
-            "hash.js": "1.1.3",
-            "js-sha3": "0.5.7",
-            "scrypt-js": "2.0.4",
-            "setimmediate": "1.0.4",
-            "uuid": "2.0.1",
-            "xmlhttprequest": "1.8.0"
-          }
-        },
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-          "dev": true,
-          "optional": true
-        },
-        "scrypt-js": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
-          "dev": true,
-          "optional": true
-        },
-        "setimmediate": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
-          "dev": true,
-          "optional": true
-        },
-        "uuid": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -6008,14 +5925,73 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
-      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.15.0.tgz",
+      "integrity": "sha512-NGAYP/+RDM2sVfmKiKOCgJYPstAO40vPAgACoWPO/+yoYKSgAXIFaBKsV8P0Cc7fwKgvj27SjRNX4L7f4/jCKQ==",
+      "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "debug": "^4.3.1"
+        "@typescript-eslint/scope-manager": "5.15.0",
+        "@typescript-eslint/types": "5.15.0",
+        "@typescript-eslint/typescript-estree": "5.15.0",
+        "debug": "^4.3.2"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.15.0.tgz",
+          "integrity": "sha512-EFiZcSKrHh4kWk0pZaa+YNJosvKE50EnmN4IfgjkA3bTHElPtYcd2U37QQkNTqwMCS7LXeDeZzEqnsOH8chjSg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.15.0",
+            "@typescript-eslint/visitor-keys": "5.15.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.15.0.tgz",
+          "integrity": "sha512-yEiTN4MDy23vvsIksrShjNwQl2vl6kJeG9YkVJXjXZnkJElzVK8nfPsWKYxcsGWG8GhurYXP4/KGj3aZAxbeOA==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.15.0.tgz",
+          "integrity": "sha512-Hb0e3dGc35b75xLzixM3cSbG1sSbrTBQDfIScqdyvrfJZVEi4XWAT+UL/HMxEdrJNB8Yk28SKxPLtAhfCbBInA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.15.0",
+            "@typescript-eslint/visitor-keys": "5.15.0",
+            "debug": "^4.3.2",
+            "globby": "^11.0.4",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.15.0.tgz",
+          "integrity": "sha512-+vX5FKtgvyHbmIJdxMJ2jKm9z2BIlXJiuewI8dsDYMp5LzPUcuTT78Ya5iwvQg3VqSVdmxyM8Anj1Jeq7733ZQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.15.0",
+            "eslint-visitor-keys": "^3.0.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/scope-manager": {
@@ -20316,7 +20292,7 @@
     },
     "nanoid": {
       "version": "3.1.30",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ=="
     },
     "nanomatch": {
@@ -20878,12 +20854,6 @@
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
       }
-    },
-    "openzeppelin-solidity-2.3.0": {
-      "version": "npm:openzeppelin-solidity@2.3.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
-      "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw==",
-      "dev": true
     },
     "opn": {
       "version": "5.5.0",
@@ -23485,6 +23455,19 @@
         "webpack-dev-server": "3.11.1",
         "webpack-manifest-plugin": "2.2.0",
         "workbox-webpack-plugin": "5.1.4"
+      },
+      "dependencies": {
+        "@typescript-eslint/parser": {
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
+          "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+          "requires": {
+            "@typescript-eslint/scope-manager": "4.33.0",
+            "@typescript-eslint/types": "4.33.0",
+            "@typescript-eslint/typescript-estree": "4.33.0",
+            "debug": "^4.3.1"
+          }
+        }
       }
     },
     "react-to-webcomponent": {
@@ -26536,6 +26519,23 @@
         "web3-utils": "1.2.2"
       },
       "dependencies": {
+        "@chainlink/contracts-0.0.10": {
+          "version": "npm:@chainlink/contracts@0.0.10",
+          "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.10.tgz",
+          "integrity": "sha512-ok+ucSQ+3mrR+zjbi6zIrdd5M9XymcqVcnXGVyqBVRYZp97jS2/rt/glP320JmHxmi4pacgDOg0Ux11xIr1S8Q==",
+          "dev": true,
+          "requires": {
+            "@truffle/contract": "^4.2.6",
+            "ethers": "^4.0.45"
+          }
+        },
+        "aes-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+          "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
+          "dev": true,
+          "optional": true
+        },
         "bn.js": {
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -26558,6 +26558,78 @@
             "elliptic": "^6.4.0",
             "xhr-request-promise": "^0.1.2"
           }
+        },
+        "ethers": {
+          "version": "4.0.49",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.49.tgz",
+          "integrity": "sha512-kPltTvWiyu+OktYy1IStSO16i2e7cS9D9OxZ81q2UUaiNPVrm/RTcbxamCXF9VUSKzJIdJV68EAIhTEVBalRWg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+          "dev": true,
+          "optional": true
+        },
+        "openzeppelin-solidity-2.3.0": {
+          "version": "npm:openzeppelin-solidity@2.3.0",
+          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
+          "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw==",
+          "dev": true
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+          "dev": true,
+          "optional": true
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+          "dev": true,
+          "optional": true
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+          "dev": true,
+          "optional": true
         },
         "web3-utils": {
           "version": "1.2.2",
@@ -27529,9 +27601,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
     },
     "u2f-api": {
       "version": "0.2.7",

--- a/wallet/package.json
+++ b/wallet/package.json
@@ -35,7 +35,7 @@
     "redux-thunk": "^2.3.0",
     "safe-buffer": "^5.2.1",
     "sass": "^1.49.7",
-    "typescript": "^4.5.5",
+    "typescript": "4.4.4",
     "wasm-loader": "^1.3.0",
     "web-vitals": "^2.1.0",
     "web3": "^1.6.0",
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@craco/craco": "^6.4.2",
     "@synthetixio/synpress": "^1.1.1",
-    "@testing-library/react": "^12.1.2"
+    "@testing-library/react": "^12.1.2",
+    "@typescript-eslint/parser": "^5.15.0"
   }
 }

--- a/wallet/src/components/BridgeComponent/index.tsx
+++ b/wallet/src/components/BridgeComponent/index.tsx
@@ -20,8 +20,8 @@ import approveImg from '../../assets/img/modalImages/adeposit_approve1.png';
 import depositConfirmed from '../../assets/img/modalImages/adeposit_confirmed.png';
 import successHand from '../../assets/img/modalImages/success-hand.png';
 import transferCompletedImg from '../../assets/img/modalImages/tranferCompleted.png';
-import { pkdGet } from '../../utils/lib/local-storage';
 import { decompressKey } from '../../nightfall-browser/services/keys';
+import { retrieveAndDecrypt } from '../../utils/lib/key-storage';
 
 const gen = require('general-number');
 
@@ -80,9 +80,10 @@ const BridgeComponent = (props: any) => {
     const { address: defaultTokenAddress } = (await getContractAddress('ERC20Mock')).data; // TODO Only for testing now
     const ercAddress = defaultTokenAddress; // TODO Location to be removed later
     console.log('TokenAddress', ercAddress);
+    const zkpKeys = await retrieveAndDecrypt(state.compressedPkd)
     switch (txType) {
       case 'deposit': {
-        const pkd = decompressKey(generalise(pkdGet(await Web3.getAccount())));
+        const pkd = decompressKey(generalise(state.compressedPkd));
         await approve(ercAddress, shieldContractAddress, 'ERC20', tokenAmountWei.toString());
         const { rawTransaction } = await deposit(
           {
@@ -90,7 +91,7 @@ const BridgeComponent = (props: any) => {
             tokenId: 0,
             value: tokenAmountWei,
             pkd,
-            nsk: state.zkpKeys.nsk,
+            nsk: zkpKeys.nsk,
             fee: 1,
             tokenType: 'ERC20',
           },
@@ -109,8 +110,8 @@ const BridgeComponent = (props: any) => {
               tokenId: 0,
               value: tokenAmountWei,
               recipientAddress: await Web3.getAccount(),
-              nsk: state.zkpKeys.nsk,
-              ask: state.zkpKeys.ask,
+              nsk: zkpKeys.nsk,
+              ask: zkpKeys.ask,
               tokenType: 'ERC20',
               fees: 1,
             },
@@ -123,8 +124,8 @@ const BridgeComponent = (props: any) => {
               tokenId: 0,
               value: tokenAmountWei,
               recipientAddress: await Web3.getAccount(),
-              nsk: state.zkpKeys.nsk,
-              ask: state.zkpKeys.ask,
+              nsk: zkpKeys.nsk,
+              ask: zkpKeys.ask,
               tokenType: 'ERC20',
               fees: 1,
             },

--- a/wallet/src/components/BridgeComponent/index.tsx
+++ b/wallet/src/components/BridgeComponent/index.tsx
@@ -23,10 +23,12 @@ import transferCompletedImg from '../../assets/img/modalImages/tranferCompleted.
 import { decompressKey } from '../../nightfall-browser/services/keys';
 import { retrieveAndDecrypt } from '../../utils/lib/key-storage';
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const gen = require('general-number');
 
 const { generalise } = gen;
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const BridgeComponent = (props: any) => {
   const [state] = useState(() => props[Object.keys(props)[1].toString()].value);
 
@@ -80,7 +82,7 @@ const BridgeComponent = (props: any) => {
     const { address: defaultTokenAddress } = (await getContractAddress('ERC20Mock')).data; // TODO Only for testing now
     const ercAddress = defaultTokenAddress; // TODO Location to be removed later
     console.log('TokenAddress', ercAddress);
-    const zkpKeys = await retrieveAndDecrypt(state.compressedPkd)
+    const zkpKeys = await retrieveAndDecrypt(state.compressedPkd);
     switch (txType) {
       case 'deposit': {
         const pkd = decompressKey(generalise(state.compressedPkd));

--- a/wallet/src/components/TokenItem/index.jsx
+++ b/wallet/src/components/TokenItem/index.jsx
@@ -14,6 +14,7 @@ import maticImg from '../../assets/img/polygon-chain.svg';
 import { UserContext } from '../../hooks/User/index.jsx';
 import transfer from '../../nightfall-browser/services/transfer';
 import { getContractAddress } from '../../common-files/utils/contract';
+import { retrieveAndDecrypt } from '../../utils/lib/key-storage';
 
 const symbols = {
   matic,
@@ -31,11 +32,12 @@ export default function TokenItem({
 }) {
   const [showSendModal, setShowSendModal] = useState(false);
   const [state] = React.useContext(UserContext);
-  const defaultSend = state?.zkpKeys?.compressedPkd;
+  const defaultSend = state?.compressedPkd;
   const [valueToSend, setTransferValue] = useState(0);
 
   async function sendTx() {
     const { address: shieldContractAddress } = (await getContractAddress('Shield')).data;
+    const { nsk, ask } = await retrieveAndDecrypt(state.compressedPkd);
     await transfer(
       {
         offchain: true,
@@ -45,8 +47,8 @@ export default function TokenItem({
           recipientCompressedPkds: [defaultSend],
           values: [valueToSend],
         },
-        nsk: state.zkpKeys.nsk,
-        ask: state.zkpKeys.ask,
+        nsk,
+        ask,
         fee: 1,
       },
       shieldContractAddress,
@@ -197,7 +199,7 @@ export default function TokenItem({
               <div>
                 <input
                   type="text"
-                  placeholder={state?.zkpKeys?.compressedPkd}
+                  placeholder={state?.compressedPkd}
                   id="TokenItem_modalSend_compressedPkd"
                 />
                 <p>Enter a valid address existing on the Polygon Nightfall L2</p>

--- a/wallet/src/hooks/User/index.jsx
+++ b/wallet/src/hooks/User/index.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import jsSha3 from 'js-sha3';
 import { useLocation } from 'react-router-dom';
 
 import Web3 from '../../common-files/utils/web3';
-import { METAMASK_MESSAGE, DEFAULT_NF_ADDRESS_INDEX } from '../../constants';
 import * as Storage from '../../utils/lib/local-storage';
 import { generateKeys } from '../../nightfall-browser/services/keys';
 import blockProposedEventHandler from '../../nightfall-browser/event-handlers/block-proposed';
@@ -22,20 +20,23 @@ export const UserContext = React.createContext({
 
 // eslint-disable-next-line react/prop-types
 export const UserProvider = ({ children }) => {
-  // const [state, dispatch] = React.useReducer(reducer, initialState);
   const [state, setState] = React.useState(initialState);
   const [isSyncComplete, setIsSyncComplete] = React.useState(false);
   const location = useLocation();
-  // const [isRoot, setIsRoot] = React.useState(location.pathname === '/');
 
   const deriveAccounts = async (mnemonic, numAccts) => {
-    const accountRange = Array.from({length: numAccts}, (v, i) => i)
-    const zkpKeys = await Promise.all(accountRange.map( i => generateKeys(mnemonic,`m/44'/60'/0'/${i.toString()}`)));
+    const accountRange = Array.from({ length: numAccts }, (v, i) => i);
+    const zkpKeys = await Promise.all(
+      accountRange.map(i => generateKeys(mnemonic, `m/44'/60'/0'/${i.toString()}`)),
+    );
     const aesGenParams = { name: 'AES-GCM', length: 128 };
     const key = await crypto.subtle.generateKey(aesGenParams, false, ['encrypt', 'decrypt']);
     await storeBrowserKey(key);
     await Promise.all(zkpKeys.map(zkpKey => encryptAndStore(zkpKey)));
-    Storage.pkdArraySet(await Web3.getAccount(), zkpKeys.map(z => z.compressedPkd));
+    Storage.pkdArraySet(
+      await Web3.getAccount(),
+      zkpKeys.map(z => z.compressedPkd),
+    );
     setState(previousState => {
       return {
         ...previousState,
@@ -52,7 +53,7 @@ export const UserProvider = ({ children }) => {
           ...previousState,
           compressedPkd: pkds[0],
         };
-      })
+      });
     }
   };
 
@@ -72,7 +73,7 @@ export const UserProvider = ({ children }) => {
     socket.addEventListener('message', async function (event) {
       console.log('Message from server ', JSON.parse(event.data));
       const parsed = JSON.parse(event.data);
-      const { ivk, nsk } = await retrieveAndDecrypt(state.compressedPkd)
+      const { ivk, nsk } = await retrieveAndDecrypt(state.compressedPkd);
       if (parsed.type === 'sync') {
         parsed.historicalData
           .sort((a, b) => a.blockNumberL2 - b.blockNumberL2)
@@ -101,7 +102,6 @@ export const UserProvider = ({ children }) => {
   React.useEffect(() => {
     setupWebSocket();
   }, [state.compressedPkd]);
-
 
   /*
    * TODO: children should render when sync is complete

--- a/wallet/src/nightfall-browser/services/commitment-storage.js
+++ b/wallet/src/nightfall-browser/services/commitment-storage.js
@@ -419,20 +419,6 @@ export async function getWalletBalanceDetails(compressedPkd, ercList) {
   // work out the balance contribution of each commitment  - a 721 token has no value field in the
   // commitment but each 721 token counts as a balance of 1. Then finally add up the individual
   // commitment balances to get a balance for each erc address.
-  const res1 = wallet.map(e => ({
-    ercAddress: `0x${BigInt(e.preimage.ercAddress).toString(16).padStart(40, '0')}`, // Pad this to actual address length
-    compressedPkd: e.preimage.compressedPkd,
-    tokenId: !!BigInt(e.preimage.tokenId),
-    value: Number(BigInt(e.preimage.value)),
-    id: Number(BigInt(e.preimage.tokenId)),
-  }));
-  const res2 = res1.filter(
-    e =>
-      (e.tokenId || e.value > 0) &&
-      e.compressedPkd === compressedPkd &&
-      (ercAddressList.length === 0 || ercAddressList.includes(e.ercAddress.toUpperCase())),
-  );
-  console.log('RES2: ', res2);
   const res = wallet
     .map(e => ({
       ercAddress: `0x${BigInt(e.preimage.ercAddress).toString(16).padStart(40, '0')}`, // Pad this to actual address length

--- a/wallet/src/nightfall-browser/services/commitment-storage.js
+++ b/wallet/src/nightfall-browser/services/commitment-storage.js
@@ -18,6 +18,7 @@ const {
   SUBMITTED_BLOCKS_COLLECTION,
   TRANSACTIONS_COLLECTION,
   COMMITMENTS_COLLECTION,
+  KEYS_COLLECTION,
 } = global.config;
 
 const { generalise } = gen;
@@ -30,6 +31,7 @@ const connectDB = async () => {
       newDb.createObjectStore(TIMBER_COLLECTION);
       newDb.createObjectStore(SUBMITTED_BLOCKS_COLLECTION);
       newDb.createObjectStore(TRANSACTIONS_COLLECTION);
+      newDb.createObjectStore(KEYS_COLLECTION);
     },
   });
 };

--- a/wallet/src/nightfall-browser/services/database.js
+++ b/wallet/src/nightfall-browser/services/database.js
@@ -13,6 +13,7 @@ const {
   SUBMITTED_BLOCKS_COLLECTION,
   TRANSACTIONS_COLLECTION,
   COMMITMENTS_COLLECTION,
+  KEYS_COLLECTION,
 } = global.config;
 
 // This needs to have better indexDB performance.
@@ -24,6 +25,7 @@ const connectDB = async () => {
       newDb.createObjectStore(TIMBER_COLLECTION);
       newDb.createObjectStore(SUBMITTED_BLOCKS_COLLECTION);
       newDb.createObjectStore(TRANSACTIONS_COLLECTION);
+      newDb.createObjectStore(KEYS_COLLECTION);
     },
   });
 };

--- a/wallet/src/utils/lib/key-storage.ts
+++ b/wallet/src/utils/lib/key-storage.ts
@@ -1,0 +1,106 @@
+/**
+ * Generate Random bytes
+ * generateKeys
+ *
+ */
+
+import { openDB } from 'idb';
+
+type ZkpAccount = {
+  pkd: Array<string>;
+  compressedPkd: string;
+  nsk: string;
+  ask: string;
+  ivk: string;
+};
+
+type CipherText = {
+  cipherText: string;
+  iv: Uint8Array;
+}
+
+function isZkpAccount(o: any): o is ZkpAccount {
+  return "pkd" in o && "compressedPkd" in o && "nsk" in o && "ask" in o
+}
+
+const {
+  COMMITMENTS_DB,
+  TIMBER_COLLECTION,
+  SUBMITTED_BLOCKS_COLLECTION,
+  TRANSACTIONS_COLLECTION,
+  COMMITMENTS_COLLECTION,
+  KEYS_COLLECTION,
+  // @ts-ignore
+} = global.config;
+
+const connectDB = async () => {
+  return openDB(COMMITMENTS_DB, 1, {
+    upgrade(newDb) {
+      newDb.createObjectStore(COMMITMENTS_COLLECTION);
+      newDb.createObjectStore(TIMBER_COLLECTION);
+      newDb.createObjectStore(SUBMITTED_BLOCKS_COLLECTION);
+      newDb.createObjectStore(TRANSACTIONS_COLLECTION);
+      newDb.createObjectStore(KEYS_COLLECTION);
+    },
+  });
+};
+
+export const storeBrowserKey = async (key: CryptoKey) => {
+  const db = await connectDB();
+  return db.put(KEYS_COLLECTION, key, 'cryptokey');
+};
+
+const encrypt = async (acct: ZkpAccount, key: CryptoKey): Promise<CipherText> => {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const buffer = new TextEncoder().encode(JSON.stringify(acct));
+  const cipherText = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, buffer)
+  return {
+    cipherText: Buffer.from(cipherText).toString('base64'),
+    iv,
+  }
+}
+
+export const encryptAndStore = async (acct: ZkpAccount) => {
+  const db = await connectDB();
+  const key = await db.get(KEYS_COLLECTION, 'cryptokey');
+  const cipherText = await encrypt(acct, key);
+  return db.put(
+    KEYS_COLLECTION, cipherText, acct.compressedPkd,
+  );
+};
+
+const decrypt = async (cipherText: BufferSource, key: CryptoKey, iv: Uint8Array) : Promise<ZkpAccount> => {
+  const plainText: BufferSource = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    cipherText,
+  );
+  const decodeBuffer = new TextDecoder().decode(plainText)
+  return JSON.parse(decodeBuffer); // TODO error handling
+}
+
+export const retrieveAndDecrypt = async (compressedPkd: string) : Promise<ZkpAccount>  => {
+  const db = await connectDB();
+  const key = await db.get(KEYS_COLLECTION, 'cryptokey');
+  const { cipherText, iv } = await db.get(KEYS_COLLECTION, compressedPkd); // TODO error handling
+  return decrypt(Buffer.from(cipherText,'base64'), key, iv);
+};
+
+export const rotateKey = async () => {
+  const db = await connectDB();
+  const keysCollection = await db.getAllKeys(KEYS_COLLECTION);
+  // Retrieve pkds
+  const compressedPkds = keysCollection.filter(k => k !== 'cryptokey');
+  // Generate New Key
+  const aesGenParams = { name: 'AES-GCM', length: 128 };
+  const newKey: CryptoKey = await crypto.subtle.generateKey(aesGenParams, false, ['encrypt', 'decrypt']);
+  // Retrieve and Decrypt all accounts
+  const decryptedZkpAccounts = await Promise.all(compressedPkds.map(async (pkd: IDBValidKey) => retrieveAndDecrypt(pkd.toString())));
+  // Re-encrypt these accounts under the new key and store.
+  const reEncryptedZkpAccounts = await Promise.all(decryptedZkpAccounts.map( async dec => {
+    const cipherText = await encrypt(dec, newKey);
+    return db.put(KEYS_COLLECTION,cipherText, dec.compressedPkd )
+  }));
+  // Store the new key.
+  return storeBrowserKey(newKey)
+}

--- a/wallet/src/utils/lib/key-storage.ts
+++ b/wallet/src/utils/lib/key-storage.ts
@@ -17,11 +17,7 @@ type ZkpAccount = {
 type CipherText = {
   cipherText: string;
   iv: Uint8Array;
-}
-
-function isZkpAccount(o: any): o is ZkpAccount {
-  return "pkd" in o && "compressedPkd" in o && "nsk" in o && "ask" in o
-}
+};
 
 const {
   COMMITMENTS_DB,
@@ -30,6 +26,7 @@ const {
   TRANSACTIONS_COLLECTION,
   COMMITMENTS_COLLECTION,
   KEYS_COLLECTION,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
 } = global.config;
 
@@ -45,7 +42,7 @@ const connectDB = async () => {
   });
 };
 
-export const storeBrowserKey = async (key: CryptoKey) => {
+export const storeBrowserKey = async (key: CryptoKey): Promise<IDBValidKey> => {
   const db = await connectDB();
   return db.put(KEYS_COLLECTION, key, 'cryptokey');
 };
@@ -53,54 +50,63 @@ export const storeBrowserKey = async (key: CryptoKey) => {
 const encrypt = async (acct: ZkpAccount, key: CryptoKey): Promise<CipherText> => {
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const buffer = new TextEncoder().encode(JSON.stringify(acct));
-  const cipherText = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, buffer)
+  const cipherText = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, buffer);
   return {
     cipherText: Buffer.from(cipherText).toString('base64'),
     iv,
-  }
-}
+  };
+};
 
-export const encryptAndStore = async (acct: ZkpAccount) => {
+export const encryptAndStore = async (acct: ZkpAccount): Promise<IDBValidKey> => {
   const db = await connectDB();
   const key = await db.get(KEYS_COLLECTION, 'cryptokey');
   const cipherText = await encrypt(acct, key);
-  return db.put(
-    KEYS_COLLECTION, cipherText, acct.compressedPkd,
-  );
+  return db.put(KEYS_COLLECTION, cipherText, acct.compressedPkd);
 };
 
-const decrypt = async (cipherText: BufferSource, key: CryptoKey, iv: Uint8Array) : Promise<ZkpAccount> => {
+const decrypt = async (
+  cipherText: BufferSource,
+  key: CryptoKey,
+  iv: Uint8Array,
+): Promise<ZkpAccount> => {
   const plainText: BufferSource = await crypto.subtle.decrypt(
     { name: 'AES-GCM', iv },
     key,
     cipherText,
   );
-  const decodeBuffer = new TextDecoder().decode(plainText)
+  const decodeBuffer = new TextDecoder().decode(plainText);
   return JSON.parse(decodeBuffer); // TODO error handling
-}
+};
 
-export const retrieveAndDecrypt = async (compressedPkd: string) : Promise<ZkpAccount>  => {
+export const retrieveAndDecrypt = async (compressedPkd: string): Promise<ZkpAccount> => {
   const db = await connectDB();
   const key = await db.get(KEYS_COLLECTION, 'cryptokey');
   const { cipherText, iv } = await db.get(KEYS_COLLECTION, compressedPkd); // TODO error handling
-  return decrypt(Buffer.from(cipherText,'base64'), key, iv);
+  return decrypt(Buffer.from(cipherText, 'base64'), key, iv);
 };
 
-export const rotateKey = async () => {
+export const rotateKey = async (): Promise<IDBValidKey> => {
   const db = await connectDB();
   const keysCollection = await db.getAllKeys(KEYS_COLLECTION);
   // Retrieve pkds
   const compressedPkds = keysCollection.filter(k => k !== 'cryptokey');
   // Generate New Key
   const aesGenParams = { name: 'AES-GCM', length: 128 };
-  const newKey: CryptoKey = await crypto.subtle.generateKey(aesGenParams, false, ['encrypt', 'decrypt']);
+  const newKey: CryptoKey = await crypto.subtle.generateKey(aesGenParams, false, [
+    'encrypt',
+    'decrypt',
+  ]);
   // Retrieve and Decrypt all accounts
-  const decryptedZkpAccounts = await Promise.all(compressedPkds.map(async (pkd: IDBValidKey) => retrieveAndDecrypt(pkd.toString())));
+  const decryptedZkpAccounts = await Promise.all(
+    compressedPkds.map(async (pkd: IDBValidKey) => retrieveAndDecrypt(pkd.toString())),
+  );
   // Re-encrypt these accounts under the new key and store.
-  const reEncryptedZkpAccounts = await Promise.all(decryptedZkpAccounts.map( async dec => {
-    const cipherText = await encrypt(dec, newKey);
-    return db.put(KEYS_COLLECTION,cipherText, dec.compressedPkd )
-  }));
+  await Promise.all(
+    decryptedZkpAccounts.map(async dec => {
+      const cipherText = await encrypt(dec, newKey);
+      return db.put(KEYS_COLLECTION, cipherText, dec.compressedPkd);
+    }),
+  );
   // Store the new key.
-  return storeBrowserKey(newKey)
-}
+  return storeBrowserKey(newKey);
+};

--- a/wallet/src/utils/lib/local-storage.js
+++ b/wallet/src/utils/lib/local-storage.js
@@ -1,50 +1,15 @@
 /* ignore unused exports */
-import AES from 'crypto-js/aes';
-import Utf8 from 'crypto-js/enc-utf8';
 
 const STORAGE_VERSION_KEY = 'nightfallStorageVersion';
 const STORAGE_VERSION = 1;
 const TOKEN_POOL_KEY = 'nightfallTokensPool';
-const MNEMONIC_KEY = 'nightfallMnemonic';
 
 const storage = window.localStorage;
-
-const encryptWithAES = (text, passphrase) => {
-  return AES.encrypt(text, passphrase).toString();
-};
-
-const decryptWithAES = (ciphertext, passphrase) => {
-  const bytes = AES.decrypt(ciphertext, passphrase);
-  return bytes.toString(Utf8);
-};
 
 function init() {
   if (!storage.getItem(STORAGE_VERSION_KEY)) {
     storage.setItem(STORAGE_VERSION_KEY, STORAGE_VERSION);
   }
-}
-
-function mnemonicSet(userKey, mnemonic, passphrase) {
-  init();
-  if (!storage.getItem(MNEMONIC_KEY + userKey) && passphrase) {
-    const ciphertext = encryptWithAES(mnemonic, passphrase);
-    storage.setItem(MNEMONIC_KEY + userKey, ciphertext);
-  }
-}
-
-function mnemonicGet(userKey, passphrase) {
-  const ciphertext = storage.getItem(MNEMONIC_KEY + userKey);
-  if (typeof passphrase === 'undefined') {
-    return ciphertext;
-  }
-  if (ciphertext) {
-    return decryptWithAES(ciphertext, passphrase);
-  }
-  return ciphertext;
-}
-
-function mnemonicRemove(userKey) {
-  storage.removeItem(MNEMONIC_KEY + userKey);
 }
 
 function tokensSet(userKey, tokens) {
@@ -61,12 +26,13 @@ function clear() {
   storage.clear();
 }
 
-function pkdSet(userKey, pkd) {
-  storage.setItem(`${userKey}/pkd`, pkd);
+function pkdArraySet(userKey, pkds) {
+  init();
+  storage.setItem(`${userKey}/pkds`, JSON.stringify(pkds));
 }
 
-function pkdGet(userKey) {
-  return storage.getItem(`${userKey}/pkd`);
+function pkdArrayGet(userKey) {
+  return JSON.parse(storage.getItem(`${userKey}/pkds`));
 }
 
-export { mnemonicGet, mnemonicSet, mnemonicRemove, tokensSet, tokensGet, clear, pkdGet, pkdSet };
+export { tokensSet, tokensGet, clear, pkdArrayGet, pkdArraySet };

--- a/wallet/src/views/wallet/index.jsx
+++ b/wallet/src/views/wallet/index.jsx
@@ -110,7 +110,7 @@ function WalletModal(props) {
         <Button
           onClick={async () => {
             // await configureMnemonic(screenMnemonic);
-            await deriveAccounts(screenMnemonic, DEFAULT_ACCOUNT_NUM)
+            await deriveAccounts(screenMnemonic, DEFAULT_ACCOUNT_NUM);
             props.onHide();
           }}
           disabled={typeof screenMnemonic === 'undefined'}
@@ -131,10 +131,8 @@ export default function Wallet() {
 
   useEffect(async () => {
     const pkdsDerived = Storage.pkdArrayGet(await Web3.getAccount());
-    console.log('pkdsDerived', pkdsDerived);
     if (typeof state.compressedPkd === 'undefined' && !pkdsDerived) setModalShow(true);
     else setModalShow(false);
-    console.log('SSTAETE', state);
   }, []);
 
   useEffect(async () => {

--- a/wallet/tests/e2e/specs/e2e-spec.js
+++ b/wallet/tests/e2e/specs/e2e-spec.js
@@ -51,7 +51,6 @@ describe('End to End tests', () => {
       cy.contains('Polygon Nightfall Wallet').click();
       cy.get('button').contains('Generate Mnemonic', { timeout: 10000 }).click();
       cy.get('button').contains('Create Wallet', { timeout: 10000 }).click();
-      cy.confirmMetamaskSignatureRequest().then(confirmed => expect(confirmed).to.be.true);
       cy.get('#TokenItem_tokenDepositMATIC').click();
       cy.url().should('include', '/bridge');
       cy.wait(10000);


### PR DESCRIPTION
This PR changes the way sensitive material is stored in the browser. Instead of encrypting and storing the mnemonic, we pre-generate a number of addresses and keys, and encrypt and store those instead. The flow chart below describes the process.

All new functionality is contained within `key-storage.ts`, the other changes are just to the way `zkpKeys` are retrieved. We have to also modify the `.eslint` settings in `wallet` to better handle all the new typescript files.

Note this is a very breaking change, and requires the clearing out of the `indexedDB` and `localStorage` in the browser in order to work as intended.

<img width="939" alt="image" src="https://user-images.githubusercontent.com/9293647/158983148-f5be6bcf-1222-4e30-8eaf-77f16dece57b.png">
