### PR TITLE
Better Gas estimation for on-chain calls

### DIFF
--- a/wallet/src/components/Input/index.tsx
+++ b/wallet/src/components/Input/index.tsx
@@ -9,7 +9,7 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   prefix?: string;
 }
 
-const Input: React.FC<InputProps> = ({ mask, prefix, ...props }) => {
+const Input: React.FC<InputProps> = ({ mask, ...props }) => {
   const handleKeyUp = useCallback(
     (e: React.FormEvent<HTMLInputElement>) => {
       if (mask === 'cep') {

--- a/wallet/src/components/Input/masks.ts
+++ b/wallet/src/components/Input/masks.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export function cep(e: React.FormEvent<HTMLInputElement>) {
+export function cep(e: React.FormEvent<HTMLInputElement>): React.FormEvent<HTMLInputElement> {
   e.currentTarget.maxLength = 9;
   let { value } = e.currentTarget;
   value = value.replace(/\D/g, '');
@@ -9,7 +9,7 @@ export function cep(e: React.FormEvent<HTMLInputElement>) {
   return e;
 }
 
-export function currency(e: React.FormEvent<HTMLInputElement>) {
+export function currency(e: React.FormEvent<HTMLInputElement>): React.FormEvent<HTMLInputElement> {
   let { value } = e.currentTarget;
   value = value.replace(/\D/g, '');
   value = value.replace(/(\d)(\d{2})$/, '$1,$2');
@@ -19,7 +19,7 @@ export function currency(e: React.FormEvent<HTMLInputElement>) {
   return e;
 }
 
-export function cpf(e: React.FormEvent<HTMLInputElement>) {
+export function cpf(e: React.FormEvent<HTMLInputElement>): React.FormEvent<HTMLInputElement> {
   e.currentTarget.maxLength = 14;
   let { value } = e.currentTarget;
   if (!value.match(/^(\d{3}).(\d{3}).(\d{3})-(\d{2})$/)) {

--- a/wallet/src/hooks/Account/index.tsx
+++ b/wallet/src/hooks/Account/index.tsx
@@ -20,7 +20,8 @@ const AccountContext = createContext<AccountContextType>({} as AccountContextTyp
  * context use
  * @param children
  */
-const AccountProvider = ({ children }: any) => {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const AccountProvider = ({ children }: any): JSX.Element => {
   const [accountInstance, setAccountInstance] = useState<AccountType>(accountType);
 
   return (
@@ -38,7 +39,7 @@ const AccountProvider = ({ children }: any) => {
 /**
  * Hook to allow the context call
  */
-const useAccount = () => {
+const useAccount = (): AccountContextType => {
   const context = useContext(AccountContext);
 
   if (!context) {


### PR DESCRIPTION
This PR adds better gas estimation for any on-chain calls in the browser. It primarily uses etherscan's estimation api (this is wrapped behind a simple AWS gateway), but has a fallback function that uses the local node to do so.

The advantage of the etherscan api is that it has a richer estimation algorithm (with low, med and high - we use medium for this application) while the fallback relies on the average gas cost of the last **n**  blocks.

The url endpoint is hardcoded, it will be used for all deployments of the wallet (i.e. `testnet`, `mainnet`) since etherscan only provides an estimation for `mainnet`. This isn't a problem as it means we get a good idea of the gas costs involved on mainnet even while testing using `Goerli`.

Placing the api behind an AWS endpoint means we can monitor and add throttling or restrictions if we find that they are being over-used.


Note: There is some eslint issues fixed here too
