### PR TITLE
Fix: Mark block stake as withdrawn for the block

### DIFF
--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -68,6 +68,7 @@ contract Shield is Stateful, Structures, Config, Key_Registry, ReentrancyGuardUp
         }
         payment += BLOCK_STAKE;
         state.addPendingWithdrawal(msg.sender, payment);
+        state.setBlockStakeWithdrawn(blockHash);
     }
 
     function onERC721Received(


### PR DESCRIPTION
Critical bug detected by the Nightfall audit.
A proposer could call repeatedly the function `requestBlockPayment` in the Shield contract for the same block and will add BLOCK_STAKE to his pending withdrawal each time.  

Adding ` state.setBlockStakeWithdrawn(blockHash)` at the end of the function fixes this bug as it's checked in the function that the block stake is not already withdrawn for the blocHash.
```
require(
            state.isBlockStakeWithdrawn(blockHash) == false,
            'The block stake for this block is already claimed'
        );
```