### PR TITLE
fix offchain connection and tests

### DIFF
--- a/nightfall-client/src/services/transfer.mjs
+++ b/nightfall-client/src/services/transfer.mjs
@@ -221,20 +221,18 @@ async function transfer(transferParams) {
       // dig up connection peers
       const peerList = await getProposersUrl(NEXT_N_PROPOSERS);
       logger.debug(`Peer List: ${JSON.stringify(peerList, null, 2)}`);
-      Object.keys(peerList).forEach(async address => {
-        logger.debug(
-          `offchain transaction - calling ${peerList[address]}/proposer/offchain-transaction`,
-        );
-        await axios
-          .post(
+      await Promise.all(
+        Object.keys(peerList).map(async address => {
+          logger.debug(
+            `offchain transaction - calling ${peerList[address]}/proposer/offchain-transaction`,
+          );
+          return axios.post(
             `${peerList[address]}/proposer/offchain-transaction`,
             { transaction: optimisticTransferTransaction },
             { timeout: 3600000 },
-          )
-          .catch(err => {
-            throw new Error(err);
-          });
-      });
+          );
+        }),
+      );
       // we only want to store our own commitments so filter those that don't
       // have our public key
       newCommitments

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -92,7 +92,8 @@ const emptyL2 = async nf3Instance => {
 describe('ERC20 tests', () => {
   before(async () => {
     await nf3Proposer.init(mnemonics.proposer);
-    await nf3Proposer.registerProposer();
+    // we must set the URL from the point of view of the client container
+    await nf3Proposer.registerProposer('http://optimist1');
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer.startProposer();


### PR DESCRIPTION
The offchain transfer tests in `erc20.test.mjs` were evergreen; `client` was unable to connect to `optimist`'s `/proposer/offchain-transaction` endpoint because no `optimist` API URL was provided by the test harness to `client`.  This caused a connection error when `client` tried to connect.  However the error was thrown and caught inside an async `.forEach` loop inside `transfer.mjs` and so did not propagate back to the test harness - a double whammy.

This PR fixes both problems by providing a correct URL for `optimist` (NB: this has to be the URL as seen from inside the `client` container), and by propagating any error correctly by turning the `.forEach` into a `.map` then awaiting completion of the calls to `optimist`.