### PR TITLE
Save external offchain transactions in optimist

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,5 +3,6 @@ cd node_modules/*
 **/migrations/*
 **/doc/*
 cli/build/*
+wallet/cli/*
 test/adversary/nightfall-adversary/*
 /**/*.d.ts

--- a/common-files/utils/crypto/multihash.mjs
+++ b/common-files/utils/crypto/multihash.mjs
@@ -1,0 +1,9 @@
+/* eslint import/no-extraneous-dependencies: "off" */
+
+import crypto from 'crypto';
+
+let h = '875966a4d290bae914acd733315d1a1cbea3fb2b9fde133a0c6fffa7f726cbe3';
+for (let i = 0; i < 1024; i++) {
+  h = crypto.createHash('sha256').update(h, 'hex').digest('hex');
+}
+console.log(h);

--- a/nightfall-deployer/migrations/2_deploy_upgradeable.js
+++ b/nightfall-deployer/migrations/2_deploy_upgradeable.js
@@ -49,7 +49,6 @@ module.exports = async function (deployer) {
   await challengers.setBootChallenger(bootChallenger);
   const restrictions = await Shield.deployed();
   // restrict transfer amounts
-  console.log('**TEST**', process.env.ETH_NETWORK, RESTRICTIONS.tokens, RESTRICTIONS);
   for (let token of RESTRICTIONS.tokens[process.env.ETH_NETWORK]) {
     console.log(`Max deposit restriction for ${token.name}: ${token.amount}`);
     await restrictions.setRestriction(token.address, token.amount);

--- a/nightfall-optimist/src/event-handlers/block-proposed.mjs
+++ b/nightfall-optimist/src/event-handlers/block-proposed.mjs
@@ -66,8 +66,9 @@ async function blockProposedEventHandler(data) {
           logger.debug(
             `Processing external offchain transaction with L2 hash ${tx.transactionHash}`,
           );
-          transactionSubmittedEventHandler({ offchain: true, ...tx }); // must be offchain or we'll have seen them
+          return transactionSubmittedEventHandler({ offchain: true, ...tx }); // must be offchain or we'll have seen them
         }
+        return true;
       }),
     );
 

--- a/nightfall-optimist/src/event-handlers/block-proposed.mjs
+++ b/nightfall-optimist/src/event-handlers/block-proposed.mjs
@@ -12,8 +12,10 @@ import {
   stampNullifiers,
   getLatestTree,
   saveTree,
+  getTransactionByTransactionHash,
 } from '../services/database.mjs';
 import { getProposeBlockCalldata } from '../services/process-calldata.mjs';
+import transactionSubmittedEventHandler from './transaction-submitted.mjs';
 
 const { ZERO, HASH_TYPE, TIMBER_HEIGHT } = config;
 
@@ -51,6 +53,24 @@ async function blockProposedEventHandler(data) {
     // when a challenge is raised because the is correct block data, then the corresponding block deleted event will
     // update this collection
     await saveBlock({ blockNumber: currentBlockCount, transactionHashL1, ...block });
+
+    // It's possible that some of these transactions are new to us. That's because they were
+    // submitted by someone directly to another proposer and so there was never a TransactionSubmitted
+    // event associated with them. Either that, or we lost our database and had to resync from the chain.
+    // In which case this handler is being called be the resync code. either way, we need to add the transaction.
+    // let's use transactionSubmittedEventHandler to do this because it will perform all the duties associated
+    // with saving a transaction.
+    await Promise.all(
+      transactions.map(async tx => {
+        if (!(await getTransactionByTransactionHash(tx.transactionHash))) {
+          logger.debug(
+            `Processing external offchain transaction with L2 hash ${tx.transactionHash}`,
+          );
+          transactionSubmittedEventHandler({ offchain: true, ...tx }); // must be offchain or we'll have seen them
+        }
+      }),
+    );
+
     // Update the nullifiers we have stored, with the blockhash. These will
     // be deleted if the block check fails and we get a rollback.  We do this
     // before running the block check because we want to delete the nullifiers

--- a/nightfall-optimist/src/services/state-sync.mjs
+++ b/nightfall-optimist/src/services/state-sync.mjs
@@ -52,14 +52,14 @@ const syncState = async (
       case 'Rollback':
         await rollbackEventHandler(pastEvent);
         break;
+      case 'TransactionSubmitted':
+        await transactionSubmittedEventHandler(pastEvent);
+        break;
       case 'BlockProposed':
         await blockProposedEventHandler(pastEvent);
         break;
       case 'CommittedToChallenge':
         await committedToChallengeEventHandler(pastEvent);
-        break;
-      case 'TransactionSubmitted':
-        await transactionSubmittedEventHandler(pastEvent);
         break;
       default:
         break;


### PR DESCRIPTION
This PR will cause any transactions that appear in a L2 block which `optimist` has not got in its database, to be saved. 
This can happen when `optimist` is being resynced because the process only saves transactions that are received as part of a TransactionSubmitted event; offchain events do not create these.

I have not yet created a positive test for this code.  This will follow.