### PR TITLE
double spend bugfix

### DIFF
--- a/common-files/classes/transaction.mjs
+++ b/common-files/classes/transaction.mjs
@@ -25,7 +25,7 @@ function keccak(preimage) {
     { t: 'bytes32', v: preimage.ercAddress },
     { t: 'bytes32', v: preimage.recipientAddress },
     ...preimage.commitments.map(ch => ({ t: 'bytes32', v: ch })),
-    ...preimage.nullifiers.map(nh => ({ t: 'bytes32', v: nh })),
+    ...preimage.nullifiers.map(nh => ({ t: 'bytes31', v: nh })),
     ...preimage.compressedSecrets.map(es => ({ t: 'bytes32', v: es })),
     ...compressProof(preimage.proof).map(p => ({ t: 'uint', v: p })),
   );
@@ -81,6 +81,8 @@ class Transaction {
       compressedSecrets,
       proof: flatProof,
     }).all.hex(32);
+    // the nullifiers is 31 bytes so fix that:
+    preimage.nullifiers = preimage.nullifiers.map(n => generalise(n).hex(31));
     // compute the solidity hash, using suitable type conversions
     preimage.transactionHash = keccak(preimage);
     return preimage;

--- a/config/default.js
+++ b/config/default.js
@@ -75,13 +75,14 @@ module.exports = {
   TRANSACTIONS_PER_BLOCK: Number(process.env.TRANSACTIONS_PER_BLOCK) || 2,
   PROPOSE_BLOCK_TYPES: [
     '(uint48,address,bytes32,uint256,bytes32)',
-    '(uint112,uint64[2],uint8,uint8,bytes32,bytes32,bytes32,bytes32[2],bytes32[2],bytes32[8],uint[4])[]',
+    '(uint112,uint64[2],uint8,uint8,bytes32,bytes32,bytes32,bytes32[2],bytes31[2],bytes32[8],uint[4])[]',
   ], // used to encode/decode proposeBlock signature
   SUBMIT_TRANSACTION_TYPES:
-    '(uint112,uint64[2],uint8,uint8,bytes32,bytes32,bytes32,bytes32[2],bytes32[2],bytes32[8],uint[4])',
+    '(uint112,uint64[2],uint8,uint8,bytes32,bytes32,bytes32,bytes32[2],bytes31[2],bytes32[8],uint[4])',
   RETRIES: Number(process.env.AUTOSTART_RETRIES) || 50,
   NODE_HASHLENGTH: 32,
   ZERO: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  ZERO31: '0x00000000000000000000000000000000000000000000000000000000000000',
   HASH_TYPE: 'mimc',
   USE_STUBS: process.env.USE_STUBS === 'true',
   VK_IDS: { deposit: 0, single_transfer: 1, double_transfer: 2, withdraw: 3 }, // used as an enum to mirror the Shield contracts enum for vk types. The keys of this object must correspond to a 'folderpath' (the .zok file without the '.zok' bit)

--- a/nightfall-client/src/classes/nullifier.mjs
+++ b/nightfall-client/src/classes/nullifier.mjs
@@ -17,7 +17,7 @@ class Nullifier {
       commitment: commitment.hash,
     });
     // truncate the hash so that the nullifier fits inside a BN128 group order.
-    this.hash = new GN(sha256([this.preimage.nsk, this.preimage.commitment]).hex(32, 31));
+    this.hash = new GN(sha256([this.preimage.nsk, this.preimage.commitment]).hex(31));
   }
 }
 

--- a/nightfall-client/src/classes/nullifier.mjs
+++ b/nightfall-client/src/classes/nullifier.mjs
@@ -4,7 +4,7 @@ A nullifier class
 import gen from 'general-number';
 import sha256 from 'common-files/utils/crypto/sha256.mjs';
 
-const { generalise } = gen;
+const { generalise, GN } = gen;
 
 class Nullifier {
   preimage;
@@ -16,7 +16,8 @@ class Nullifier {
       nsk,
       commitment: commitment.hash,
     });
-    this.hash = sha256([this.preimage.nsk, this.preimage.commitment]);
+    // truncate the hash so that the nullifier fits inside a BN128 group order.
+    this.hash = new GN(sha256([this.preimage.nsk, this.preimage.commitment]).hex(32, 31));
   }
 }
 

--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -12,7 +12,7 @@ import { ivks, nsks } from '../services/keys.mjs';
 import { getLatestTree, saveTree, saveTransaction, saveBlock } from '../services/database.mjs';
 import { decryptCommitment } from '../services/commitment-sync.mjs';
 
-const { ZERO } = config;
+const { ZERO, ZERO31 } = config;
 
 /**
 This handler runs whenever a BlockProposed event is emitted by the blockchain
@@ -36,7 +36,7 @@ async function blockProposedEventHandler(data) {
   const dbUpdates = transactions.map(async transaction => {
     // filter out non zero commitments and nullifiers
     const nonZeroCommitments = transaction.commitments.flat().filter(n => n !== ZERO);
-    const nonZeroNullifiers = transaction.nullifiers.flat().filter(n => n !== ZERO);
+    const nonZeroNullifiers = transaction.nullifiers.flat().filter(n => n !== ZERO31);
     if (
       (transaction.transactionType === '1' || transaction.transactionType === '2') &&
       (await countCommitments(nonZeroCommitments)) === 0

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -22,7 +22,7 @@ export async function storeCommitment(commitment, nsk) {
   // we'll also compute and store the nullifier hash.  This will be useful for
   // spotting if the commitment spend is ever rolled back, which would mean the
   // commitment is once again available to spend
-  const nullifierHash = new Nullifier(commitment, nsk).hash.hex(32);
+  const nullifierHash = new Nullifier(commitment, nsk).hash.hex(31);
   const data = {
     _id: commitment.hash.hex(32),
     preimage: commitment.preimage.all.hex(32),

--- a/nightfall-client/src/services/transfer.mjs
+++ b/nightfall-client/src/services/transfer.mjs
@@ -155,7 +155,7 @@ async function transfer(transferParams) {
     ]),
     newCommitments.map(commitment => commitment.hash.integer),
     nullifiers.map(nullifier => nullifier.preimage.nsk.limbs(32, 8)),
-    nullifiers.map(nullifier => generalise(nullifier.hash.hex(32, 31)).integer),
+    nullifiers.map(nullifier => nullifier.hash.integer),
     localSiblingPaths.map(siblingPath => siblingPath[0].field(BN128_GROUP_ORDER, false)),
     localSiblingPaths.map(siblingPath =>
       siblingPath.slice(1).map(node => node.field(BN128_GROUP_ORDER, false)),

--- a/nightfall-client/src/services/withdraw.mjs
+++ b/nightfall-client/src/services/withdraw.mjs
@@ -74,7 +74,7 @@ async function withdraw(withdrawParams) {
     oldCommitment.hash.limbs(32, 8),
     ask.field(BN128_GROUP_ORDER),
     nullifier.preimage.nsk.limbs(32, 8),
-    generalise(nullifier.hash.hex(32, 31)).integer,
+    nullifier.hash.integer,
     recipientAddress.field(BN128_GROUP_ORDER),
     siblingPath[0].field(BN128_GROUP_ORDER),
     siblingPath.slice(1).map(node => node.field(BN128_GROUP_ORDER, false)), // siblingPAth[32] is a sha hash and will overflow a field but it's ok to take the mod here - hence the 'false' flag

--- a/nightfall-deployer/contracts/ChallengesUtil.sol
+++ b/nightfall-deployer/contracts/ChallengesUtil.sol
@@ -10,6 +10,9 @@ import './Structures.sol';
 library ChallengesUtil {
     bytes32 public constant ZERO =
         0x0000000000000000000000000000000000000000000000000000000000000000;
+    bytes32 public constant ZERO31 =
+        0x00000000000000000000000000000000000000000000000000000000000000;
+
 
     function libChallengeLeafCountCorrect(
         Structures.Block memory priorBlockL2,
@@ -80,8 +83,8 @@ library ChallengesUtil {
                 transaction.recipientAddress != ZERO ||
                 transaction.commitments[0] == ZERO ||
                 transaction.commitments[1] != ZERO ||
-                transaction.nullifiers[0] != ZERO ||
-                transaction.nullifiers[1] != ZERO ||
+                transaction.nullifiers[0] != ZERO31 ||
+                transaction.nullifiers[1] != ZERO31 ||
                 nZeroCompressedSecrets != 8 ||
                 nZeroProof == 4 || // We assume that 3 out of the 4 proof elements can be a valid ZERO. Deals with exception cases
                 transaction.historicRootBlockNumberL2[0] != 0 ||
@@ -110,8 +113,8 @@ library ChallengesUtil {
                 transaction.recipientAddress != ZERO ||
                 transaction.commitments[0] == ZERO ||
                 transaction.commitments[1] != ZERO ||
-                transaction.nullifiers[0] == ZERO ||
-                transaction.nullifiers[1] != ZERO ||
+                transaction.nullifiers[0] == ZERO31 ||
+                transaction.nullifiers[1] != ZERO31 ||
                 nZeroCompressedSecrets == 8 || // We assume that 7 out of the 8 compressed secrets elements can be a valid ZERO. Deals with exception cases
                 nZeroProof == 4 || // We assume that 3 out of the 4 proof elements can be a valid ZERO. Deals with exception cases
                 transaction.historicRootBlockNumberL2[1] != 0, // If this is a single, the second historicBlockNumber needs to be zero
@@ -139,8 +142,8 @@ library ChallengesUtil {
                 transaction.recipientAddress != ZERO ||
                 transaction.commitments[0] == ZERO ||
                 transaction.commitments[1] == ZERO ||
-                transaction.nullifiers[0] == ZERO ||
-                transaction.nullifiers[1] == ZERO ||
+                transaction.nullifiers[0] == ZERO31 ||
+                transaction.nullifiers[1] == ZERO31 ||
                 nZeroCompressedSecrets == 8 || // We assume that 7 out of the 8 compressed secrets elements can be a valid ZERO. Deals with exception cases
                 nZeroProof == 4, // We assume that 3 out of the 4 proof elements can be a valid ZERO. Deals with exception cases
             'This double transfer transaction type is valid'
@@ -166,8 +169,8 @@ library ChallengesUtil {
                 transaction.recipientAddress == ZERO ||
                 transaction.commitments[0] != ZERO ||
                 transaction.commitments[1] != ZERO ||
-                transaction.nullifiers[0] == ZERO ||
-                transaction.nullifiers[1] != ZERO ||
+                transaction.nullifiers[0] == ZERO31 ||
+                transaction.nullifiers[1] != ZERO31 ||
                 nZeroCompressedSecrets != 8 ||
                 nZeroProof == 4 || // We assume that 3 out of the 4 proof elements can be a valid ZERO. Deals with exception cases
                 transaction.historicRootBlockNumberL2[1] != 0, // A withdraw has a similar constraint as a single transfer

--- a/nightfall-deployer/contracts/Structures.sol
+++ b/nightfall-deployer/contracts/Structures.sol
@@ -41,7 +41,7 @@ contract Structures {
         bytes32 ercAddress;
         bytes32 recipientAddress;
         bytes32[2] commitments;
-        bytes32[2] nullifiers;
+        bytes31[2] nullifiers;
         bytes32[8] compressedSecrets;
         uint256[4] proof;
     }

--- a/nightfall-deployer/contracts/Utils.sol
+++ b/nightfall-deployer/contracts/Utils.sol
@@ -125,7 +125,7 @@ library Utils {
       uint256[] memory inputs = new uint256[](12);
       inputs[0] = uint256(ts.ercAddress);
       inputs[1] = uint256(ts.commitments[0]);
-      inputs[2] = uint256(ts.nullifiers[0]);
+      inputs[2] = uint256(uint248(ts.nullifiers[0]));
       inputs[3] = roots[0];
       for (uint i = 4; i < 12; i++) {
         inputs[i] = uint256(ts.compressedSecrets[i-4]);
@@ -138,7 +138,7 @@ library Utils {
       inputs[0] = uint256(ts.ercAddress);
       inputs[1] = uint256(ts.tokenId);
       inputs[2] = ts.value;
-      inputs[3] = uint256(ts.nullifiers[0]);
+      inputs[3] = uint256(uint248(ts.nullifiers[0]));
       inputs[4] = uint256(ts.recipientAddress);
       inputs[5] = roots[0];
       return inputs;
@@ -150,8 +150,8 @@ library Utils {
       inputs[1] = uint256(ts.ercAddress);
       inputs[2] = uint256(ts.commitments[0]);
       inputs[3] = uint256(ts.commitments[1]);
-      inputs[4] = uint256(ts.nullifiers[0]);
-      inputs[5] = uint256(ts.nullifiers[1]);
+      inputs[4] = uint256(uint248(ts.nullifiers[0]));
+      inputs[5] = uint256(uint248(ts.nullifiers[1]));
       inputs[6] = roots[0];
       inputs[7] = roots[1];
       for (uint i = 8; i < 16; i++) {

--- a/nightfall-optimist/src/event-handlers/block-proposed.mjs
+++ b/nightfall-optimist/src/event-handlers/block-proposed.mjs
@@ -15,7 +15,7 @@ import {
 } from '../services/database.mjs';
 import { getProposeBlockCalldata } from '../services/process-calldata.mjs';
 
-const { ZERO } = config;
+const { ZERO, ZERO31 } = config;
 
 let ws;
 
@@ -57,7 +57,7 @@ async function blockProposedEventHandler(data) {
     // asociated with a failed block, and we can't do that if we haven't
     // associated them with a blockHash.
     await stampNullifiers(
-      transactions.map(tx => tx.nullifiers.filter(nulls => nulls !== ZERO)).flat(Infinity),
+      transactions.map(tx => tx.nullifiers.filter(nulls => nulls !== ZERO31)).flat(Infinity),
       block.blockHash,
     );
     // mark transactions so that they are out of the mempool,

--- a/nightfall-optimist/src/event-handlers/rollback.mjs
+++ b/nightfall-optimist/src/event-handlers/rollback.mjs
@@ -22,7 +22,7 @@ import {
 import Block from '../classes/block.mjs';
 import checkTransaction from '../services/transaction-checker.mjs';
 
-const { ZERO } = config;
+const { ZERO31 } = config;
 
 async function rollbackEventHandler(data) {
   const { blockNumberL2 } = data.returnValues;
@@ -108,7 +108,7 @@ async function rollbackEventHandler(data) {
   // between optimist instances, this is also fine as mempools are locally-contexted anyways
   transactions.forEach(t => {
     const { transactionHash, nullifiers } = t;
-    const nonZeroNullifiers = nullifiers.filter(n => n !== ZERO);
+    const nonZeroNullifiers = nullifiers.filter(n => n !== ZERO31);
     // Is there a duplicate nullifier in our list of mempool: true and block transactions
     const duplicateSeenNullifier = nonZeroNullifiers.some(nz => nulliferSet.has(nz));
     // Is there a duplicate nullifier in our list of already spent nullifier
@@ -158,7 +158,7 @@ async function rollbackEventHandler(data) {
   const validTransactionNullifiers = validTransactions
     .map(v => v.nullifiers)
     .flat(Infinity)
-    .filter(n => n !== ZERO);
+    .filter(n => n !== ZERO31);
 
   const deletedNullifiers = unspentNullifierHashes.filter(
     un => !validTransactionNullifiers.includes(un) && !nullifierArray.includes(un),

--- a/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
+++ b/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
@@ -61,7 +61,7 @@ async function transactionSubmittedEventHandler(eventParams) {
     logger.info('Transaction checks passed');
     const storedNullifiers = (await retrieveNullifiers()).map(sNull => sNull.hash); // List of Nullifiers stored by blockProposer
     const transactionNullifiers = transaction.nullifiers.filter(
-      hash => hash !== '0x0000000000000000000000000000000000000000000000000000000000000000',
+      hash => hash !== '0x00000000000000000000000000000000000000000000000000000000000000',
     ); // Deposit transactions still have nullifier fields but they are 0
     const dupNullifier = transactionNullifiers.some(txNull => storedNullifiers.includes(txNull)); // Move to Set for performance later.
     if (dupNullifier) {

--- a/nightfall-optimist/src/services/transaction-checker.mjs
+++ b/nightfall-optimist/src/services/transaction-checker.mjs
@@ -15,6 +15,7 @@ import verify from './verify.mjs';
 
 const { generalise } = gen;
 const { PROVING_SCHEME, BACKEND, CURVE, ZERO, ZERO31, CHALLENGES_CONTRACT_NAME } = config;
+const MAX_NULLIFIER = 2n ** 249n - 1n; // constrain to 31 bytes
 
 // first, let's check the hash. That's nice and easy:
 // NB as we actually now comput the hash on receipt of the transaction this
@@ -48,7 +49,9 @@ async function checkTransactionType(transaction) {
         transaction.proof.every(p => p === ZERO) ||
         // This extra check is unique to deposits
         Number(transaction.historicRootBlockNumberL2[0]) !== 0 ||
-        Number(transaction.historicRootBlockNumberL2[1]) !== 0
+        Number(transaction.historicRootBlockNumberL2[1]) !== 0 ||
+        BigInt(transaction.nullifiers[0]) > MAX_NULLIFIER ||
+        BigInt(transaction.nullifiers[1]) > MAX_NULLIFIER
       )
         throw new TransactionError(
           'The data provided was inconsistent with a transaction type of DEPOSIT',
@@ -69,7 +72,9 @@ async function checkTransactionType(transaction) {
         transaction.nullifiers.length !== 2 ||
         transaction.compressedSecrets.every(cs => cs === ZERO) ||
         transaction.compressedSecrets.length !== 8 ||
-        transaction.proof.every(p => p === ZERO)
+        transaction.proof.every(p => p === ZERO) ||
+        BigInt(transaction.nullifiers[0]) > MAX_NULLIFIER ||
+        BigInt(transaction.nullifiers[1]) > MAX_NULLIFIER
       )
         throw new TransactionError(
           'The data provided was inconsistent with a transaction type of SINGLE_TRANSFER',
@@ -89,7 +94,9 @@ async function checkTransactionType(transaction) {
         transaction.nullifiers[0] === transaction.nullifiers[1] ||
         transaction.compressedSecrets.every(cs => cs === ZERO) ||
         transaction.compressedSecrets.length !== 8 ||
-        transaction.proof.every(p => p === ZERO)
+        transaction.proof.every(p => p === ZERO) ||
+        BigInt(transaction.nullifiers[0]) > MAX_NULLIFIER ||
+        BigInt(transaction.nullifiers[1]) > MAX_NULLIFIER
       )
         throw new TransactionError(
           'The data provided was inconsistent with a transaction type of DOUBLE_TRANSFER',
@@ -108,7 +115,9 @@ async function checkTransactionType(transaction) {
         transaction.nullifiers[1] !== ZERO31 ||
         transaction.nullifiers.length !== 2 ||
         transaction.compressedSecrets.some(cs => cs !== ZERO) ||
-        transaction.proof.every(p => p === ZERO)
+        transaction.proof.every(p => p === ZERO) ||
+        BigInt(transaction.nullifiers[0]) > MAX_NULLIFIER ||
+        BigInt(transaction.nullifiers[1]) > MAX_NULLIFIER
       )
         throw new TransactionError(
           'The data provided was inconsistent with a transaction type of WITHDRAW',

--- a/nightfall-optimist/src/services/transaction-checker.mjs
+++ b/nightfall-optimist/src/services/transaction-checker.mjs
@@ -171,7 +171,7 @@ async function verifyProof(transaction) {
         [
           // transaction.ercAddress,
           transaction.commitments[0], // not truncating here as we already ensured hash < group order
-          generalise(transaction.nullifiers[0]).hex(32, 31),
+          transaction.nullifiers[0],
           historicRootFirst.root,
           ...transaction.compressedSecrets.map(compressedSecret =>
             generalise(compressedSecret).hex(32, 31),
@@ -185,7 +185,7 @@ async function verifyProof(transaction) {
           // transaction.ercAddress, // this is correct; ercAddress appears twice
           // transaction.ercAddress, // in a double-transfer public input hash
           transaction.commitments, // not truncating here as we already ensured hash < group order
-          transaction.nullifiers.map(nullifier => generalise(nullifier).hex(32, 31)),
+          transaction.nullifiers,
           historicRootFirst.root,
           historicRootSecond.root,
           ...transaction.compressedSecrets.map(compressedSecret =>
@@ -200,7 +200,7 @@ async function verifyProof(transaction) {
           transaction.ercAddress,
           transaction.tokenId,
           transaction.value,
-          generalise(transaction.nullifiers[0]).hex(32, 31),
+          transaction.nullifiers[0],
           transaction.recipientAddress,
           historicRootFirst.root,
         ].flat(Infinity),

--- a/nightfall-optimist/src/services/transaction-checker.mjs
+++ b/nightfall-optimist/src/services/transaction-checker.mjs
@@ -14,7 +14,7 @@ import { getBlockByBlockNumberL2 } from './database.mjs';
 import verify from './verify.mjs';
 
 const { generalise } = gen;
-const { PROVING_SCHEME, BACKEND, CURVE, ZERO, CHALLENGES_CONTRACT_NAME } = config;
+const { PROVING_SCHEME, BACKEND, CURVE, ZERO, ZERO31, CHALLENGES_CONTRACT_NAME } = config;
 
 // first, let's check the hash. That's nice and easy:
 // NB as we actually now comput the hash on receipt of the transaction this
@@ -42,7 +42,7 @@ async function checkTransactionType(transaction) {
         transaction.commitments[0] === ZERO ||
         transaction.commitments[1] !== ZERO ||
         transaction.commitments.length !== 2 ||
-        transaction.nullifiers.some(n => n !== ZERO) ||
+        transaction.nullifiers.some(n => n !== ZERO31) ||
         transaction.compressedSecrets.some(cs => cs !== ZERO) ||
         transaction.compressedSecrets.length !== 8 ||
         transaction.proof.every(p => p === ZERO) ||
@@ -64,8 +64,8 @@ async function checkTransactionType(transaction) {
         transaction.commitments[0] === ZERO ||
         transaction.commitments[1] !== ZERO ||
         transaction.commitments.length !== 2 ||
-        transaction.nullifiers[0] === ZERO ||
-        transaction.nullifiers[1] !== ZERO ||
+        transaction.nullifiers[0] === ZERO31 ||
+        transaction.nullifiers[1] !== ZERO31 ||
         transaction.nullifiers.length !== 2 ||
         transaction.compressedSecrets.every(cs => cs === ZERO) ||
         transaction.compressedSecrets.length !== 8 ||
@@ -84,7 +84,7 @@ async function checkTransactionType(transaction) {
         transaction.recipientAddress !== ZERO ||
         transaction.commitments.some(c => c === ZERO) ||
         transaction.commitments.length !== 2 ||
-        transaction.nullifiers.some(n => n === ZERO) ||
+        transaction.nullifiers.some(n => n === ZERO31) ||
         transaction.nullifiers.length !== 2 ||
         transaction.nullifiers[0] === transaction.nullifiers[1] ||
         transaction.compressedSecrets.every(cs => cs === ZERO) ||
@@ -104,8 +104,8 @@ async function checkTransactionType(transaction) {
         transaction.ercAddress === ZERO ||
         transaction.recipientAddress === ZERO ||
         transaction.commitments.some(c => c !== ZERO) ||
-        transaction.nullifiers[0] === ZERO ||
-        transaction.nullifiers[1] !== ZERO ||
+        transaction.nullifiers[0] === ZERO31 ||
+        transaction.nullifiers[1] !== ZERO31 ||
         transaction.nullifiers.length !== 2 ||
         transaction.compressedSecrets.some(cs => cs !== ZERO) ||
         transaction.proof.every(p => p === ZERO)

--- a/test/neg-http.mjs
+++ b/test/neg-http.mjs
@@ -10,7 +10,7 @@ import { createBadBlock, topicEventMapping, Web3Client } from './utils.mjs';
 
 const { expect } = chai;
 const txQueue = new Queue({ autostart: true, concurrency: 1 });
-const ZERO = '0x0000000000000000000000000000000000000000000000000000000000000000';
+const ZERO31 = '0x00000000000000000000000000000000000000000000000000000000000000';
 chai.use(chaiHttp);
 chai.use(chaiAsPromised);
 
@@ -185,7 +185,7 @@ describe('Testing the challenge http API', () => {
               );
             } else if (counter === 1) {
               [duplicateNullifier] = transactions
-                .map(t => t.nullifiers.filter(n => n !== ZERO))
+                .map(t => t.nullifiers.filter(n => n !== ZERO31))
                 .flat(Infinity);
               logger.debug(
                 `Created good block to extract duplicate nullifier ${duplicateNullifier} from with blockHash ${block.blockHash}`,

--- a/wallet/src/common-files/classes/transaction.js
+++ b/wallet/src/common-files/classes/transaction.js
@@ -25,7 +25,7 @@ function keccak(preimage) {
     { t: 'bytes32', v: preimage.ercAddress },
     { t: 'bytes32', v: preimage.recipientAddress },
     ...preimage.commitments.map(ch => ({ t: 'bytes32', v: ch })),
-    ...preimage.nullifiers.map(nh => ({ t: 'bytes32', v: nh })),
+    ...preimage.nullifiers.map(nh => ({ t: 'bytes31', v: nh })),
     ...preimage.compressedSecrets.map(es => ({ t: 'bytes32', v: es })),
     ...compressProof(preimage.proof).map(p => ({ t: 'uint', v: p })),
   );
@@ -81,6 +81,8 @@ class Transaction {
       compressedSecrets,
       proof: flatProof,
     }).all.hex(32);
+    // the nullifiers is 31 bytes so fix that:
+    preimage.nullifiers = preimage.nullifiers.map(n => generalise(n).hex(31));
     // compute the solidity hash, using suitable type conversions
     preimage.transactionHash = keccak(preimage);
     return preimage;

--- a/wallet/src/contract-abis/Shield.json
+++ b/wallet/src/contract-abis/Shield.json
@@ -431,9 +431,9 @@
             "type": "bytes32[2]"
           },
           {
-            "internalType": "bytes32[2]",
+            "internalType": "bytes31[2]",
             "name": "nullifiers",
-            "type": "bytes32[2]"
+            "type": "bytes31[2]"
           },
           {
             "internalType": "bytes32[8]",
@@ -539,9 +539,9 @@
             "type": "bytes32[2]"
           },
           {
-            "internalType": "bytes32[2]",
+            "internalType": "bytes31[2]",
             "name": "nullifiers",
-            "type": "bytes32[2]"
+            "type": "bytes31[2]"
           },
           {
             "internalType": "bytes32[8]",
@@ -719,9 +719,9 @@
             "type": "bytes32[2]"
           },
           {
-            "internalType": "bytes32[2]",
+            "internalType": "bytes31[2]",
             "name": "nullifiers",
-            "type": "bytes32[2]"
+            "type": "bytes31[2]"
           },
           {
             "internalType": "bytes32[8]",
@@ -838,9 +838,9 @@
             "type": "bytes32[2]"
           },
           {
-            "internalType": "bytes32[2]",
+            "internalType": "bytes31[2]",
             "name": "nullifiers",
-            "type": "bytes32[2]"
+            "type": "bytes31[2]"
           },
           {
             "internalType": "bytes32[8]",
@@ -913,9 +913,9 @@
             "type": "bytes32[2]"
           },
           {
-            "internalType": "bytes32[2]",
+            "internalType": "bytes31[2]",
             "name": "nullifiers",
-            "type": "bytes32[2]"
+            "type": "bytes31[2]"
           },
           {
             "internalType": "bytes32[8]",
@@ -1020,9 +1020,9 @@
             "type": "bytes32[2]"
           },
           {
-            "internalType": "bytes32[2]",
+            "internalType": "bytes31[2]",
             "name": "nullifiers",
-            "type": "bytes32[2]"
+            "type": "bytes31[2]"
           },
           {
             "internalType": "bytes32[8]",

--- a/wallet/src/nightfall-browser/classes/nullifier.js
+++ b/wallet/src/nightfall-browser/classes/nullifier.js
@@ -6,7 +6,7 @@ A nullifier class
 import gen from 'general-number';
 import sha256 from '../../common-files/utils/crypto/sha256';
 
-const { generalise } = gen;
+const { generalise, GN } = gen;
 
 class Nullifier {
   preimage;
@@ -18,7 +18,7 @@ class Nullifier {
       nsk,
       commitment: commitment.hash,
     });
-    this.hash = sha256([this.preimage.nsk, this.preimage.commitment]);
+    this.hash = new GN(sha256([this.preimage.nsk, this.preimage.commitment]).hex(31));
   }
 }
 

--- a/wallet/src/nightfall-browser/event-handlers/block-proposed.js
+++ b/wallet/src/nightfall-browser/event-handlers/block-proposed.js
@@ -15,7 +15,7 @@ import Secrets from '../classes/secrets';
 // import { ivks, nsks } from '../services/keys';
 import { getTreeByBlockNumberL2, saveTree, saveTransaction, saveBlock } from '../services/database';
 
-const { ZERO } = global.config;
+const { ZERO, ZERO31 } = global.config;
 
 /**
 This handler runs whenever a BlockProposed event is emitted by the blockchain
@@ -39,7 +39,7 @@ async function blockProposedEventHandler(data, ivks, nsks) {
   const dbUpdates = transactions.map(async transaction => {
     // filter out non zero commitments and nullifiers
     const nonZeroCommitments = transaction.commitments.flat().filter(n => n !== ZERO);
-    const nonZeroNullifiers = transaction.nullifiers.flat().filter(n => n !== ZERO);
+    const nonZeroNullifiers = transaction.nullifiers.flat().filter(n => n !== ZERO31);
     const storeCommitments = [];
     const tempTransactionStore = [];
     if (

--- a/wallet/src/nightfall-browser/services/commitment-storage.js
+++ b/wallet/src/nightfall-browser/services/commitment-storage.js
@@ -40,7 +40,7 @@ const connectDB = async () => {
 
 // function to format a commitment for a mongo db and store it
 export async function storeCommitment(commitment, nsk) {
-  const nullifierHash = new Nullifier(commitment, nsk).hash.hex(32);
+  const nullifierHash = new Nullifier(commitment, nsk).hash.hex(31);
   const data = {
     _id: commitment.hash.hex(32),
     preimage: commitment.preimage.all.hex(32),


### PR DESCRIPTION
fixes https://github.com/EYBlockchain/nightfall_3_private/issues/38

It is possible to double spend by using a nullifier which is congruent but not equal to one that has been used before; the proof will still verify because it works over the BN128 group order.  Simply constraining the value to be less than the group order in `Verifier.sol` will not work because this is only used in the event of a challenge.

There are really three solutions.  The more complex approach is to challenge any values which are greater than the group order.  This has the advantage that it is easy to extend to other variables but is more time-consuming to implement. Alternatively, one can simply drop any transactions which have values greater than the group order, which will work only while we have total control of block creation.

The approach taken here however was to note that when we generate a proof, we actually truncate the nullifier hash to 31 bytes anyway. We can use this to our advantage and simply make the nullifier hash 31 bytes everywhere, including in the `Transaction` struct.  This prevents anyone proposing a block containing a transaction with a nullifier >31 bytes long.  This obviates the need for a challenge mechanism. To assist the proposer, we also check that a Transaction has a nullifier not exceeding 31 bytes, so that any such will be dropped.