### PR TITLE
Update timber paths in browser and client

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -23,6 +23,7 @@ module.exports = {
   COMMITMENTS_COLLECTION: 'commitments',
   PEERS_COLLECTION: 'peers',
   TIMBER_COLLECTION: 'timber',
+  SIBLING_COLLECTION: 'sibling_paths',
   CIRCUIT_COLLECTION: 'circuit_storage',
   CONTRACT_ARTIFACTS: '/app/build/contracts',
   PROPOSERS_CONTRACT_NAME: 'Proposers',

--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -84,6 +84,8 @@ async function blockProposedEventHandler(data) {
         s.leafIndex,
         s._id,
         siblingPath,
+        HASH_TYPE,
+        TIMBER_HEIGHT,
       );
       return updateSiblingPath(s._id, block.blockNumberL2, updatedPath, updatedTimber.root);
     }),

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -102,15 +102,6 @@ export async function markOnChain(
   return db.collection(COMMITMENTS_COLLECTION).updateMany(query, update);
 }
 
-// function to mark a commitments as on chain for a mongo db
-export async function setSiblingInfo(commitment, siblingPath, leafIndex, root) {
-  const connection = await mongo.connection(MONGO_URL);
-  const query = { _id: commitment, isOnChain: { $ne: -1 } };
-  const update = { $set: { siblingPath, leafIndex, root } };
-  const db = connection.db(COMMITMENTS_DB);
-  return db.collection(COMMITMENTS_COLLECTION).updateMany(query, update);
-}
-
 // function to mark a commitment as pending nullication for a mongo db
 async function markPending(commitment) {
   const connection = await mongo.connection(MONGO_URL);
@@ -160,17 +151,6 @@ export async function getNullifiedByTransactionHashL1(transactionHashNullifiedL1
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(COMMITMENTS_DB);
   return db.collection(COMMITMENTS_COLLECTION).find({ transactionHashNullifiedL1 }).toArray();
-}
-
-export async function getSiblingInfo(commitment) {
-  const connection = await mongo.connection(MONGO_URL);
-  const db = connection.db(COMMITMENTS_DB);
-  return db
-    .collection(COMMITMENTS_COLLECTION)
-    .findOne(
-      { _id: commitment.hash.hex(32) },
-      { projection: { siblingPath: 1, root: 1, order: 1, isOnChain: 1, leafIndex: 1 } },
-    );
 }
 
 /*

--- a/wallet/src/nightfall-browser/event-handlers/block-proposed.js
+++ b/wallet/src/nightfall-browser/event-handlers/block-proposed.js
@@ -130,7 +130,7 @@ async function blockProposedEventHandler(data, ivks, nsks) {
         s.commitment,
         siblingPath,
       );
-      return updateSiblingPath(s.commitment, block.blockNumberL2, updatedPath);
+      return updateSiblingPath(s.commitment, block.blockNumberL2, updatedPath, updatedTimber.root);
     }),
   );
 

--- a/wallet/src/nightfall-browser/event-handlers/block-proposed.js
+++ b/wallet/src/nightfall-browser/event-handlers/block-proposed.js
@@ -129,6 +129,8 @@ async function blockProposedEventHandler(data, ivks, nsks) {
         s.leafIndex,
         s.commitment,
         siblingPath,
+        HASH_TYPE,
+        TIMBER_HEIGHT,
       );
       return updateSiblingPath(s.commitment, block.blockNumberL2, updatedPath, updatedTimber.root);
     }),
@@ -140,7 +142,13 @@ async function blockProposedEventHandler(data, ivks, nsks) {
     blockCommitments.map(async (c, i) => {
       const count = await countCommitments([c]);
       if (count > 0) {
-        const siblingPath = Timber.statelessSiblingPath(latestTree, blockCommitments, i);
+        const siblingPath = Timber.statelessSiblingPath(
+          latestTree,
+          blockCommitments,
+          i,
+          HASH_TYPE,
+          TIMBER_HEIGHT,
+        );
         return saveSiblingPath(
           c,
           block.blockNumberL2,

--- a/wallet/src/nightfall-browser/services/commitment-storage.js
+++ b/wallet/src/nightfall-browser/services/commitment-storage.js
@@ -21,6 +21,7 @@ const {
   COMMITMENTS_COLLECTION,
   KEYS_COLLECTION,
   CIRCUIT_COLLECTION,
+  SIBLING_COLLECTION,
 } = global.config;
 
 const { generalise } = gen;
@@ -35,6 +36,7 @@ const connectDB = async () => {
       newDb.createObjectStore(TRANSACTIONS_COLLECTION);
       newDb.createObjectStore(KEYS_COLLECTION);
       newDb.createObjectStore(CIRCUIT_COLLECTION);
+      newDb.createObjectStore(SIBLING_COLLECTION);
     },
   });
 };
@@ -129,27 +131,6 @@ export async function markOnChain(
   );
 }
 
-// function to mark a commitments as on chain for a mongo db
-export async function setSiblingInfo(commitment, siblingPath, leafIndex, root) {
-  const db = await connectDB();
-  const res = await db.getAll(COMMITMENTS_COLLECTION);
-  const filtered = res.filter(r => r._id === commitment && r.isOnChain !== -1);
-  if (filtered.length === 1) {
-    const { siblingPath: a, leafIndex: b, root: c, ...rest } = filtered[0];
-    return db.put(
-      COMMITMENTS_COLLECTION,
-      {
-        siblingPath,
-        leafIndex,
-        root,
-        ...rest,
-      },
-      filtered[0]._id,
-    );
-  }
-  return null;
-}
-
 // function to mark a commitment as pending nullication for a mongo db
 async function markPending(commitment) {
   const db = await connectDB();
@@ -210,10 +191,6 @@ export async function getNullifiedByTransactionHashL1(transactionHashNullifiedL1
   const db = await connectDB();
   const res = await db.getAll(COMMITMENTS_COLLECTION);
   return res.filter(r => r.transactionHashNullifiedL1 === transactionHashNullifiedL1);
-}
-export async function getSiblingInfo(commitment) {
-  const db = await connectDB();
-  return db.get(COMMITMENTS_COLLECTION, commitment.hash.hex(32));
 }
 
 /*

--- a/wallet/src/nightfall-browser/services/database.js
+++ b/wallet/src/nightfall-browser/services/database.js
@@ -379,7 +379,7 @@ export async function updateSiblingPath(commitmentHash, blockNumberL2, siblingPa
   const updatedDiffs = [...existingPath.diffPaths, { root, blockNumberL2, ...siblingPath }]; // Pushing is mutable and returns array length
   return db.put(
     SIBLING_COLLECTION,
-    { ...existingPath, diffPaths: updatedDiffs.slice(-12) }, // The storage window is the last 12 paths.
+    { ...existingPath, diffPaths: updatedDiffs.slice(-4) }, // The storage window is the last 4 paths.
     commitmentHash,
   );
 }


### PR DESCRIPTION
This PR closes #540.

This adds a new collections `sibling_path` to the databases. This stores the:
- base sibling path ( An object containing sibling information from the block that the commitment is mined in)
- diffPaths ( An array of sibling path objects representing the updated sibling paths).

To ensure that the diffPaths array does not have unbounded growth, we restrict it to the last 4 blocks. If a rollback was to occur that is deeper than 4 blocks, we would have to revert to the base sibling path.

This can be tested by just running the standard tests.

### Notes
- The storage of diffPaths is currently not optimal, having a more compressed storage method will enable us to extend the maximum length of this array.
- siblingPaths for already spent commitments are still updated, this is because there is no clear indication of when a spent commitment is past the finalised window.
- This PR has not been tested with rollbacks, this will need to be revisited when rollbacks are enabled.
- There are numerous performance optimisations that can be tackled to make the update process quicker.