### PR TITLE
fix: margin, typos

### DIFF
--- a/wallet/src/components/BridgeComponent/index.jsx
+++ b/wallet/src/components/BridgeComponent/index.jsx
@@ -495,7 +495,7 @@ const BridgeComponent = () => {
           </div>
           {/* TRANSFER MODE */}
           <div className="transfer_mode">
-            <span className="transfer_mode_text"> Transfer Mode: </span>
+            <span className="transfer_mode_text">Transfer Mode:</span>
             <span className="transfer_bridge_text">
               {txType.charAt(0).toUpperCase() + txType.slice(1)} Bridge
             </span>
@@ -589,7 +589,7 @@ const BridgeComponent = () => {
                 </SpinnerBox>
 
                 <TransferMode>
-                  <h3>Transaction created sucessfully.</h3>
+                  <h3>Transaction created successfully.</h3>
                   <ModalText>Your transfer is ready to send.</ModalText>
                   {/* <a className={styles.footerText}>View on etherscan</a> */}
                   <ContinueTransferButton

--- a/wallet/src/components/BridgeComponent/styles.scss
+++ b/wallet/src/components/BridgeComponent/styles.scss
@@ -559,6 +559,7 @@ $medium: 900px;
 .transfer_mode_text {
   height: 16px;
   left: 571px;  
+  margin-right: 6px;
 
   /* Body/Extra Small */
 

--- a/wallet/src/components/Modals/Bridge/Transfer/index.jsx
+++ b/wallet/src/components/Modals/Bridge/Transfer/index.jsx
@@ -164,7 +164,7 @@ const TransferModal = ({
                 {' '}
                 To minimise the risk of chain reorganisations, your transfer will wait for{' '}
               </span>
-              <span className="text-primary"> 12 block confirmations</span> before being finalized.
+              <span className="text-primary"> 12 block confirmations</span> before being finalised.
             </TransferModeText>
           </TransferMode>
           <Divider />

--- a/wallet/src/components/Modals/sendModal.tsx
+++ b/wallet/src/components/Modals/sendModal.tsx
@@ -696,7 +696,7 @@ const SendModal = (props: SendModalProps): JSX.Element => {
                 <img src={successHand} alt="success hand" />
               </SpinnerBox>
               <div className="transferModeModal" id="Bridge_modal_success">
-                <h3>Transaction created sucessfully.</h3>
+                <h3>Transaction created successfully.</h3>
                 <div className="modalText">Your transfer is ready to send.</div>
                 <ContinueTransferButton
                   id="Bridge_modal_continueTransferButton"


### PR DESCRIPTION
Small PR that adds a margin to the right of `Transfer Mode: ` text and fixes a couple of typos.