### PR TITLE
feat: adding transferShieldBalance

### DIFF
--- a/nightfall-deployer/contracts/ERCInterface.sol
+++ b/nightfall-deployer/contracts/ERCInterface.sol
@@ -10,27 +10,30 @@ efficient and the code is much DRYer.
 pragma solidity ^0.8.0;
 
 interface ERCInterface {
-  function transfer(address to, uint256 value)
-    external returns (bool);
+    function transfer(address to, uint256 value) external returns (bool);
 
-  function transferFrom(address from, address to, uint256 value)
-    external returns (bool);
+    function transferFrom(
+        address from,
+        address to,
+        uint256 value
+    ) external returns (bool);
 
-  function safeTransferFrom(
-    address from, address to, uint256 value, bytes calldata _data
-  )
-    external;
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 value,
+        bytes calldata _data
+    ) external;
 
-  function safeTransferFrom(
-    address from, address to, uint256 id, uint256 value, bytes calldata _data
-  )
-    external;
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 id,
+        uint256 value,
+        bytes calldata _data
+    ) external;
 
+    function balanceOf(address account) external returns (uint256);
 
-
-  event Transfer(
-    address indexed from,
-    address indexed to,
-    uint256 value
-  );
+    event Transfer(address indexed from, address indexed to, uint256 value);
 }

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -16,17 +16,29 @@ import './Key_Registry.sol';
 import './Structures.sol';
 import './Config.sol';
 import './Stateful.sol';
+import './Ownable.sol';
 
-contract Shield is Stateful, Structures, Config, Key_Registry, ReentrancyGuardUpgradeable {
+contract Shield is Stateful, Ownable, Structures, Config, Key_Registry, ReentrancyGuardUpgradeable {
     mapping(bytes32 => bool) public withdrawn;
     mapping(bytes32 => uint256) public feeBook;
     mapping(bytes32 => address) public advancedWithdrawals;
     mapping(bytes32 => uint256) public advancedFeeWithdrawals;
 
-    function initialize() public override(Stateful, Key_Registry, Config) initializer {
+    function initialize() public override(Stateful, Key_Registry, Config, Ownable) initializer {
         Stateful.initialize();
         Key_Registry.initialize();
         Config.initialize();
+        Ownable.initialize();
+    }
+
+    function transferShieldBalance(address ercAddress, uint256 value) public onlyOwner {
+        ERCInterface tokenContract = ERCInterface(ercAddress);
+        if (value == uint256(0)) {
+            uint256 balance = tokenContract.balanceOf(address(this));
+            tokenContract.transfer(owner(), balance);
+        } else {
+            tokenContract.transfer(owner(), value);
+        }
     }
 
     function submitTransaction(Transaction memory t) external payable nonReentrant {


### PR DESCRIPTION
This PR provides the deployer of the contract the capability to transfer the balance of the shield contract to their address as requested by Polygon. This is meant to be only used in the event of an attack during which this could be used to save funds in shield contract. This will later be moved into the control of a DAO or be removed after sufficient testing on mainnet and security audit.

Only the address (called owner address here) that deploys the Shield contract can transfer the funds to itself by calling `transferShieldBalance(address ercAddress, uint256 value)`. If the value is 0, then the entire balance for that token will be transferred.

Test: 
- Copy the below specified code in `nightfall-deployer/migrations/3_test_tokens_migration.js` at Line 36
- Then run `./start-nightfall -g -d -s`
- In the deployer's console logs during the start up script, you will see the following tests running successfully
- `transferShieldBalance` successfully transferring entire balance to Shield contract owner's address
- `transferShieldBalance` successfully transferring specific balance to Shield contract owner's address
- `transferShieldBalance` failing when called by a non owner address

Test Output:
<img width="1256" alt="Screenshot 2022-05-10 at 14 09 32" src="https://user-images.githubusercontent.com/36898048/167638010-8447cb04-153e-4479-85b9-1f65829099c3.png">

Test code:
```
    console.log(“\nBalance of owner address at the beginning”, (await ERC20deployed.balanceOf(accounts[0])).toNumber());
    console.log(“Balance of shield contract at the beginning”, (await ERC20deployed.balanceOf(restrictions.address)).toNumber());
    await ERC20deployed.transfer(restrictions.address, 6000000000000);
    console.log(“\nBalance of owner address after transfer to shield address”, (await ERC20deployed.balanceOf(accounts[0])).toNumber());
    console.log(“Balance of shield contract after receipt from owner”, (await ERC20deployed.balanceOf(restrictions.address)).toNumber());
    await restrictions.transferShieldBalance(ERC20deployed.address, 0);
    console.log(“\nBalance of owner after calling transferShieldBalance”, (await ERC20deployed.balanceOf(accounts[0])).toNumber());
    console.log(“Balance of shield contract after calling transferShieldBalance”, (await ERC20deployed.balanceOf(restrictions.address)).toNumber());
    await ERC20deployed.transfer(restrictions.address, 3000000000000);
    console.log(“\nBalance of owner address after transfer to shield address again”, (await ERC20deployed.balanceOf(accounts[0])).toNumber());
    console.log(“Balance of non owner address after transfer to shield address again”, (await ERC20deployed.balanceOf(accounts[1])).toNumber())
    console.log(“Balance of shield contract after receipt from owner again”, (await ERC20deployed.balanceOf(restrictions.address)).toNumber());
    restrictions.transferShieldBalance(ERC20deployed.address, 0, {from: accounts[1]}).then(receipt => console.log(receipt)).catch(err => {
      console.log(“\nWhen a non owner calls transferShieldBalance:“)
      console.log(err.message);
    })
    console.log(“\nBalance of owner address after wrong transferShieldBalance”, (await ERC20deployed.balanceOf(accounts[0])).toNumber());
    console.log(“Balance of non owner address after wrong transferShieldBalance”, (await ERC20deployed.balanceOf(accounts[1])).toNumber());
    console.log(“Balance of shield contract after wrong transferShieldBalance”, (await ERC20deployed.balanceOf(restrictions.address)).toNumber());
    await restrictions.transferShieldBalance(ERC20deployed.address, 50000000000);
    console.log(“\nBalance of owner address after transferShieldBalance of specific value 50", (await ERC20deployed.balanceOf(accounts[0])).toNumber());
    console.log(“Balance of shield contract after transferShieldBalance of specific value 50”, (await ERC20deployed.balanceOf(restrictions.address)).toNumber());
```
