### PR TITLE
Handle Uint112 in browser

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,7 +3,6 @@ cd node_modules/*
 **/migrations/*
 **/doc/*
 cli/build/*
-wallet/**
 test/adversary/nightfall-adversary/*
 wallet/build
 /**/*.d.ts

--- a/wallet/package-lock.json
+++ b/wallet/package-lock.json
@@ -3527,89 +3527,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "@chainlink/contracts-0.0.10": {
-      "version": "npm:@chainlink/contracts@0.0.10",
-      "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.10.tgz",
-      "integrity": "sha512-ok+ucSQ+3mrR+zjbi6zIrdd5M9XymcqVcnXGVyqBVRYZp97jS2/rt/glP320JmHxmi4pacgDOg0Ux11xIr1S8Q==",
-      "dev": true,
-      "requires": {
-        "@truffle/contract": "^4.2.6",
-        "ethers": "^4.0.45"
-      },
-      "dependencies": {
-        "aes-js": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-          "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
-          "dev": true,
-          "optional": true
-        },
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-          "dev": true,
-          "optional": true
-        },
-        "ethers": {
-          "version": "4.0.49",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.49.tgz",
-          "integrity": "sha512-kPltTvWiyu+OktYy1IStSO16i2e7cS9D9OxZ81q2UUaiNPVrm/RTcbxamCXF9VUSKzJIdJV68EAIhTEVBalRWg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aes-js": "3.0.0",
-            "bn.js": "^4.11.9",
-            "elliptic": "6.5.4",
-            "hash.js": "1.1.3",
-            "js-sha3": "0.5.7",
-            "scrypt-js": "2.0.4",
-            "setimmediate": "1.0.4",
-            "uuid": "2.0.1",
-            "xmlhttprequest": "1.8.0"
-          }
-        },
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-          "dev": true,
-          "optional": true
-        },
-        "scrypt-js": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
-          "dev": true,
-          "optional": true
-        },
-        "setimmediate": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
-          "dev": true,
-          "optional": true
-        },
-        "uuid": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -8349,6 +8266,12 @@
         "@types/node": "*"
       }
     },
+    "@types/chai": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
+      "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
+      "dev": true
+    },
     "@types/eslint": {
       "version": "7.28.2",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.2.tgz",
@@ -8450,6 +8373,12 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
+      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
       "dev": true
     },
     "@types/node": {
@@ -8904,6 +8833,12 @@
         "@typescript-eslint/types": "4.33.0",
         "eslint-visitor-keys": "^2.0.0"
       }
+    },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
     },
     "@walletconnect/browser-utils": {
       "version": "1.7.1",
@@ -9782,6 +9717,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -12124,6 +12065,12 @@
         }
       }
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "browserify": {
       "version": "16.2.3",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.2.3.tgz",
@@ -12703,6 +12650,21 @@
         "nofilter": "^1.0.4"
       }
     },
+    "chai": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -12816,6 +12778,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "check-more-types": {
@@ -14544,6 +14512,15 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
       "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
     },
     "deep-equal": {
       "version": "1.1.1",
@@ -18322,6 +18299,12 @@
         "micromatch": "^4.0.2"
       }
     },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
+    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -18763,6 +18746,12 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -19018,6 +19007,12 @@
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
     },
     "growly": {
       "version": "1.3.0",
@@ -23360,6 +23355,15 @@
       "resolved": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.9.1.tgz",
       "integrity": "sha512-3uKtU6BhIK6ZRCE/QyiXq/KuRvPeEAz/VFwqd99jPbpgFY9gHLw2krqvcuCFGepeW94BipS/B3TqIfTc9pUeZg=="
     },
+    "loupe": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "dev": true,
+      "requires": {
+        "get-func-name": "^2.0.0"
+      }
+    },
     "lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -23878,6 +23882,234 @@
       "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
       "requires": {
         "mkdirp": "*"
+      }
+    },
+    "mocha": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "dev": true,
+      "requires": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "4.2.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.1",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "workerpool": "6.2.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "chokidar": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+          "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+          "dev": true,
+          "requires": {
+            "anymatch": "~3.1.2",
+            "braces": "~3.0.2",
+            "fsevents": "~2.3.2",
+            "glob-parent": "~5.1.2",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.6.0"
+          }
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+          "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "nanoid": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+          "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "serialize-javascript": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+          "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+          "dev": true
+        }
       }
     },
     "mock-fs": {
@@ -24679,12 +24911,6 @@
         "is-wsl": "^2.1.1"
       }
     },
-    "openzeppelin-solidity-2.3.0": {
-      "version": "npm:openzeppelin-solidity@2.3.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
-      "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw==",
-      "dev": true
-    },
     "opn": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -25070,6 +25296,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+    },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true
     },
     "pause-stream": {
       "version": "0.0.11",
@@ -30819,6 +31051,23 @@
         "web3-utils": "1.2.2"
       },
       "dependencies": {
+        "@chainlink/contracts-0.0.10": {
+          "version": "npm:@chainlink/contracts@0.0.10",
+          "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.10.tgz",
+          "integrity": "sha512-ok+ucSQ+3mrR+zjbi6zIrdd5M9XymcqVcnXGVyqBVRYZp97jS2/rt/glP320JmHxmi4pacgDOg0Ux11xIr1S8Q==",
+          "dev": true,
+          "requires": {
+            "@truffle/contract": "^4.2.6",
+            "ethers": "^4.0.45"
+          }
+        },
+        "aes-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+          "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
+          "dev": true,
+          "optional": true
+        },
         "bn.js": {
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -30841,6 +31090,78 @@
             "elliptic": "^6.4.0",
             "xhr-request-promise": "^0.1.2"
           }
+        },
+        "ethers": {
+          "version": "4.0.49",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.49.tgz",
+          "integrity": "sha512-kPltTvWiyu+OktYy1IStSO16i2e7cS9D9OxZ81q2UUaiNPVrm/RTcbxamCXF9VUSKzJIdJV68EAIhTEVBalRWg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+          "dev": true,
+          "optional": true
+        },
+        "openzeppelin-solidity-2.3.0": {
+          "version": "npm:openzeppelin-solidity@2.3.0",
+          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
+          "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw==",
+          "dev": true
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+          "dev": true,
+          "optional": true
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+          "dev": true,
+          "optional": true
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+          "dev": true,
+          "optional": true
         },
         "web3-utils": {
           "version": "1.2.2",
@@ -31710,9 +32031,9 @@
       "dev": true
     },
     "ts-node": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
-      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
       "requires": {
         "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",
@@ -31725,13 +32046,14 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.0",
         "yn": "3.1.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
-          "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw=="
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
         },
         "acorn-walk": {
           "version": "8.2.0",
@@ -32295,6 +32617,11 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
+      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA=="
     },
     "v8-to-istanbul": {
       "version": "7.1.2",
@@ -34884,6 +35211,12 @@
         "microevent.ts": "~0.1.1"
       }
     },
+    "workerpool": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "dev": true
+    },
     "wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -35063,6 +35396,32 @@
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
+      }
+    },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "decamelize": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
           "dev": true
         }
       }

--- a/wallet/package.json
+++ b/wallet/package.json
@@ -54,7 +54,7 @@
     "start:ropsten": "REACT_APP_ENVIRONMENT=Ropsten craco start",
     "build": "LOCAL_PROPOSER=false USE_STUBS=true craco build",
     "deploy": "npm run build && aws s3 sync build s3://pnf-dev-browser --cache-control max-age=172800 --delete && aws configure set preview.cloudfront true && aws cloudfront create-invalidation --distribution-id ENV3X13MLR5YT --paths \"/*\"",
-    "test": "craco test --env=jsdom",
+    "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register 'tests/**/*.ts'",
     "eject": "craco eject",
     "e2e-test": "npx synpress run --env TRANSACTIONS_PER_BLOCK=2"
   },
@@ -74,7 +74,13 @@
     "@craco/craco": "^6.4.2",
     "@synthetixio/synpress": "^1.1.1",
     "@testing-library/react": "^12.1.2",
+    "@types/chai": "^4.3.0",
+    "@types/mocha": "^9.1.0",
+    "@types/react-router-dom": "^5.3.3",
+    "@typescript-eslint/parser": "^5.15.0",
+    "chai": "^4.3.6",
+    "mocha": "^9.2.2",
     "react-scripts": "4.0.3",
-    "@typescript-eslint/parser": "^5.15.0"
+    "ts-node": "^10.7.0"
   }
 }

--- a/wallet/package.json
+++ b/wallet/package.json
@@ -49,7 +49,7 @@
     "zokrates-js": "^1.0.39"
   },
   "scripts": {
-    "start": "LOCAL_PROPOSER=false USE_STUBS=true craco start",
+    "start": "LOCAL_PROPOSER=true USE_STUBS=true craco start",
     "start:docker": "REACT_APP_ENVIRONMENT=Docker PORT=3010 craco start",
     "start:ropsten": "REACT_APP_ENVIRONMENT=Ropsten craco start",
     "build": "LOCAL_PROPOSER=false USE_STUBS=true craco build",

--- a/wallet/src/common-files/classes/bigFloat.ts
+++ b/wallet/src/common-files/classes/bigFloat.ts
@@ -17,7 +17,10 @@ class BigFloat {
       const stringVal: string =
         typeof floatVal === 'string' ? floatVal : floatVal.toFixed(numDecimals);
       const [displaySignificand, displayMantissa] = stringVal.split('.');
-      this.mantissa = displayMantissa.padEnd(numDecimals, '0').slice(0, numDecimals);
+      this.mantissa =
+        typeof displayMantissa === 'undefined'
+          ? '0'.repeat(numDecimals)
+          : displayMantissa.padEnd(numDecimals, '0').slice(0, numDecimals);
       this.significand = displaySignificand;
       this.numDecimals = numDecimals;
     }

--- a/wallet/src/common-files/classes/bigFloat.ts
+++ b/wallet/src/common-files/classes/bigFloat.ts
@@ -1,0 +1,63 @@
+type Operands = BigFloat | number | bigint | string;
+
+class BigFloat {
+  significand: string; // Part before the decimal
+
+  mantissa: string; // Part after the decimal
+
+  numDecimals: number; // The scaling factor
+
+  constructor(floatVal: number | bigint | string, numDecimals: number) {
+    if (typeof floatVal === 'bigint') {
+      const stringVal = floatVal.toString().padStart(numDecimals, '0');
+      this.significand = stringVal.slice(0, -numDecimals);
+      this.mantissa = stringVal.slice(-numDecimals);
+      this.numDecimals = numDecimals;
+    } else {
+      const stringVal: string =
+        typeof floatVal === 'string' ? floatVal : floatVal.toFixed(numDecimals);
+      const [displaySignificand, displayMantissa] = stringVal.split('.');
+      this.mantissa = displayMantissa.padEnd(numDecimals, '0').slice(0, numDecimals);
+      this.significand = displaySignificand;
+      this.numDecimals = numDecimals;
+    }
+  }
+
+  toBigInt(): bigint {
+    return BigInt(`${this.significand}${this.mantissa}`);
+  }
+
+  toString(): string {
+    if (this.significand.length === 0) return `0.${this.mantissa}`;
+    return `${this.significand}.${this.mantissa}`;
+  }
+
+  toFixed(displayDecimals: number): string {
+    if (this.significand.length === 0) return `0.${this.mantissa.slice(0, displayDecimals)}`;
+    return `${this.significand}.${this.mantissa.slice(0, displayDecimals)}`;
+  }
+
+  static parseOperand(operand: Operands, numDecimals: number): BigFloat {
+    if (operand instanceof BigFloat) return operand;
+    if (typeof operand === 'bigint') return new BigFloat(operand.toString(), numDecimals);
+    if (typeof operand === 'string') return new BigFloat(operand, numDecimals);
+    // Here typescript is smart enough to know operand is a number now.
+    return new BigFloat(operand.toFixed(numDecimals), numDecimals);
+  }
+
+  mul(operand: Operands): BigFloat {
+    const thisBN = BigInt(`${this.significand}${this.mantissa}`);
+    const operandBN: bigint = BigFloat.parseOperand(operand, this.numDecimals).toBigInt();
+    const resultedBN: bigint = thisBN * operandBN;
+    const scaledBN: bigint = resultedBN / 10n ** BigInt(this.numDecimals); // Anything truncated from this is precision we dont care about anyways.
+    return new BigFloat(scaledBN, this.numDecimals);
+  }
+
+  add(operand: Operands): BigFloat {
+    const thisBN = BigInt(`${this.significand}${this.mantissa}`);
+    const operandBN: bigint = BigFloat.parseOperand(operand, this.numDecimals).toBigInt();
+    return new BigFloat(thisBN + operandBN, this.numDecimals);
+  }
+}
+
+export default BigFloat;

--- a/wallet/src/common-files/classes/transaction.js
+++ b/wallet/src/common-files/classes/transaction.js
@@ -17,7 +17,7 @@ function keccak(preimage) {
   const web3 = Web3.connection();
   // compute the solidity hash, using suitable type conversions
   return web3.utils.soliditySha3(
-    { t: 'uint64', v: preimage.value },
+    { t: 'uint112', v: preimage.value },
     ...preimage.historicRootBlockNumberL2.map(hi => ({ t: 'uint256', v: hi })),
     { t: 'uint8', v: preimage.transactionType },
     { t: 'uint8', v: preimage.tokenType },

--- a/wallet/src/components/BridgeComponent/index.jsx
+++ b/wallet/src/components/BridgeComponent/index.jsx
@@ -31,6 +31,7 @@ import { APPROVE_AMOUNT } from '../../constants';
 import { retrieveAndDecrypt } from '../../utils/lib/key-storage';
 import { decompressKey } from '../../nightfall-browser/services/keys';
 import { saveTransaction } from '../../nightfall-browser/services/database';
+import BigFloat from '../../common-files/classes/bigFloat';
 
 const { proposerUrl } = global.config;
 
@@ -38,26 +39,6 @@ const { proposerUrl } = global.config;
 const gen = require('general-number');
 
 const { generalise } = gen;
-
-const bnAsNumber = (bn, numDecimals, displayDecimals = 4) => {
-  const stringBn = bn.toString();
-  const mantissa = stringBn.slice(-numDecimals);
-  const significand = stringBn.slice(0, stringBn.length - numDecimals);
-  const displayMantissa = mantissa.slice(0, displayDecimals);
-  return Number(`${significand}.${displayMantissa}`);
-};
-
-const numberAsBN = (numberBn, numDecimals) => {
-  const [displaySignificand, displayMantissa] = numberBn.toString().split('.');
-  console.log('displaySignificand', displaySignificand);
-  console.log('displayMantissa', displayMantissa);
-  console.log('numberAsBN no mantissa', BigInt(displaySignificand) * 10n ** BigInt(numDecimals));
-  if (typeof displayMantissa === 'undefined')
-    return BigInt(displaySignificand) * 10n ** BigInt(numDecimals);
-  const mantissa = Number(`0.${displayMantissa}`) * 10 ** numDecimals;
-  console.log('numberAsBN', BigInt(`${displaySignificand}${mantissa.toString()}`));
-  return BigInt(`${displaySignificand}${mantissa.toString()}`);
-};
 
 const BridgeComponent = () => {
   const [state] = useContext(UserContext);
@@ -183,7 +164,7 @@ const BridgeComponent = () => {
           {
             ercAddress,
             tokenId: 0,
-            value: numberAsBN(transferValue, token.decimals).toString(),
+            value: new BigFloat(transferValue, token.decimals).toBigInt().toString(),
             pkd,
             nsk: zkpKeys.nsk,
             fee: 1,
@@ -210,7 +191,7 @@ const BridgeComponent = () => {
             offchain: true,
             ercAddress,
             tokenId: 0,
-            value: numberAsBN(transferValue, token.decimals).toString(),
+            value: new BigFloat(transferValue, token.decimals).toBigInt().toString(),
             recipientAddress: await Web3.getAccount(),
             nsk: zkpKeys.nsk,
             ask: zkpKeys.ask,
@@ -241,8 +222,9 @@ const BridgeComponent = () => {
 
   const handleShow = () => {
     if (
-      (txType === 'deposit' && numberAsBN(transferValue, token.decimals) > l1Balance) ||
-      (txType === 'withdraw' && numberAsBN(transferValue, token.decimals) > l2Balance)
+      (txType === 'deposit' &&
+        new BigFloat(transferValue, token.decimals).toBigInt() > l1Balance) ||
+      (txType === 'withdraw' && new BigFloat(transferValue, token.decimals).toBigInt() > l2Balance)
     )
       toast.error("Input value can't be greater than balance!");
     else if (!transferValue) toast.warn('Input a value for transfer, please.');
@@ -333,10 +315,10 @@ const BridgeComponent = () => {
                 <div className="balance_details">
                   <p>Balance: </p>
                   {token && txType === 'deposit' && (
-                    <p>{`${bnAsNumber(l1Balance, token.decimals).toFixed(4)} ${token.symbol}`}</p>
+                    <p>{`${new BigFloat(l1Balance, token.decimals).toFixed(4)} ${token.symbol}`}</p>
                   )}
                   {token && txType === 'withdraw' && (
-                    <p>{`${bnAsNumber(l2Balance, token.decimals).toFixed(4)} ${token.symbol}`}</p>
+                    <p>{`${new BigFloat(l2Balance, token.decimals).toFixed(4)} ${token.symbol}`}</p>
                   )}
                   {!token && (
                     <p>
@@ -409,10 +391,10 @@ const BridgeComponent = () => {
               <div className="balance_details">
                 <p>Balance: </p>
                 {token && txType === 'deposit' && (
-                  <p>{`${bnAsNumber(l2Balance, token.decimals).toFixed(4)} ${token.symbol}`}</p>
+                  <p>{`${new BigFloat(l2Balance, token.decimals).toFixed(4)} ${token.symbol}`}</p>
                 )}
                 {token && txType === 'withdraw' && (
-                  <p>{`${bnAsNumber(l1Balance, token.decimals).toFixed(4)} ${token.symbol}`}</p>
+                  <p>{`${new BigFloat(l1Balance, token.decimals).toFixed(4)} ${token.symbol}`}</p>
                 )}
                 {!token && (
                   // <p>
@@ -422,8 +404,8 @@ const BridgeComponent = () => {
                   // </p>
                   <p>
                     {txType === 'withdraw'
-                      ? `${bnAsNumber(l2Balance, token.decimals).toFixed(4)} ${token.symbol}`
-                      : `${bnAsNumber(l1Balance, token.decimals).toFixed(4)} ${token.symbol}`}
+                      ? `${new BigFloat(l2Balance, token.decimals).toFixed(4)} ${token.symbol}`
+                      : `${new BigFloat(l1Balance, token.decimals).toFixed(4)} ${token.symbol}`}
                   </p>
                 )}
               </div>

--- a/wallet/src/components/BridgeComponent/index.jsx
+++ b/wallet/src/components/BridgeComponent/index.jsx
@@ -39,6 +39,26 @@ const gen = require('general-number');
 
 const { generalise } = gen;
 
+const bnAsNumber = (bn, numDecimals, displayDecimals = 4) => {
+  const stringBn = bn.toString();
+  const mantissa = stringBn.slice(-numDecimals);
+  const significand = stringBn.slice(0, stringBn.length - numDecimals);
+  const displayMantissa = mantissa.slice(0, displayDecimals);
+  return Number(`${significand}.${displayMantissa}`);
+};
+
+const numberAsBN = (numberBn, numDecimals) => {
+  const [displaySignificand, displayMantissa] = numberBn.toString().split('.');
+  console.log('displaySignificand', displaySignificand);
+  console.log('displayMantissa', displayMantissa);
+  console.log('numberAsBN no mantissa', BigInt(displaySignificand) * 10n ** BigInt(numDecimals));
+  if (typeof displayMantissa === 'undefined')
+    return BigInt(displaySignificand) * 10n ** BigInt(numDecimals);
+  const mantissa = Number(`0.${displayMantissa}`) * 10 ** numDecimals;
+  console.log('numberAsBN', BigInt(`${displaySignificand}${mantissa.toString()}`));
+  return BigInt(`${displaySignificand}${mantissa.toString()}`);
+};
+
 const BridgeComponent = () => {
   const [state] = useContext(UserContext);
   const { setAccountInstance, accountInstance } = useAccount();
@@ -163,7 +183,7 @@ const BridgeComponent = () => {
           {
             ercAddress,
             tokenId: 0,
-            value: (BigInt(transferValue) * 10n ** BigInt(token.decimals)).toString(),
+            value: numberAsBN(transferValue, token.decimals).toString(),
             pkd,
             nsk: zkpKeys.nsk,
             fee: 1,
@@ -190,7 +210,7 @@ const BridgeComponent = () => {
             offchain: true,
             ercAddress,
             tokenId: 0,
-            value: (BigInt(transferValue) * 10n ** BigInt(token.decimals)).toString(),
+            value: numberAsBN(transferValue, token.decimals).toString(),
             recipientAddress: await Web3.getAccount(),
             nsk: zkpKeys.nsk,
             ask: zkpKeys.ask,
@@ -221,8 +241,8 @@ const BridgeComponent = () => {
 
   const handleShow = () => {
     if (
-      (txType === 'deposit' && (BigInt(transferValue) * 10n ** BigInt(token.decimals)) > l1Balance) ||
-      (txType === 'withdraw' && (BigInt(transferValue) * 10n ** BigInt(token.decimals)) > l2Balance)
+      (txType === 'deposit' && numberAsBN(transferValue, token.decimals) > l1Balance) ||
+      (txType === 'withdraw' && numberAsBN(transferValue, token.decimals) > l2Balance)
     )
       toast.error("Input value can't be greater than balance!");
     else if (!transferValue) toast.warn('Input a value for transfer, please.');
@@ -313,19 +333,10 @@ const BridgeComponent = () => {
                 <div className="balance_details">
                   <p>Balance: </p>
                   {token && txType === 'deposit' && (
-                    // <p> {token.decimals} </p>
-                    // <p>{`${(l1Balance / 10 ** token.decimals).toFixed(4)} ${token.symbol}`}</p>
-                    <p>{
-                      `${l1Balance.toString().slice(0,l1Balance.toString().length - token.decimals)}.
-                      ${(l1Balance.toString().slice(-token.decimals)).slice(0,4)} ${token.symbol}`
-                    }</p>
+                    <p>{`${bnAsNumber(l1Balance, token.decimals).toFixed(4)} ${token.symbol}`}</p>
                   )}
                   {token && txType === 'withdraw' && (
-                    // <p>{`${(l2Balance / 10 ** token.decimals).toFixed(4)} ${token.symbol}`}</p>
-                    <p>{
-                      `${l2Balance.toString().slice(0,l2Balance.toString().length - token.decimals)}.
-                      ${(l2Balance.toString().slice(-token.decimals)).slice(0,4)} ${token.symbol}`
-                    }</p>
+                    <p>{`${bnAsNumber(l2Balance, token.decimals).toFixed(4)} ${token.symbol}`}</p>
                   )}
                   {!token && (
                     <p>
@@ -398,18 +409,10 @@ const BridgeComponent = () => {
               <div className="balance_details">
                 <p>Balance: </p>
                 {token && txType === 'deposit' && (
-                  // <p>{`${(l2Balance / 10 ** token.decimals).toFixed(4)} ${token.symbol}`}</p>
-                  <p>{
-                    `${l2Balance.toString().slice(0,l2Balance.toString().length - token.decimals)}.
-                    ${(l2Balance.toString().slice(-token.decimals)).slice(0,4)} ${token.symbol}`
-                  }</p>
+                  <p>{`${bnAsNumber(l2Balance, token.decimals).toFixed(4)} ${token.symbol}`}</p>
                 )}
                 {token && txType === 'withdraw' && (
-                  // <p>{`${(l1Balance / 10 ** token.decimals).toFixed(4)} ${token.symbol}`}</p>
-                  <p>{
-                    `${l1Balance.toString().slice(0,l1Balance.toString().length - token.decimals)}.
-                    ${(l1Balance.toString().slice(-token.decimals)).slice(0,4)} ${token.symbol}`
-                  }</p>
+                  <p>{`${bnAsNumber(l1Balance, token.decimals).toFixed(4)} ${token.symbol}`}</p>
                 )}
                 {!token && (
                   // <p>
@@ -419,9 +422,8 @@ const BridgeComponent = () => {
                   // </p>
                   <p>
                     {txType === 'withdraw'
-                      ? `${l2Balance.toString().slice(0,l2Balance.toString().length - token.decimals)}.${(l2Balance.toString().slice(-token.decimals)).slice(0,4)} ${token.symbol}`
-                      : `${l1Balance.toString().slice(0,l1Balance.toString().length - token.decimals)}.${(l1Balance.toString().slice(-token.decimals)).slice(0,4)} ${token.symbol}`
-                  }
+                      ? `${bnAsNumber(l2Balance, token.decimals).toFixed(4)} ${token.symbol}`
+                      : `${bnAsNumber(l1Balance, token.decimals).toFixed(4)} ${token.symbol}`}
                   </p>
                 )}
               </div>

--- a/wallet/src/components/BridgeComponent/index.jsx
+++ b/wallet/src/components/BridgeComponent/index.jsx
@@ -320,14 +320,7 @@ const BridgeComponent = () => {
                   {token && txType === 'withdraw' && (
                     <p>{`${new BigFloat(l2Balance, token.decimals).toFixed(4)} ${token.symbol}`}</p>
                   )}
-                  {!token && (
-                    <p>
-                      0
-                      {/* {txType === 'deposit'
-                        ? `${(l1Balance / 10 ** token.decimals).toFixed(4)}`
-                        : `${(l2Balance / 10 ** token.decimals).toFixed(4)}`} */}
-                    </p>
-                  )}
+                  {!token && <p>0</p>}
                 </div>
               </div>
               <div className="from_section_line"></div>
@@ -397,11 +390,6 @@ const BridgeComponent = () => {
                   <p>{`${new BigFloat(l1Balance, token.decimals).toFixed(4)} ${token.symbol}`}</p>
                 )}
                 {!token && (
-                  // <p>
-                  //   {txType === 'withdraw'
-                  //     ? `${(l2Balance / 10 ** token.decimals).toFixed(4)}`
-                  //     : `${(l1Balance / 10 ** token.decimals).toFixed(4)}`}
-                  // </p>
                   <p>
                     {txType === 'withdraw'
                       ? `${new BigFloat(l2Balance, token.decimals).toFixed(4)} ${token.symbol}`

--- a/wallet/src/components/BridgeComponent/index.jsx
+++ b/wallet/src/components/BridgeComponent/index.jsx
@@ -42,8 +42,8 @@ const { generalise } = gen;
 const BridgeComponent = () => {
   const [state] = useContext(UserContext);
   const { setAccountInstance, accountInstance } = useAccount();
-  const [l1Balance, setL1Balance] = useState(0);
-  const [l2Balance, setL2Balance] = useState(0);
+  const [l1Balance, setL1Balance] = useState(0n);
+  const [l2Balance, setL2Balance] = useState(0n);
   const [shieldContractAddress, setShieldAddress] = useState('');
   const location = useLocation();
 
@@ -163,7 +163,7 @@ const BridgeComponent = () => {
           {
             ercAddress,
             tokenId: 0,
-            value: (transferValue * 10 ** token.decimals).toString(),
+            value: (BigInt(transferValue) * 10n ** BigInt(token.decimals)).toString(),
             pkd,
             nsk: zkpKeys.nsk,
             fee: 1,
@@ -190,7 +190,7 @@ const BridgeComponent = () => {
             offchain: true,
             ercAddress,
             tokenId: 0,
-            value: (transferValue * 10 ** token.decimals).toString(),
+            value: (BigInt(transferValue) * 10n ** BigInt(token.decimals)).toString(),
             recipientAddress: await Web3.getAccount(),
             nsk: zkpKeys.nsk,
             ask: zkpKeys.ask,
@@ -221,8 +221,8 @@ const BridgeComponent = () => {
 
   const handleShow = () => {
     if (
-      (txType === 'deposit' && transferValue > l1Balance) ||
-      (txType === 'withdraw' && transferValue > l2Balance)
+      (txType === 'deposit' && (BigInt(transferValue) * 10n ** BigInt(token.decimals)) > l1Balance) ||
+      (txType === 'withdraw' && (BigInt(transferValue) * 10n ** BigInt(token.decimals)) > l2Balance)
     )
       toast.error("Input value can't be greater than balance!");
     else if (!transferValue) toast.warn('Input a value for transfer, please.');
@@ -248,8 +248,8 @@ const BridgeComponent = () => {
       // const { address } = (await getContractAddress('ERC20Mock')).data; // TODO REMOVE THIS WHEN OFFICIAL ADDRESSES
       const l2bal = await getWalletBalance(state.compressedPkd);
       if (Object.hasOwnProperty.call(l2bal, state.compressedPkd))
-        setL2Balance(l2bal[state.compressedPkd][token.address.toLowerCase()] ?? 0);
-      else setL2Balance(0);
+        setL2Balance(l2bal[state.compressedPkd][token.address.toLowerCase()] ?? 0n);
+      else setL2Balance(0n);
     }
   }
 
@@ -314,10 +314,18 @@ const BridgeComponent = () => {
                   <p>Balance: </p>
                   {token && txType === 'deposit' && (
                     // <p> {token.decimals} </p>
-                    <p>{`${(l1Balance / 10 ** token.decimals).toFixed(4)} ${token.symbol}`}</p>
+                    // <p>{`${(l1Balance / 10 ** token.decimals).toFixed(4)} ${token.symbol}`}</p>
+                    <p>{
+                      `${l1Balance.toString().slice(0,l1Balance.toString().length - token.decimals)}.
+                      ${(l1Balance.toString().slice(-token.decimals)).slice(0,4)} ${token.symbol}`
+                    }</p>
                   )}
                   {token && txType === 'withdraw' && (
-                    <p>{`${(l2Balance / 10 ** token.decimals).toFixed(4)} ${token.symbol}`}</p>
+                    // <p>{`${(l2Balance / 10 ** token.decimals).toFixed(4)} ${token.symbol}`}</p>
+                    <p>{
+                      `${l2Balance.toString().slice(0,l2Balance.toString().length - token.decimals)}.
+                      ${(l2Balance.toString().slice(-token.decimals)).slice(0,4)} ${token.symbol}`
+                    }</p>
                   )}
                   {!token && (
                     <p>
@@ -390,16 +398,30 @@ const BridgeComponent = () => {
               <div className="balance_details">
                 <p>Balance: </p>
                 {token && txType === 'deposit' && (
-                  <p>{`${(l2Balance / 10 ** token.decimals).toFixed(4)} ${token.symbol}`}</p>
+                  // <p>{`${(l2Balance / 10 ** token.decimals).toFixed(4)} ${token.symbol}`}</p>
+                  <p>{
+                    `${l2Balance.toString().slice(0,l2Balance.toString().length - token.decimals)}.
+                    ${(l2Balance.toString().slice(-token.decimals)).slice(0,4)} ${token.symbol}`
+                  }</p>
                 )}
                 {token && txType === 'withdraw' && (
-                  <p>{`${(l1Balance / 10 ** token.decimals).toFixed(4)} ${token.symbol}`}</p>
+                  // <p>{`${(l1Balance / 10 ** token.decimals).toFixed(4)} ${token.symbol}`}</p>
+                  <p>{
+                    `${l1Balance.toString().slice(0,l1Balance.toString().length - token.decimals)}.
+                    ${(l1Balance.toString().slice(-token.decimals)).slice(0,4)} ${token.symbol}`
+                  }</p>
                 )}
                 {!token && (
+                  // <p>
+                  //   {txType === 'withdraw'
+                  //     ? `${(l2Balance / 10 ** token.decimals).toFixed(4)}`
+                  //     : `${(l1Balance / 10 ** token.decimals).toFixed(4)}`}
+                  // </p>
                   <p>
                     {txType === 'withdraw'
-                      ? `${(l2Balance / 10 ** token.decimals).toFixed(4)}`
-                      : `${(l1Balance / 10 ** token.decimals).toFixed(4)}`}
+                      ? `${l2Balance.toString().slice(0,l2Balance.toString().length - token.decimals)}.${(l2Balance.toString().slice(-token.decimals)).slice(0,4)} ${token.symbol}`
+                      : `${l1Balance.toString().slice(0,l1Balance.toString().length - token.decimals)}.${(l1Balance.toString().slice(-token.decimals)).slice(0,4)} ${token.symbol}`
+                  }
                   </p>
                 )}
               </div>

--- a/wallet/src/components/Input/index.tsx
+++ b/wallet/src/components/Input/index.tsx
@@ -9,7 +9,7 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   prefix?: string;
 }
 
-const Input: React.FC<InputProps> = ({ mask, prefix, ...props }) => {
+const Input: React.FC<InputProps> = ({ mask, ...props }) => {
   const handleKeyUp = useCallback(
     (e: React.FormEvent<HTMLInputElement>) => {
       if (mask === 'cep') {

--- a/wallet/src/components/Input/masks.ts
+++ b/wallet/src/components/Input/masks.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export function cep(e: React.FormEvent<HTMLInputElement>) {
+export function cep(e: React.FormEvent<HTMLInputElement>): React.FormEvent<HTMLInputElement> {
   e.currentTarget.maxLength = 9;
   let { value } = e.currentTarget;
   value = value.replace(/\D/g, '');
@@ -9,7 +9,7 @@ export function cep(e: React.FormEvent<HTMLInputElement>) {
   return e;
 }
 
-export function currency(e: React.FormEvent<HTMLInputElement>) {
+export function currency(e: React.FormEvent<HTMLInputElement>): React.FormEvent<HTMLInputElement> {
   let { value } = e.currentTarget;
   value = value.replace(/\D/g, '');
   value = value.replace(/(\d)(\d{2})$/, '$1,$2');
@@ -19,7 +19,7 @@ export function currency(e: React.FormEvent<HTMLInputElement>) {
   return e;
 }
 
-export function cpf(e: React.FormEvent<HTMLInputElement>) {
+export function cpf(e: React.FormEvent<HTMLInputElement>): React.FormEvent<HTMLInputElement> {
   e.currentTarget.maxLength = 14;
   let { value } = e.currentTarget;
   if (!value.match(/^(\d{3}).(\d{3}).(\d{3})-(\d{2})$/)) {

--- a/wallet/src/components/Modals/sendModal.tsx
+++ b/wallet/src/components/Modals/sendModal.tsx
@@ -161,7 +161,7 @@ const SendModal = (props: SendModalProps): JSX.Element => {
         tokenId: 0,
         recipientData: {
           recipientCompressedPkds: [recipient],
-          values: [(Number(valueToSend) * 10 ** sendToken.decimals).toString()],
+          values: [(BigInt(valueToSend) * 10n ** BigInt(sendToken.decimals)).toString()],
         },
         nsk,
         ask,

--- a/wallet/src/contract-abis/Shield.json
+++ b/wallet/src/contract-abis/Shield.json
@@ -391,9 +391,9 @@
       {
         "components": [
           {
-            "internalType": "uint64",
+            "internalType": "uint112",
             "name": "value",
-            "type": "uint64"
+            "type": "uint112"
           },
           {
             "internalType": "uint64[2]",

--- a/wallet/src/hooks/Account/index.tsx
+++ b/wallet/src/hooks/Account/index.tsx
@@ -20,7 +20,8 @@ const AccountContext = createContext<AccountContextType>({} as AccountContextTyp
  * context use
  * @param children
  */
-const AccountProvider = ({ children }: any) => {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const AccountProvider = ({ children }: any): JSX.Element => {
   const [accountInstance, setAccountInstance] = useState<AccountType>(accountType);
 
   return (
@@ -38,7 +39,7 @@ const AccountProvider = ({ children }: any) => {
 /**
  * Hook to allow the context call
  */
-const useAccount = () => {
+const useAccount = (): AccountContextType => {
   const context = useContext(AccountContext);
 
   if (!context) {

--- a/wallet/src/nightfall-browser/services/commitment-storage.js
+++ b/wallet/src/nightfall-browser/services/commitment-storage.js
@@ -329,7 +329,7 @@ export async function getWalletBalance(pkd) {
     }))
     .reduce((acc, e) => {
       if (!acc[e.compressedPkd]) acc[e.compressedPkd] = {};
-      if (!acc[e.compressedPkd][e.ercAddress]) acc[e.compressedPkd][e.ercAddress] = 0;
+      if (!acc[e.compressedPkd][e.ercAddress]) acc[e.compressedPkd][e.ercAddress] = 0n;
       acc[e.compressedPkd][e.ercAddress] += e.balance;
       return acc;
     }, {});

--- a/wallet/src/nightfall-browser/services/commitment-storage.js
+++ b/wallet/src/nightfall-browser/services/commitment-storage.js
@@ -319,7 +319,7 @@ export async function getWalletBalance(pkd) {
       ercAddress: `0x${BigInt(e.preimage.ercAddress).toString(16).padStart(40, '0')}`, // Pad this to actual address length
       compressedPkd: e.preimage.compressedPkd,
       tokenId: !!BigInt(e.preimage.tokenId),
-      value: Number(BigInt(e.preimage.value)),
+      value: BigInt(e.preimage.value),
     }))
     .filter(e => e.tokenId || e.value > 0) // there should be no commitments with tokenId and value of ZERO
     .map(e => ({

--- a/wallet/tests/unit/float.ts
+++ b/wallet/tests/unit/float.ts
@@ -1,0 +1,27 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { expect } from 'chai';
+import BigFloat from '../../src/common-files/classes/bigFloat';
+
+describe('BigFloat tests', () => {
+  it('Check small floats', () => {
+    const float = 1.01;
+    const bigFloat: BigFloat = new BigFloat(float, 2);
+    expect(bigFloat.toString()).to.equal(float.toString());
+  });
+  it('Check big floats', () => {
+    // Float Test is 18446744073709552000.012345678987654321
+    // Significand > 2**64 and mantissa length === 18
+    const significand = '18446744073709552000';
+    const mantissa = '012345678987654321';
+    const bigintFloat = BigInt(`${significand}${mantissa}`);
+    const bigFloat: BigFloat = new BigFloat(bigintFloat, 18);
+    expect(bigFloat.toString()).to.equal(`${significand}.${mantissa}`);
+  });
+  it('Do operations on big floats', () => {
+    const significand = '18446744073709552000';
+    const mantissa = '012345678987654321';
+    const bigFloat = new BigFloat(`${significand}.${mantissa}`, 18);
+    const operand = 0.01;
+    expect(bigFloat.add(operand).toString()).to.equal(`${significand}.022345678987654321`);
+  });
+});

--- a/wallet/tests/unit/float.ts
+++ b/wallet/tests/unit/float.ts
@@ -1,27 +1,127 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
+/* eslint-disable import/no-extraneous-dependencies */
 import { expect } from 'chai';
+import * as fc from 'fast-check';
 import BigFloat from '../../src/common-files/classes/bigFloat';
 
+const numDecimals = 18; // Big Float handles any but this is useful for our testing.
+
+const arbitraryStringOfNumbers = (minLength: number, maxLength: number): fc.Arbitrary<string> => {
+  return fc.stringOf(fc.constantFrom('1', '2', '3', '4', '5', '6', '7', '8', '9', '0'), {
+    minLength,
+    maxLength,
+  });
+};
+
 describe('BigFloat tests', () => {
-  it('Check small floats', () => {
-    const float = 1.01;
-    const bigFloat: BigFloat = new BigFloat(float, 2);
-    expect(bigFloat.toString()).to.equal(float.toString());
+  describe('Basic unit tests', () => {
+    it('Should correctly construct small floats', () => {
+      const float = 1.01;
+      const bigFloat: BigFloat = new BigFloat(float, 2);
+      expect(bigFloat.toString()).to.equal(float.toString());
+    });
+    it('Should correctly construct big floats', () => {
+      // Float Test is 18446744073709552000.012345678987654321
+      // Significand > 2**64 and mantissa length === 18
+      const significand = '18446744073709552000';
+      const mantissa = '012345678987654321';
+      const bigintFloat = BigInt(`${significand}${mantissa}`);
+      const bigFloat: BigFloat = new BigFloat(bigintFloat, 18);
+      expect(bigFloat.toString()).to.equal(`${significand}.${mantissa}`);
+    });
+    it('Should add on big floats', () => {
+      const significand = '18446744073709552000';
+      const mantissa = '012345678987654321';
+      const bigFloat = new BigFloat(`${significand}.${mantissa}`, 18);
+      const operand = 0.01;
+      expect(bigFloat.add(operand).toString()).to.equal(`${significand}.022345678987654321`);
+    });
+    it('Should multiply on big floats', () => {
+      const significand = '18446744073709552000';
+      const mantissa = '012345678987654321';
+      const bigFloat = new BigFloat(`${significand}.${mantissa}`, 18);
+      const operand = 0.01;
+      // We pick 0.01 so we just need to scale the initial values;
+      const updatedSignificand = significand.slice(0, -2);
+      // We slice two from the mantissa as we have to maintain set precision.
+      const updatedMantissa = `00${mantissa.slice(0, -2)}`;
+      expect(bigFloat.mul(operand).toString()).to.equal(`${updatedSignificand}.${updatedMantissa}`);
+    });
   });
-  it('Check big floats', () => {
-    // Float Test is 18446744073709552000.012345678987654321
-    // Significand > 2**64 and mantissa length === 18
-    const significand = '18446744073709552000';
-    const mantissa = '012345678987654321';
-    const bigintFloat = BigInt(`${significand}${mantissa}`);
-    const bigFloat: BigFloat = new BigFloat(bigintFloat, 18);
-    expect(bigFloat.toString()).to.equal(`${significand}.${mantissa}`);
+
+  describe('Testing Idempotent Construction', () => {
+    it('Check construction from float', () => {
+      fc.assert(
+        fc.property(
+          fc.double({ next: true, min: 0, max: 1, noDefaultInfinity: true, noNaN: true }),
+          doubleFloat => {
+            const bigFloat = new BigFloat(doubleFloat, numDecimals);
+            expect(bigFloat.toFixed(numDecimals)).to.equal(doubleFloat.toFixed(numDecimals));
+          },
+        ),
+      );
+    });
+    it('Check construction from integer', () => {
+      fc.assert(
+        fc.property(fc.nat(), int => {
+          const bigFloat = new BigFloat(int, numDecimals);
+          expect(bigFloat.toFixed(numDecimals)).to.equal(int.toFixed(numDecimals));
+        }),
+      );
+    });
+    it('Check construction from string', () => {
+      fc.assert(
+        fc.property(
+          arbitraryStringOfNumbers(1, 30),
+          arbitraryStringOfNumbers(numDecimals, numDecimals),
+          (significand, mantissa) => {
+            const bigFloat = new BigFloat(`${significand}.${mantissa}`, numDecimals);
+            expect(bigFloat.toString()).to.equal(`${significand}.${mantissa}`);
+          },
+        ),
+      );
+    });
   });
-  it('Do operations on big floats', () => {
-    const significand = '18446744073709552000';
-    const mantissa = '012345678987654321';
-    const bigFloat = new BigFloat(`${significand}.${mantissa}`, 18);
-    const operand = 0.01;
-    expect(bigFloat.add(operand).toString()).to.equal(`${significand}.022345678987654321`);
+
+  describe('Test basic arithmetic operations', () => {
+    it('Should add correctly', () => {
+      fc.assert(
+        fc.property(
+          arbitraryStringOfNumbers(1, 5),
+          arbitraryStringOfNumbers(9, 9),
+          fc.double({ next: true, min: 0.1, max: 100000, noDefaultInfinity: true, noNaN: true }),
+          (significand, mantissa, operand) => {
+            const roundOperand = Number(operand.toFixed(9));
+            const bigFloat = new BigFloat(`${significand}.${mantissa}`, 9);
+            const bigOperand = new BigFloat(operand.toString(), 9);
+            const result = Number(`${significand}.${mantissa}`) + roundOperand;
+            // Checking float operations is a pain...
+            expect(Number(bigFloat.add(bigOperand).toFixed(9))).closeTo(
+              Number(result.toFixed(9)),
+              0.000000002,
+            );
+          },
+        ),
+      );
+    });
+    it('Should multiply correctly', () => {
+      fc.assert(
+        fc.property(
+          arbitraryStringOfNumbers(1, 5),
+          arbitraryStringOfNumbers(9, 9),
+          fc.double({ next: true, min: 0.1, max: 100000, noDefaultInfinity: true, noNaN: true }),
+          (significand, mantissa, operand) => {
+            const roundOperand = Number(operand.toFixed(9));
+            const bigFloat = new BigFloat(`${significand}.${mantissa}`, 9);
+            const bigOperand = new BigFloat(operand.toString(), 9);
+            const result = Number(`${significand}.${mantissa}`) * roundOperand;
+            // Checking float operations is a pain...
+            expect(Number(bigFloat.mul(bigOperand).toFixed(9))).closeTo(
+              Number(result.toFixed(9)),
+              0.0001,
+            );
+          },
+        ),
+      );
+    });
   });
 });

--- a/wallet/tsconfig.json
+++ b/wallet/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "lib": [
       "dom",
       "dom.iterable",

--- a/wallet/tsconfig.json
+++ b/wallet/tsconfig.json
@@ -24,8 +24,8 @@
   },
   "include": [
     "src",
-    "src/components",
-     "src/custom.d.ts"
+    "src/custom.d.ts",
+    "tests/",
   ]
   
 }


### PR DESCRIPTION
This PR adds functionality for the browser to be able to handle uint112 values. It does this primarily through updating the browser to use `bigInts` where possible and the use of a new `BigFloat` class. 

This class  acts like `bigInt` but for floating points. It is not arbitrary precision, but instead fixed precision where the significand (the part on the LHS of the decimal) is a `bigInt`. Floating points are required because of the necessary UI conversions to display values to the user.

This class currently only supports addition and multiplication - since that is all the browser needs for now.

Note: There are also smaller eslint fixes in this PR.

### Testing
- The `BigFloat` class can be tested using `npm t` **inside the wallet directory**
