### PR TITLE
feat: removing MPC flag, now the setup only runs for stubs 🏁

### DIFF
--- a/docker-compose.stubs.yml
+++ b/docker-compose.stubs.yml
@@ -1,14 +1,18 @@
 version: '3.5'
 # Use this script for making nightfall_3 use stubs.
 services:
-    client1:
-      environment:
-        USE_STUBS: 'true' # make sure this flag is the same as in deployer service
+  client1:
+    environment:
+      USE_STUBS: 'true' # make sure this flag is the same as in deployer service
 
-    client2:
-      environment:
-        USE_STUBS: 'true' # make sure this flag is the same as in deployer service
+  client2:
+    environment:
+      USE_STUBS: 'true' # make sure this flag is the same as in deployer service
 
-    deployer:
-      environment:
-        USE_STUBS: 'true' # make sure this flag is the same as in deployer service
+  deployer:
+    environment:
+      USE_STUBS: 'true' # make sure this flag is the same as in deployer service
+
+  worker:
+    environment:
+      USE_STUBS: 'true'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,6 @@ services:
       - nightfall_network
     environment:
       LOG_LEVEL: info
-      MPC: ${MPC}
     # Temporary container to deploy contracts and circuits and populate volumes
   deployer:
     #image: docker.pkg.github.com/eyblockchain/nightfall-deployer/nightfall_deployer:1.1.0
@@ -178,7 +177,6 @@ services:
       - type: volume
         source: proving_files
         target: /app/public/
-
 
 volumes:
   mongodb1: null

--- a/start-nightfall
+++ b/start-nightfall
@@ -50,8 +50,6 @@ while [ -n "$1" ]; do
                                     ;;
       -a  | --adversary)            ADVERSARY="-f docker-compose.adversary.yml"
                                     ;;
-      -mpc)                         export MPC="true"
-                                    ;;
       * )                           usage
                               exit 1
     esac

--- a/test/ping-pong/docker-compose.stubs.yml
+++ b/test/ping-pong/docker-compose.stubs.yml
@@ -1,10 +1,14 @@
 version: '3.5'
 # Use this script for making nightfall_3 use stubs.
 services:
-    client:
-      environment:
-        USE_STUBS: 'true' # make sure this flag is the same as in deployer service
-        
-    deployer:
-      environment:
-        USE_STUBS: 'true' # make sure this flag is the same as in deployer service
+  client:
+    environment:
+      USE_STUBS: 'true' # make sure this flag is the same as in deployer service
+
+  deployer:
+    environment:
+      USE_STUBS: 'true' # make sure this flag is the same as in deployer service
+
+  worker:
+    environment:
+      USE_STUBS: 'true'

--- a/zokrates-worker/src/index.mjs
+++ b/zokrates-worker/src/index.mjs
@@ -8,37 +8,41 @@ import logger from './utils/logger.mjs';
 
 const {
   MPC: { MPC_PARAMS_URL },
+  USE_STUBS,
 } = config;
 
 const main = async () => {
   try {
     if (!fs.existsSync('./mpc_params')) fs.mkdirSync('./mpc_params');
 
-    const mpcPromises = [];
+    if (!USE_STUBS) {
+      logger.info('Not using stubs, downloading MPC param files...');
+      const mpcPromises = [];
 
-    for (const circuit of ['deposit', 'double_transfer', 'single_transfer', 'withdraw']) {
-      if (!fs.existsSync(`./mpc_params/${circuit}`)) {
-        mpcPromises.push(
-          new Promise((resolve, reject) => {
-            axios
-              .get(`${MPC_PARAMS_URL}/${circuit}`, {
-                responseType: 'stream',
-              })
-              .then(response => {
-                resolve();
-                response.data.pipe(fs.createWriteStream(`./mpc_params/${circuit}`));
-              })
-              .catch(error => {
-                reject();
-                logger.error(error);
-                throw new Error(error);
-              });
-          }),
-        );
+      for (const circuit of ['deposit', 'double_transfer', 'single_transfer', 'withdraw']) {
+        if (!fs.existsSync(`./mpc_params/${circuit}`)) {
+          mpcPromises.push(
+            new Promise((resolve, reject) => {
+              axios
+                .get(`${MPC_PARAMS_URL}/${circuit}`, {
+                  responseType: 'stream',
+                })
+                .then(response => {
+                  resolve();
+                  response.data.pipe(fs.createWriteStream(`./mpc_params/${circuit}`));
+                })
+                .catch(error => {
+                  reject();
+                  logger.error(error);
+                  throw new Error(error);
+                });
+            }),
+          );
+        }
       }
-    }
 
-    await Promise.all(mpcPromises);
+      await Promise.all(mpcPromises);
+    }
 
     // 1 means enable it
     // 0 mean keep it disabled

--- a/zokrates-worker/src/services/generateKeys.mjs
+++ b/zokrates-worker/src/services/generateKeys.mjs
@@ -1,7 +1,10 @@
 import fs from 'fs';
 import path from 'path';
+import config from 'config';
 import { compile, extractVk, exportKeys, setup } from '../zokrates-lib/index.mjs';
 import logger from '../utils/logger.mjs';
+
+const { USE_STUBS } = config;
 
 export default async function generateKeys({ filepath, curve = 'bn128' }) {
   const outputPath = `./output`;
@@ -28,7 +31,7 @@ export default async function generateKeys({ filepath, curve = 'bn128' }) {
     curve,
   );
 
-  if (process.env.MPC) {
+  if (!USE_STUBS) {
     logger.info('Export keys...');
     await exportKeys(`${outputPath}/${circuitDir}`, `${circuitName}`);
   } else {

--- a/zokrates-worker/src/zokrates-lib/exportKeys.mjs
+++ b/zokrates-worker/src/zokrates-lib/exportKeys.mjs
@@ -22,16 +22,6 @@ export default async function exportKeys(path, circuitName, options = {}) {
   const { maxReturn = 10000000, verbose = false } = options;
 
   return new Promise((resolve, reject) => {
-    console.log(
-      'mpc',
-      'export',
-      '-i',
-      `./mpc_params/${circuitName}`,
-      '-v',
-      `${path}/${circuitName}_vk.key`,
-      '-p',
-      `${path}/${circuitName}_pk.key`,
-    );
     const zokrates = spawn(
       '/app/zokrates',
       [


### PR DESCRIPTION
The worker now exports the keys from the MPC ceremony, unless you choose to use stubs, in which case it will run the normal setup