### PR TITLE
fix: initialToken couldnt find MATIC due to lowerCase method

### DIFF
--- a/wallet/src/components/BridgeComponent/index.jsx
+++ b/wallet/src/components/BridgeComponent/index.jsx
@@ -137,9 +137,8 @@ const BridgeComponent = () => {
   const initialTx = history?.location?.tokenState?.initialTxType ?? 'deposit';
   const initialToken =
     supportedTokens.find(
-      t => t.address.toLowerCase() === history?.location?.tokenState?.tokenAddress,
+      t => t.address.toLowerCase() === history?.location?.tokenState?.tokenAddress.toLowerCase(),
     ) ?? supportedTokens[0];
-
   const [token, setToken] = useState(initialToken);
   const [txType, setTxType] = useState(initialTx);
   const [transferValue, setTransferValue] = useState('0');


### PR DESCRIPTION
Wrong selected token - MATIC tx. From Nightfall Assets click `Deposit` or `Withdraw` button next to MATIC. Selected token on L2 Bridge defaults to ETH (`supportedTokens[0]`) since `t.address` in _supported-tokens-testnet.ts_ is not lower case.


