### PR TITLE
Westlad/enhanced gas test

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,17 +108,37 @@ make the standard tests fast.
 
 In reality, a value of two transactions per block, although convenient for testing, wouldn't make
 very efficient use of Optimism. A more realistic value is 32 transactions per layer 2 block. This
-value can be configured by the environment variable `TRANSACTIONS_PER_BLOCK` in the
-`docker-compose.yml` file (part of the `optimist` service). This is important for the Block Gas
-measurement, which requires a value of 32 to be set.
+value can be configured by the environment variable `TRANSACTIONS_PER_BLOCK`. This is important
+for the Block Gas measurement, which only makes sense for more realistic block sizes.
 
-To measure the Block Gas used per transaction, first edit the `TRANSACTIONS_PER_BLOCK` variable as
-above (don't forget to change it back after), restart nightfall_3, and run:
+To measure the Block Gas used per transaction, export the `TRANSACTIONS_PER_BLOCK` variable in both
+the terminal which will run nightfall and the terminal from which the test will be run, setting it to the
+value at which you want to run the test (32 in the example here):
+
+```sh
+export TRANSACTIONS_PER_BLOCK=32
+```
+Any reasonable value will work but they must be the same for both nightfall and the test.
+Obviously, it only makes sense to compare performance at the same value of `TRANSACTIONS_PER_BLOCK`.
+
+Then start nightfall:
+
+```sh
+./start-nightfall -g -d -s
+```
+Then, in the other terminal window run the test
 
 ```sh
 npm run test-gas
 ```
+The test will print out values of gas used for each type of transaction as it progresses.
 
+Do not forget to set the `TRANSACTIONS_PER_BLOCK` back to 2 when you have finished or the other tests
+may fail in strange ways.
+
+```sh
+export TRANSACTIONS_PER_BLOCK=2
+```
 ### Test chain reorganisations
 
 In Layer 2 solutions, Layer 2 state is held off-chain but created by a series of Layer 1
@@ -192,14 +212,14 @@ Nightfall_3 provides a Wallet to exercise its features. To use it:
 
 - Deploy nightfall (only ganache for now) from Nightfall's root folder
 
-```
+```sh
 ./start-nightfall -g -d -s
 ```
 
 - In a different terminal, start proposer from Nightfall's root folder once Nightfall deployment is
   finished (you will see this `nightfall_3-deployer-1 exited with code 0`).
 
-```
+```sh
 ./proposer
 ```
 

--- a/nightfall-deployer/src/circuit-setup.mjs
+++ b/nightfall-deployer/src/circuit-setup.mjs
@@ -27,7 +27,7 @@ async function waitForZokrates() {
       200
     ) {
       logger.warn(
-        `No response from zokratesworker yet.  That's ok. We'll wait three seconds and try again...`,
+        `No response from zokrates_worker yet.  That's ok. We'll wait three seconds and try again...`,
       );
 
       await new Promise(resolve => setTimeout(resolve, 3000));

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -346,6 +346,60 @@ export const depositNTransactions = async (nf3, N, ercAddress, tokenType, value,
   return depositTransactions;
 };
 
+export const transferNTransactions = async (
+  nf3,
+  N,
+  ercAddress,
+  tokenType,
+  value,
+  tokenId,
+  compressedPkd,
+  fee,
+) => {
+  const transferTransactions = [];
+  for (let i = 0; i < N; i++) {
+    const res = await nf3.transfer(
+      false,
+      ercAddress,
+      tokenType,
+      value,
+      tokenId,
+      compressedPkd,
+      fee,
+    );
+    expectTransaction(res);
+    transferTransactions.push(res);
+  }
+  return transferTransactions;
+};
+
+export const withdrawNTransactions = async (
+  nf3,
+  N,
+  ercAddress,
+  tokenType,
+  value,
+  tokenId,
+  recipientAddress,
+  fee,
+) => {
+  const withdrawTransactions = [];
+  for (let i = 0; i < N; i++) {
+    const res = await nf3.withdraw(
+      false,
+      ercAddress,
+      tokenType,
+      value,
+      tokenId,
+      recipientAddress,
+      fee,
+    );
+    expectTransaction(res);
+    withdrawTransactions.push(res);
+  }
+  return withdrawTransactions;
+};
+
 /**
   function to retrieve balance of user because getLayer2Balances returns
   balances of all users


### PR DESCRIPTION
This PR enhances the coverage of the test-gas test.  This test will now measure the L1 and L2 gas usage for all four types of nightfall transaction (deposit, single transfer, double transfer, withdraw) and also for the finalise withdraw.  The latter is already covered by the e2e tests, but it uses minimal resources, and so I included it here so that this test provides a complete measure of all gas used.

To use this test locally, you will need to set the environment variable `TRANSACTIONS_PER_BLOCK` to the value that you want to use in the test run.  For example:
```sh
export TRANSACTIONS_PER_BLOCK=32
```
Do this in both the window from which you start nightfall and the window from which you run the test. _Do not_ forget to set it back to 2 when you have finished (same command as above but with 2, rather than 32) otherwise you'll spend half a day wondering why none of your other tests pass any more. Closing the windows will also work as the export does not persist past logout.

Other than that, the test is completely standard `./start-nightfall -g -s -d` and `npm run test-gas`.