### PR TITLE
remove unnecessary deploys

### DIFF
--- a/nightfall-deployer/migrations/2_deploy_upgradeable.js
+++ b/nightfall-deployer/migrations/2_deploy_upgradeable.js
@@ -29,8 +29,6 @@ module.exports = async function (deployer) {
   await deployer.deploy(ChallengesUtil);
   await deployer.link(ChallengesUtil, Challenges);
 
-  // await deployProxy(Structures, [], { deployer, unsafeAllowLinkedLibraries: true });
-  // await deployProxy(Config, [], { deployer, unsafeAllowLinkedLibraries: true });
   await deployProxy(Proposers, [], { deployer, unsafeAllowLinkedLibraries: true });
   await deployProxy(Challenges, [], { deployer, unsafeAllowLinkedLibraries: true });
   await deployProxy(Shield, [], { deployer, unsafeAllowLinkedLibraries: true });

--- a/nightfall-deployer/migrations/2_deploy_upgradeable.js
+++ b/nightfall-deployer/migrations/2_deploy_upgradeable.js
@@ -29,8 +29,8 @@ module.exports = async function (deployer) {
   await deployer.deploy(ChallengesUtil);
   await deployer.link(ChallengesUtil, Challenges);
 
-  await deployProxy(Structures, [], { deployer, unsafeAllowLinkedLibraries: true });
-  await deployProxy(Config, [], { deployer, unsafeAllowLinkedLibraries: true });
+  // await deployProxy(Structures, [], { deployer, unsafeAllowLinkedLibraries: true });
+  // await deployProxy(Config, [], { deployer, unsafeAllowLinkedLibraries: true });
   await deployProxy(Proposers, [], { deployer, unsafeAllowLinkedLibraries: true });
   await deployProxy(Challenges, [], { deployer, unsafeAllowLinkedLibraries: true });
   await deployProxy(Shield, [], { deployer, unsafeAllowLinkedLibraries: true });


### PR DESCRIPTION
We deploy `Structures.sol` and `Config.sol` but it's unnecessary.  These contracts are inherited by several other contracts but they're never called by anything.