### PR TITLE
blocks can be made at any point in time

### DIFF
--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -182,12 +182,23 @@ class Nf3 {
 
   /**
     Gets the number of unprocessed transactions on the optimist
+    @method
     @async
     */
 
   async unprocessedTransactionCount() {
     const { result: mempool } = (await axios.get(`${this.optimistBaseUrl}/proposer/mempool`)).data;
     return mempool.filter(e => e.mempool).length;
+  }
+
+  /**
+  Forces optimist to make a block with whatever transactions it has to hand i.e. it won't wait
+  until it has TRANSACTIONS_PER_BLOCK of them
+  @method
+  @async
+  */
+  async makeBlockNow() {
+    return axios.get(`${this.optimistBaseUrl}/block/make-now`);
   }
 
   /**

--- a/nightfall-optimist/src/routes/block.mjs
+++ b/nightfall-optimist/src/routes/block.mjs
@@ -11,6 +11,7 @@ import {
   getBlockByRoot,
   getTransactionsByTransactionHashes,
 } from '../services/database.mjs';
+import { setMakeNow } from '../services/block-assembler.mjs';
 
 const router = express.Router();
 
@@ -21,6 +22,16 @@ router.post('/check', async (req, res, next) => {
     const result = await checkBlock(block, transactions);
     logger.debug(`Result of block check was ${JSON.stringify(result, null, 2)}`);
     res.json(result);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/make-now', async (req, res, next) => {
+  logger.debug('make-now endpoint received GET');
+  try {
+    setMakeNow();
+    res.send('Making short block');
   } catch (err) {
     next(err);
   }

--- a/test/e2e/tokens/erc1155.test.mjs
+++ b/test/e2e/tokens/erc1155.test.mjs
@@ -38,7 +38,7 @@ let stateAddress;
 let eventLogs = [];
 let availableTokenIds;
 
-/* 
+/*
   This function tries to zero the number of unprocessed transactions in the optimist node
   that nf3 is connected to. We call it extensively on the tests, as we want to query stuff from the
   L2 layer, which is dependent on a block being made. We also need 0 unprocessed transactions by the end
@@ -163,6 +163,25 @@ describe('ERC1155 tests', () => {
 
       expect(balanceAfter[0] - balanceBefore[0]).to.be.equal(transferValue);
       expect(balanceAfter[1] - balanceBefore[1]).to.be.equal(transferValue);
+    });
+
+    it('should deposit some ERC1155 crypto into a ZKP commitment and make a block with a single transaction', async function () {
+      // We create enough transactions to fill blocks full of deposits.
+      const res0 = await nf3Proposer1.makeBlockNow();
+      expect(res0.data).to.be.equal('Making short block');
+      const res = await nf3Users[0].deposit(
+        erc1155Address,
+        tokenTypeERC1155,
+        transferValue,
+        availableTokenIds[2],
+        fee,
+      );
+      expectTransaction(res);
+
+      // Wait until we see the right number of blocks appear
+      eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+
+      await emptyL2(nf3Users[0]);
     });
   });
 


### PR DESCRIPTION
This PR creates a new `optimist` endpoint `/block/make-now` (and wrappers it in the Nf3 class method `makeBlockNow`).  When called, `optimist` will make a 'short' block using whatever transactions it has in its database, even if that is less than `TRANSACTIONS_PER_BLOCK`. The short block is still made by queuing `conditionalMakeBlock` in the usual way, so the queue is never bypassed. The new code will not make a block if there are no transactions: there must be at least one. If there are already >=`TRANSACTIONS_PER_BLOCK` transactions, then calling this endpoint has no effect.

To test, an additional test stanza has been added to the ERC1155 tests, whereby `makeBlockNow` is called and a single deposit transaction is made.  The test then waits for a block to be created.  Normally it would wait forever (well, until it times out) but because the end point has been called, a block with a single transaction will be made.  you can double check this by looking at the logs and you will find a block with a `transactionHashes` of length 1, rather than 2.