### PR TITLE
fix: erc20 test race condition

### DIFF
--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -529,7 +529,7 @@ describe('ERC20 tests', () => {
               fee,
             );
             await emptyL2(nf3Users[0]);
-            await new Promise(resolve => setTimeout(resolve, 15000));
+            await new Promise(resolve => setTimeout(resolve, 30000));
           }
 
           // console.log('withdrawing', trnsferValue * 6);


### PR DESCRIPTION
There is a race condition problem where a transfer needed commitment from prior transaction which has not been written to the client’s database yet. Adding some waiting time solves it. So it is just the test and not the functionality of restricted withdrawals that is broken