### PR TITLE
sync fix

### DIFF
--- a/nightfall-optimist/src/event-handlers/block-proposed.mjs
+++ b/nightfall-optimist/src/event-handlers/block-proposed.mjs
@@ -66,7 +66,12 @@ async function blockProposedEventHandler(data) {
           logger.debug(
             `Processing external offchain transaction with L2 hash ${tx.transactionHash}`,
           );
-          return transactionSubmittedEventHandler({ offchain: true, ...tx }, false); // must be offchain or we'll have seen them, mempool = false
+          return transactionSubmittedEventHandler({
+            blocknumberL2: block.blockNumberL2,
+            mempool: false,
+            offchain: true,
+            ...tx,
+          }); // must be offchain or we'll have seen them, mempool = false
         }
         return true;
       }),

--- a/nightfall-optimist/src/event-handlers/block-proposed.mjs
+++ b/nightfall-optimist/src/event-handlers/block-proposed.mjs
@@ -66,7 +66,7 @@ async function blockProposedEventHandler(data) {
           logger.debug(
             `Processing external offchain transaction with L2 hash ${tx.transactionHash}`,
           );
-          return transactionSubmittedEventHandler({ offchain: true, ...tx }); // must be offchain or we'll have seen them
+          return transactionSubmittedEventHandler({ offchain: true, ...tx }, false); // must be offchain or we'll have seen them
         }
         return true;
       }),

--- a/nightfall-optimist/src/event-handlers/block-proposed.mjs
+++ b/nightfall-optimist/src/event-handlers/block-proposed.mjs
@@ -66,7 +66,7 @@ async function blockProposedEventHandler(data) {
           logger.debug(
             `Processing external offchain transaction with L2 hash ${tx.transactionHash}`,
           );
-          return transactionSubmittedEventHandler({ offchain: true, ...tx }, false); // must be offchain or we'll have seen them
+          return transactionSubmittedEventHandler({ offchain: true, ...tx }, false); // must be offchain or we'll have seen them, mempool = false
         }
         return true;
       }),

--- a/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
+++ b/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
@@ -41,7 +41,7 @@ async function checkAlreadyInBlock(_transaction) {
 /**
 This handler runs whenever a new transaction is submitted to the blockchain
 */
-async function transactionSubmittedEventHandler(eventParams, mempool) {
+async function transactionSubmittedEventHandler(eventParams) {
   const { offchain = false, ...data } = eventParams;
   let transaction;
   if (offchain) {
@@ -72,7 +72,6 @@ async function transactionSubmittedEventHandler(eventParams, mempool) {
     }
     if (transactionNullifiers.length > 0)
       saveNullifiers(transactionNullifiers, transaction.blockNumber); // we can now safely store the nullifiers IFF they are present
-    if (mempool) transaction.mempool = mempool;
     saveTransaction({ ...transaction }); // then we need to save it
   } catch (err) {
     if (err instanceof TransactionError)

--- a/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
+++ b/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
@@ -41,7 +41,7 @@ async function checkAlreadyInBlock(_transaction) {
 /**
 This handler runs whenever a new transaction is submitted to the blockchain
 */
-async function transactionSubmittedEventHandler(eventParams) {
+async function transactionSubmittedEventHandler(eventParams, mempool = true) {
   const { offchain = false, ...data } = eventParams;
   let transaction;
   if (offchain) {
@@ -72,7 +72,7 @@ async function transactionSubmittedEventHandler(eventParams) {
     }
     if (transactionNullifiers.length > 0)
       saveNullifiers(transactionNullifiers, transaction.blockNumber); // we can now safely store the nullifiers IFF they are present
-    saveTransaction({ ...transaction }); // then we need to save it
+    saveTransaction({ ...transaction, mempool }); // then we need to save it
   } catch (err) {
     if (err instanceof TransactionError)
       logger.warn(

--- a/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
+++ b/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
@@ -41,7 +41,7 @@ async function checkAlreadyInBlock(_transaction) {
 /**
 This handler runs whenever a new transaction is submitted to the blockchain
 */
-async function transactionSubmittedEventHandler(eventParams, mempool = true) {
+async function transactionSubmittedEventHandler(eventParams, mempool) {
   const { offchain = false, ...data } = eventParams;
   let transaction;
   if (offchain) {
@@ -72,7 +72,8 @@ async function transactionSubmittedEventHandler(eventParams, mempool = true) {
     }
     if (transactionNullifiers.length > 0)
       saveNullifiers(transactionNullifiers, transaction.blockNumber); // we can now safely store the nullifiers IFF they are present
-    saveTransaction({ ...transaction, mempool }); // then we need to save it
+    if (mempool) transaction.mempool = mempool;
+    saveTransaction({ ...transaction }); // then we need to save it
   } catch (err) {
     if (err instanceof TransactionError)
       logger.warn(

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -269,12 +269,12 @@ export async function getMostProfitableTransactions(number) {
 Function to save a (unprocessed) Transaction
 */
 export async function saveTransaction(_transaction) {
-  const { mempool = true } = _transaction; // mempool may not exist
+  const { mempool = true, blockNumberL2 = -1 } = _transaction;
   const transaction = {
     _id: _transaction.transactionHash,
     ..._transaction,
     mempool,
-    blockNumberL2: -1,
+    blockNumberL2,
   };
   logger.debug(
     `saving transaction ${transaction.transactionHash}, with layer 1 block number ${_transaction.blockNumber}`,


### PR DESCRIPTION
If we find a transaction in a block that we have not seen before then we save it but make sure its marked as not in the mempool because it must now be onchain.  This achieves that be enabling a new parameter for calling transactionSubmittedEventHandler, so that `mempool` can be set (true or false, false in this case).

We also have to set the `blockNumberL2` of the block that this transaction is in (by default it will be assigned `-1`)