### PR TITLE
add amount restrictions for mainnet and goerli ERC contracts

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -290,6 +290,28 @@ module.exports = {
           amount: '1000000000000',
         },
       ],
+      development: [
+        {
+          name: 'MockERC20',
+          address: '0xB5Acbe9a0F1F8B98F3fC04471F7fE5d2c222cB44',
+          amount: 200,
+        },
+        {
+          name: 'Test-Eth',
+          address: '0x3f152B63Ec5CA5831061B2DccFb29a874C317502',
+          amount: '10000000000000000000000',
+        },
+        {
+          name: 'MATIC',
+          address: '0x499d11E0b6eAC7c0593d8Fb292DCBbF815Fb29Ae',
+          amount: '10000000000000000000000',
+        },
+        {
+          name: 'USDC',
+          address: '0x07865c6e87b9f70255377e024ace6630c1eaa37f',
+          amount: '1000000000000',
+        },
+      ],
       mainnet: [
         {
           name: 'WETH',

--- a/config/default.js
+++ b/config/default.js
@@ -294,34 +294,44 @@ module.exports = {
         {
           name: 'WETH',
           address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
-          amount: '1000000000000000000',
+          amount: process.env.WETH_MAINNET_RESTRICT || '1000000000000000000',
         },
         {
           name: 'MATIC',
           address: '0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0',
-          amount: '1000000000000000000000',
+          amount: process.env.MATIC_MAINNET_RESTRICT || '1000000000000000000000',
         },
         {
           name: 'USDC',
           address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-          amount: '1000000000',
+          amount: process.env.USDC_MAINNET_RESTRICT || '1000000000',
+        },
+        {
+          name: 'USDT',
+          address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+          amount: process.env.USDT_MAINNET_RESTRICT || '1000000000',
+        },
+        {
+          name: 'DAI',
+          address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+          amount: process.env.DAI_MAINNET_RESTRICT || '1000000000000000000000',
         },
       ],
       goerli: [
         {
           name: 'WETH',
-          address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
-          amount: '1000000000000000000',
+          address: '0x3f152B63Ec5CA5831061B2DccFb29a874C317502',
+          amount: process.env.WETH_GOERLI_RESTRICT || '1000000000000000000',
         },
         {
           name: 'MATIC',
           address: '0x499d11E0b6eAC7c0593d8Fb292DCBbF815Fb29Ae',
-          amount: '1000000000000000000000',
+          amount: process.env.MATIC_GOERLI_RESTRICT || '1000000000000000000000',
         },
         {
           name: 'USDC',
           address: '0x07865c6E87B9F70255377e024ace6630C1Eaa37F',
-          amount: '1000000000',
+          amount: process.env.USDC_GOERLI_RESTRICT || '1000000000',
         },
       ],
     },

--- a/config/default.js
+++ b/config/default.js
@@ -267,28 +267,64 @@ module.exports = {
       bootChallenger:
         process.env.BOOT_CHALLENGER_ADDRESS || '0xfCb059A4dB5B961d3e48706fAC91a55Bad0035C9',
     },
-    tokens: [
-      {
-        name: 'MockERC20',
-        address: '0xB5Acbe9a0F1F8B98F3fC04471F7fE5d2c222cB44',
-        amount: 200,
-      },
-      {
-        name: 'Test-Eth',
-        address: '0x3f152B63Ec5CA5831061B2DccFb29a874C317502',
-        amount: '10000000000000000000000',
-      },
-      {
-        name: 'MATIC',
-        address: '0x499d11E0b6eAC7c0593d8Fb292DCBbF815Fb29Ae',
-        amount: '10000000000000000000000',
-      },
-      {
-        name: 'USDC',
-        address: '0x07865c6e87b9f70255377e024ace6630c1eaa37f',
-        amount: '1000000000000',
-      },
-    ],
+    tokens: {
+      blockchain1: [
+        {
+          name: 'MockERC20',
+          address: '0xB5Acbe9a0F1F8B98F3fC04471F7fE5d2c222cB44',
+          amount: 200,
+        },
+        {
+          name: 'Test-Eth',
+          address: '0x3f152B63Ec5CA5831061B2DccFb29a874C317502',
+          amount: '10000000000000000000000',
+        },
+        {
+          name: 'MATIC',
+          address: '0x499d11E0b6eAC7c0593d8Fb292DCBbF815Fb29Ae',
+          amount: '10000000000000000000000',
+        },
+        {
+          name: 'USDC',
+          address: '0x07865c6e87b9f70255377e024ace6630c1eaa37f',
+          amount: '1000000000000',
+        },
+      ],
+      mainnet: [
+        {
+          name: 'WETH',
+          address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+          amount: '1000000000000000000',
+        },
+        {
+          name: 'MATIC',
+          address: '0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0',
+          amount: '1000000000000000000000',
+        },
+        {
+          name: 'USDC',
+          address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          amount: '1000000000',
+        },
+      ],
+      goerli: [
+        {
+          name: 'WETH',
+          address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+          amount: '1000000000000000000',
+        },
+        {
+          name: 'MATIC',
+          address: '0x499d11E0b6eAC7c0593d8Fb292DCBbF815Fb29Ae',
+          amount: '1000000000000000000000',
+        },
+        {
+          name: 'USDC',
+          address: '0x07865c6E87B9F70255377e024ace6630C1Eaa37F',
+          amount: '1000000000',
+        },
+      ],
+    },
   },
 
   // for Browser use

--- a/nightfall-deployer/migrations/2_deploy_upgradeable.js
+++ b/nightfall-deployer/migrations/2_deploy_upgradeable.js
@@ -46,6 +46,7 @@ module.exports = async function (deployer) {
   await challengers.setBootChallenger(bootChallenger);
   const restrictions = await Shield.deployed();
   // restrict transfer amounts
+  console.log('**TEST**', process.env.ETH_NETWORK, RESTRICTIONS.tokens, RESTRICTIONS);
   for (let token of RESTRICTIONS.tokens[process.env.ETH_NETWORK]) {
     console.log(`Max deposit restriction for ${token.name}: ${token.amount}`);
     await restrictions.setRestriction(token.address, token.amount);

--- a/nightfall-deployer/migrations/2_deploy_upgradeable.js
+++ b/nightfall-deployer/migrations/2_deploy_upgradeable.js
@@ -14,7 +14,8 @@ const State = artifacts.require('State.sol');
 
 const config = require('config');
 
-const { addresses } = config.RESTRICTIONS;
+const { RESTRICTIONS } = config;
+const { addresses } = RESTRICTIONS;
 
 module.exports = async function (deployer) {
   await deployer.deploy(Verifier);
@@ -43,4 +44,10 @@ module.exports = async function (deployer) {
   const { bootProposer, bootChallenger } = addresses;
   await proposers.setBootProposer(bootProposer);
   await challengers.setBootChallenger(bootChallenger);
+  const restrictions = await Shield.deployed();
+  // restrict transfer amounts
+  for (let token of RESTRICTIONS.tokens[process.env.ETH_NETWORK]) {
+    console.log(`Max deposit restriction for ${token.name}: ${token.amount}`);
+    await restrictions.setRestriction(token.address, token.amount);
+  }
 };

--- a/nightfall-deployer/migrations/3_test_tokens_migration.js
+++ b/nightfall-deployer/migrations/3_test_tokens_migration.js
@@ -21,13 +21,9 @@ const nERC721 = 35;
 module.exports = function (deployer, _, accounts) {
   deployer.then(async () => {
     const restrictions = await Shield.deployed();
-    
-    for (let token of RESTRICTIONS.tokens) {
-      console.log(`Max deposit restriction for ${token.name}: ${token.amount}`);
-      await restrictions.setRestriction(token.address, token.amount);
-    }
 
     if (DEPLOY_MOCK_TOKENS === 'false') return;
+
     await deployer.deploy(ERC20Mock, 1001010000000000); // initialSupply
 
     const ERC20deployed = await ERC20Mock.deployed();

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -27,7 +27,9 @@ const {
 } = config.TEST_OPTIONS;
 
 const {
-  RESTRICTIONS: { tokens: defaultRestrictions },
+  RESTRICTIONS: {
+    tokens: { blockchain1: defaultRestrictions },
+  },
 } = config;
 
 const nf3Users = [new Nf3(signingKeys.user1, environment), new Nf3(signingKeys.user2, environment)];


### PR DESCRIPTION
This PR extends the test code that put restrictions on the amount that can be deposited or withdrawn.
<img width="377" alt="image" src="https://user-images.githubusercontent.com/7968974/165894082-2d646ef1-f2fb-4573-ab9e-967b5ae35429.png">
It selects the contract addresses to put limits on via the environment variable `ETH_NETWORK` which is the same one used to select the truffle configuration for deployment, so it's transparent to the deployer.  Value restrictions are created in the contract migration.

Test in the normal way, although obviously it's not possible to directly test mainnet and goerli values.  However the symmetry between those and the ganache (`ETH_NETWORK=blockchain1`) case.