### PR TITLE
resync cleanup

### DIFF
--- a/common-files/utils/event-queue.mjs
+++ b/common-files/utils/event-queue.mjs
@@ -25,8 +25,8 @@ import logger from 'common-files/utils/logger.mjs';
 import { web3 } from 'common-files/utils/contract.mjs';
 
 const { MAX_QUEUE, CONFIRMATION_POLL_TIME, CONFIRMATIONS } = config;
-const fastQueue = new Queue({ autostart: true, concurrency: 1 });
-const slowQueue = new Queue({ autostart: true, concurrency: 1 });
+const fastQueue = new Queue({ autostart: false, concurrency: 1 });
+const slowQueue = new Queue({ autostart: false, concurrency: 1 });
 const removed = {}; // singleton holding transaction hashes of any removed events
 const stopQueue = new Queue({ autostart: false, concurrency: 1 });
 export const queues = [fastQueue, slowQueue, stopQueue];

--- a/nightfall-client/src/services/state-sync.mjs
+++ b/nightfall-client/src/services/state-sync.mjs
@@ -6,6 +6,7 @@ their local commitments databsae.
 import config from 'config';
 import logger from 'common-files/utils/logger.mjs';
 import mongo from 'common-files/utils/mongo.mjs';
+import { unpauseQueue } from 'common-files/utils/event-queue.mjs';
 import { waitForContract } from '../event-handlers/subscribe.mjs';
 import blockProposedEventHandler from '../event-handlers/block-proposed.mjs';
 import rollbackEventHandler from '../event-handlers/rollback.mjs';
@@ -57,6 +58,8 @@ export const initialClientSync = async () => {
   const firstSeenBlockNumber = Math.min(...commitmentBlockNumbers);
   logger.info(`firstSeenBlockNumber: ${firstSeenBlockNumber}`);
   // fistSeenBlockNumber can be infinity if the commitmentBlockNumbers array is empty
-  if (firstSeenBlockNumber === Infinity) return syncState(STATE_GENESIS_BLOCK);
-  return syncState(firstSeenBlockNumber);
+  if (firstSeenBlockNumber === Infinity) await syncState(STATE_GENESIS_BLOCK);
+  else await syncState(firstSeenBlockNumber);
+  unpauseQueue(0); // the queues are paused to start with, so get them going once we are synced
+  unpauseQueue(1);
 };

--- a/nightfall-optimist/src/event-handlers/subscribe.mjs
+++ b/nightfall-optimist/src/event-handlers/subscribe.mjs
@@ -87,7 +87,7 @@ export async function waitForContract(contractName) {
  * @param arg - List of arguments to be passed to callback, the first element must be the event-handler functions
  * @returns = List of emitters from each contract.
  */
-export async function startEventQueue(lastSyncedBlock, callback, ...arg) {
+export async function startEventQueue(callback, ...arg) {
   const contractNames = [
     STATE_CONTRACT_NAME,
     SHIELD_CONTRACT_NAME,
@@ -96,10 +96,7 @@ export async function startEventQueue(lastSyncedBlock, callback, ...arg) {
   ];
   const contracts = await Promise.all(contractNames.map(c => waitForContract(c)));
   const emitters = contracts.map(e => {
-    let emitterC;
-    // if we've just resynced, start from the end of the sync:
-    if (lastSyncedBlock) emitterC = e.events.allEvents({ fromBlock: lastSyncedBlock + 1 });
-    else emitterC = e.events.allEvents();
+    const emitterC = e.events.allEvents();
     emitterC.on('changed', event => callback(event, arg));
     emitterC.on('data', event => callback(event, arg));
     return emitterC;

--- a/nightfall-optimist/src/index.mjs
+++ b/nightfall-optimist/src/index.mjs
@@ -29,24 +29,24 @@ const main = async () => {
     await subscribeToChallengeWebSocketConnection(setChallengeWebSocketConnection);
     await subscribeToInstantWithDrawalWebSocketConnection(setInstantWithdrawalWebSocketConnection);
     await subscribeToProposedBlockWebSocketConnection(setBlockProposedWebSocketConnection);
-    // try to sync any missing blockchain state
-    // only then start making blocks and listening to new proposers
-    initialBlockSync(proposer).then(async lastSyncedBlock => {
-      await startEventQueue(lastSyncedBlock, queueManager, eventHandlers, proposer);
-      queues[0].on('end', () => {
-        // We do the proposer isMe check here to fail fast instead of re-enqueing.
-        // We check if the queue[2] is empty, this is safe it is manually enqueued/dequeued.
-        if (proposer.isMe && queues[2].length === 0) {
-          // logger.info('Queue has emptied. Queueing block assembler.');
-          return enqueueEvent(conditionalMakeBlock, 0, proposer);
-        }
-        // eslint-disable-next-line no-void, no-useless-return
-        return void false; // This is here to satisfy consistent return rules, we do nothing.
-      });
-      // We enqueue a message so that we can actualy trigger the queue.end call even if we havent received anything.
-      // This helps in the case that we restart client and we are the current proposer.
-      await enqueueEvent(() => logger.info('Start Queue'), 0);
+    // start the event queue
+    await startEventQueue(queueManager, eventHandlers, proposer);
+    // enqueue the block-assembler every time the queue becomes empty
+    queues[0].on('end', () => {
+      // We do the proposer isMe check here to fail fast instead of re-enqueing.
+      // We check if the queue[2] is empty, this is safe it is manually enqueued/dequeued.
+      if (proposer.isMe && queues[2].length === 0) {
+        // logger.info('Queue has emptied. Queueing block assembler.');
+        return enqueueEvent(conditionalMakeBlock, 0, proposer);
+      }
+      // eslint-disable-next-line no-void, no-useless-return
+      return void false; // This is here to satisfy consistent return rules, we do nothing.
     });
+    // We enqueue a message so that we can actualy trigger the queue.end call even if we havent received anything.
+    // This helps in the case that we restart client and we are the current proposer.
+    await enqueueEvent(() => logger.info('Start Queue'), 0);
+    // try to sync any missing blockchain state (event queues will be paused until this finishes)
+    initialBlockSync(proposer);
     app.listen(80);
   } catch (err) {
     logger.error(err);

--- a/nightfall-optimist/src/services/state-sync.mjs
+++ b/nightfall-optimist/src/services/state-sync.mjs
@@ -103,7 +103,11 @@ export default async proposer => {
   const lastBlockNumberL2 = Number(
     (await stateContractInstance.methods.getNumberOfL2Blocks().call()) - 1,
   );
-  if (lastBlockNumberL2 === -1) return null; // The blockchain is empty
+  if (lastBlockNumberL2 === -1) {
+    unpauseQueue(0); // queues are started paused, therefore we need to unpause them before proceeding.
+    unpauseQueue(1);
+    return null; // The blockchain is empty
+  }
   // pause the queues so we stop processing incoming events while we sync
   await Promise.all([pauseQueue(0), pauseQueue(1)]);
   const missingBlocks = await checkBlocks(); // Stores any gaps of missing blocks


### PR DESCRIPTION
Currently,  when we restart optimist, it will resync before it starts listening to events. It: pauses processing of its input queues; replays all existing transactions; restarts processing its queues; subscribes to new events from the point of the last L2 block in its freshly-resynced database.

This can cause errors to display because any transactions which arrived after the last L2 block are played twice.  Optimist will drop the second event, so no harm is done, but it will show an error in the logs.

Additionally, this process is overly complex: we stop processing events in the queues while resyncing.  This means we could simply start our event listeners as our first action;  they won't hurt the resync because any events they hear will just join the queue and wait until the resync is completed.  At that point the queue will start moving again and they'll be processed. Thus there is no need for the complex 'start-listening-from-where-the-resync-stopped', at all.

This PR starts the event listeners as soon as the container is up.

Testing is a little tricky.  Fire up the browser locally and make a set of transactions to give some complete blocks.  Then make another transaction _but don't press 'send'_.
In a terminal remove the optimist1 container: `docker compose -f docker-compose.yml -f docker-compose.ganache.yml -f docker-compose.stubs.yml -f docker-compose.dev.yml rm optimist1`
Then up it again (same command but replace `rm` with `up`).  You should see the resync happening as `optimist1` comes up.  While the resync is still running, press 'send' to throw in your transaction. When the rsync is finished, you should see your transaction added neatly afterwards, once the queues start moving.