### PR TITLE
Update restrictions

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -285,9 +285,9 @@ module.exports = {
     tokens: {
       blockchain1: [
         {
-          name: 'MockERC20',
+          name: 'ERC20Mock',
           address: '0xB5Acbe9a0F1F8B98F3fC04471F7fE5d2c222cB44',
-          amount: 200,
+          amount: '200',
         },
         {
           name: 'Test-Eth',
@@ -307,9 +307,9 @@ module.exports = {
       ],
       staging: [
         {
-          name: 'MockERC20',
+          name: 'ERC20Mock',
           address: '0xB5Acbe9a0F1F8B98F3fC04471F7fE5d2c222cB44',
-          amount: 200,
+          amount: '200',
         },
         {
           name: 'Test-Eth',
@@ -329,7 +329,7 @@ module.exports = {
       ],
       development: [
         {
-          name: 'MockERC20',
+          name: 'ERC20Mock',
           address: '0xB5Acbe9a0F1F8B98F3fC04471F7fE5d2c222cB44',
           amount: 200,
         },

--- a/nightfall-deployer/contracts/Config.sol
+++ b/nightfall-deployer/contracts/Config.sol
@@ -14,7 +14,7 @@ contract Config is Ownable {
 
     address bootProposer;
     address bootChallenger;
-    mapping(address => uint256) erc20limit;
+    mapping(address => uint256[2]) erc20limit;
 
     function initialize() public virtual override initializer {
         Ownable.initialize();
@@ -49,15 +49,25 @@ contract Config is Ownable {
     }
 
     // restricting tokens
-    function getRestriction(address tokenAddr) public view returns (uint256) {
-        return erc20limit[tokenAddr];
+    // 0 for deposit and 1 for withdraw
+    function getRestriction(address tokenAddr, uint256 transactionType)
+        public
+        view
+        returns (uint256)
+    {
+        return erc20limit[tokenAddr][transactionType];
     }
 
-    function setRestriction(address tokenAddr, uint256 amount) external onlyOwner {
-        erc20limit[tokenAddr] = amount;
+    function setRestriction(
+        address tokenAddr,
+        uint256 depositAmount,
+        uint256 withdrawAmount
+    ) external onlyOwner {
+        erc20limit[tokenAddr][0] = depositAmount;
+        erc20limit[tokenAddr][1] = withdrawAmount;
     }
 
-    function removeRestriction(address tokenAddr) external onlyOwner {
-        delete erc20limit[tokenAddr];
+    function removeRestriction(address tokenAddr, uint256 transactionType) external onlyOwner {
+        delete erc20limit[tokenAddr][transactionType];
     }
 }

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -242,7 +242,7 @@ contract Shield is Stateful, Structures, Config, Key_Registry, ReentrancyGuardUp
 
         if (t.tokenType == TokenType.ERC20) {
             if (t.tokenId != ZERO) revert('ERC20 deposit should have tokenId equal to ZERO');
-            if (t.value >= super.getRestriction(addr))
+            if (t.value > super.getRestriction(addr, 1))
                 revert('Value is above current restrictions for withdrawals');
             else tokenContract.transfer(recipientAddress, uint256(t.value));
         } else if (t.tokenType == TokenType.ERC721) {
@@ -275,7 +275,7 @@ contract Shield is Stateful, Structures, Config, Key_Registry, ReentrancyGuardUp
 
         if (t.tokenType == TokenType.ERC20) {
             if (t.tokenId != ZERO) revert('ERC20 deposit should have tokenId equal to ZERO');
-            if (t.value >= super.getRestriction(addr))
+            if (t.value > super.getRestriction(addr, 0))
                 revert('Value is above current restrictions for deposits');
             else tokenContract.transferFrom(msg.sender, address(this), uint256(t.value));
         } else if (t.tokenType == TokenType.ERC721) {

--- a/nightfall-deployer/migrations/2_deploy_upgradeable.js
+++ b/nightfall-deployer/migrations/2_deploy_upgradeable.js
@@ -47,7 +47,8 @@ module.exports = async function (deployer) {
   const restrictions = await Shield.deployed();
   // restrict transfer amounts
   for (let token of RESTRICTIONS.tokens[process.env.ETH_NETWORK]) {
-    console.log(`Max deposit restriction for ${token.name}: ${token.amount}`);
-    await restrictions.setRestriction(token.address, token.amount);
+    console.log(`Max allowed deposit value for ${token.name}: ${(BigInt(token.amount) / BigInt(4)).toString()}`); // BigInt division returns whole number which is a floor. Not Math.floor() needed
+    console.log(`Max allowed withdraw value for ${token.name}: ${token.amount}`);
+    await restrictions.setRestriction(token.address, (BigInt(token.amount) / BigInt(4)).toString(), token.amount);
   }
 };

--- a/nightfall-deployer/migrations/3_test_tokens_migration.js
+++ b/nightfall-deployer/migrations/3_test_tokens_migration.js
@@ -32,7 +32,7 @@ module.exports = function (deployer, _, accounts) {
     await ERC20deployed.transfer(addresses.user2, 1000000000000);
 
     // Set a restriction for ping-pong
-    await restrictions.setRestriction(ERC20deployed.address, erc20default);
+    await restrictions.setRestriction(ERC20deployed.address, (BigInt(erc20default)/BigInt(4)).toString(), erc20default);
 
     if (!config.ETH_ADDRESS) {
       // indicates we're running a wallet test that uses hardcoded addresses

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -500,8 +500,8 @@ describe('ERC20 tests', () => {
           // Transfer 1000 + 200 to self      Input [1000, 250]  Output [1200, 50]    Commitment List after [50, 50, 50, 50, 100, 1200]
 
           // console.log('Making 6 deposits', maxERC20DepositValue);
-          let transferValue = Math.floor(maxERC20WithdrawValue / 5); // maxERC20DepositValue < transferValue < maxERC20WithdrawValue
-          let withdrawValue = transferValue * 6; // transferValue = ( maxERC20WithdrawValue / 5 ) * 6 > maxERC20WithdrawValue
+          const trnsferValue = Math.floor(maxERC20WithdrawValue / 5); // maxERC20DepositValue < trnsferValue < maxERC20WithdrawValue
+          const withdrawValue = trnsferValue * 6; // trnsferValue = ( maxERC20WithdrawValue / 5 ) * 6 > maxERC20WithdrawValue
 
           await depositNTransactions(
             nf3Users[0],
@@ -517,12 +517,12 @@ describe('ERC20 tests', () => {
           await new Promise(resolve => setTimeout(resolve, 15000));
 
           for (let i = 0; i < 5; i++) {
-            // console.log('transfering self', transferValue * (i + 2));
+            // console.log('transfering self', trnsferValue * (i + 2));
             await nf3Users[0].transfer(
               false,
               erc20Address,
               tokenType,
-              transferValue * (i + 2),
+              trnsferValue * (i + 2),
               tokenId,
               nf3Users[0].zkpKeys.compressedPkd,
               fee,
@@ -531,7 +531,7 @@ describe('ERC20 tests', () => {
             await new Promise(resolve => setTimeout(resolve, 15000));
           }
 
-          // console.log('withdrawing', transferValue * 6);
+          // console.log('withdrawing', trnsferValue * 6);
           const rec = await nf3Users[0].withdraw(
             false,
             erc20Address,

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -339,11 +339,9 @@ export const expectTransaction = res => {
 export const depositNTransactions = async (nf3, N, ercAddress, tokenType, value, tokenId, fee) => {
   const depositTransactions = [];
   for (let i = 0; i < N; i++) {
-    const res = await nf3.deposit(ercAddress, tokenType, value, tokenId, fee);
-    expectTransaction(res);
-    depositTransactions.push(res);
+    depositTransactions.push(nf3.deposit(ercAddress, tokenType, value, tokenId, fee));
   }
-  return depositTransactions;
+  return Promise.all(depositTransactions);
 };
 
 export const transferNTransactions = async (


### PR DESCRIPTION
Description:
If a user does two deposits with the max deposit amount, then a transfer, the user already owns a commitment of value bigger than the max withdraw limit. To control this, this PR introduces max deposit amount to be a quarter of max withdraw amount. 

Other fixes:
- It also fixes restriction tests which always pass despite depositing/withdrawing a value over or under the restriction limit because
  - For a successful test, the test expects to catch an error message `Transaction has been reverted by the EVM`. This error message is also thrown by the test by calling `expect.fail('Transaction has not been reverted by the EVM');` Which meant the test would work even if deposit/withdraw calls were commented out because the error was always thrown and caught as expected.
  - Also, the values used for deposit or withdraw tests were always below the max limit. So the tests created valid deposit and withdraw transactions which did not revert on the blockchain as they were under the max deposit and withdraw restrictions
- Updated the contracts such that if 1000 MATIC is set as the withdraw limit, 1000 MATIC can be withdrawn successfully whilst 1001 will fail. Earlier only values `<1000` MATIC were accepted and values equal to and over 1000 MATIC reverted. 

Test:
Automatically done by Github Action.
For a further review, look in blockchain logs of ganache test for transactions with revert messages
`Value is above current restrictions for deposits` and `Value is above current restrictions for withdrawals` 