### PR TITLE
Better estimating of proposer gas price and gas limit

### DIFF
--- a/cli/lib/constants.mjs
+++ b/cli/lib/constants.mjs
@@ -21,5 +21,9 @@ export const DEFAULT_BLOCK_STAKE = 1;
 export const WEBSOCKET_PING_TIME = 15000;
 
 export const GAS_MULTIPLIER = Number(process.env.GAS_MULTIPLIER) || 2;
-export const GAS = process.env.GAS || 8000000;
+export const GAS_PRICE_MULTIPLIER = Number(process.env.GAS_PRICE_MULTIPLIER) || 2;
+export const GAS = process.env.GAS || 4000000;
 export const GAS_PRICE = process.env.GAS_PRICE || '20000000000';
+export const GAS_ESTIMATE_ENDPOINT =
+  process.env.GAS_ESTIMATE_ENDPOINT ||
+  'https://vqxy02tr5e.execute-api.us-east-2.amazonaws.com/production/estimateGas';

--- a/cli/lib/constants.mjs
+++ b/cli/lib/constants.mjs
@@ -23,7 +23,7 @@ export const WEBSOCKET_PING_TIME = 15000;
 export const GAS_MULTIPLIER = Number(process.env.GAS_MULTIPLIER) || 2;
 export const GAS_PRICE_MULTIPLIER = Number(process.env.GAS_PRICE_MULTIPLIER) || 2;
 export const GAS = process.env.GAS || 4000000;
-export const GAS_PRICE = process.env.GAS_PRICE || '20000000000';
+export const GAS_PRICE = process.env.GAS_PRICE || '10000000000';
 export const GAS_ESTIMATE_ENDPOINT =
   process.env.GAS_ESTIMATE_ENDPOINT ||
   'https://vqxy02tr5e.execute-api.us-east-2.amazonaws.com/production/estimateGas';


### PR DESCRIPTION
fixes #666 

The proposer uses the nf3 class to submit transactions.  The way that this set the gasPrice and gasLimit was quite crude and results in the proposer paying over the odds for gas and using such a high gas limit that there is not enough in the proposer's account to submit the transaction.  This PR fixes that and gives much better values for both.  The strategy used is essentially the same as for the wallet.

For gasPrice:
- it uses Etherescan to get an average value for the last several block.  If that fails...
- it uses web3js to find the gasPrice for the previous block,  If that fails...
- it uses a fixed value (set at 100 GWei, currently).
In each case, the resulting figure is multiplied by a fixed multiplier (`GAS_PRICE_MULTIPLIER`) to give high confidence of a successful transaction.

For gasLimit:
- it uses web3.estimate gas.  If that fails (it often does)...
- it uses a fixed value (set at 4MGas).
In each case, the resulting figure is multiplied by a fixed multiplier (`GAS_MULTIPLIER`) to give high confidence of a successful transaction.

To test.  Use the standard `npm t` test but temporarily edit the `test` script in `package.json` so that `LOG_LEVEL=debug`.  You can then see the gas price and gas limit chosen, as the test proceeds.