### PR TITLE
avoid storing redundant tx from blockpropose event

### DIFF
--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -98,7 +98,6 @@ async function blockProposedEventHandler(data, syncing) {
   });
 
   await Promise.all(dbUpdates).then(async updateReturn => {
-
     // only save block if any transaction in it is saved/stored to db
     const saveBlockToDb = updateReturn.map(d => d[0]);
     if (saveBlockToDb.includes(true)) {

--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -98,6 +98,8 @@ async function blockProposedEventHandler(data, syncing) {
   });
 
   await Promise.all(dbUpdates).then(async updateReturn => {
+
+    // only save block if any transaction in it is saved/stored to db
     const saveBlockToDb = updateReturn.map(d => d[0]);
     if (saveBlockToDb.includes(true)) {
       await saveBlock({ blockNumber: currentBlockCount, transactionHashL1, ...block });

--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -75,15 +75,16 @@ async function blockProposedEventHandler(data, syncing) {
       saveTxToDb = true;
     }
 
-    if (saveTxToDb) await saveTransaction({
-      transactionHashL1,
-      blockNumber: data.blockNumber,
-      blockNumberL2: block.blockNumberL2,
-      ...transaction
-    }).catch(function (err) {
-      if (!syncing || !err.message.includes('replay existing transaction')) throw err;
-      logger.warn('Attempted to replay existing transaction. This is expected while syncing');
-    });
+    if (saveTxToDb)
+      await saveTransaction({
+        transactionHashL1,
+        blockNumber: data.blockNumber,
+        blockNumberL2: block.blockNumberL2,
+        ...transaction,
+      }).catch(function (err) {
+        if (!syncing || !err.message.includes('replay existing transaction')) throw err;
+        logger.warn('Attempted to replay existing transaction. This is expected while syncing');
+      });
 
     return Promise.all([
       saveTxToDb,

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -61,6 +61,14 @@ export async function countCommitments(commitments) {
   return db.collection(COMMITMENTS_COLLECTION).countDocuments(query);
 }
 
+// function to get count of nullifier. Can also be used to check if it exists
+export async function countNullifiers(nullifiers) {
+  const connection = await mongo.connection(MONGO_URL);
+  const query = { nullifier: { $in: nullifiers } };
+  const db = connection.db(COMMITMENTS_DB);
+  return db.collection(COMMITMENTS_COLLECTION).countDocuments(query);
+}
+
 // // function to get count of transaction hashes. Used to decide if we should store
 // // incoming blocks or transactions.
 // export async function countTransactionHashes(transactionHashes) {

--- a/nightfall-client/src/services/commitment-sync.mjs
+++ b/nightfall-client/src/services/commitment-sync.mjs
@@ -34,9 +34,11 @@ export async function decryptCommitment(transaction, zkpPrivateKey, nullifierKey
       logger.info("This encrypted message isn't for this recipient");
     }
   });
-  await Promise.all(storeCommitments).catch(function (err) {
-    logger.info(err);
-  });
+
+  if (storeCommitments.length === 0) {
+    throw Error("This encrypted message isn't for any of recipients");
+  }
+  return Promise.all(storeCommitments);
 }
 
 /**

--- a/wallet/src/nightfall-browser/event-handlers/block-proposed.js
+++ b/wallet/src/nightfall-browser/event-handlers/block-proposed.js
@@ -33,18 +33,10 @@ async function blockProposedEventHandler(data, ivks, nsks) {
   console.log(`Received Block Proposed event: ${JSON.stringify(data)}`);
   // ivk will be used to decrypt secrets whilst nsk will be used to calculate nullifiers for commitments and store them
   const { blockNumber: currentBlockCount, transactionHash: transactionHashL1 } = data;
-  // const { transactions, block } = await getProposeBlockCalldata(data);
   const { transactions, block, blockTimestamp } = data;
   const latestTree = await getTreeByBlockNumberL2(block.blockNumberL2 - 1);
   const blockCommitments = transactions.map(t => t.commitments.filter(c => c !== ZERO)).flat();
-
-  if ((await countTransactionHashes(block.transactionHashes)) > 0) {
-    await saveBlock({
-      blockNumber: currentBlockCount,
-      transactionHashL1,
-      ...block,
-    });
-  }
+  let isTxDecrypt = false;
 
   const dbUpdates = transactions.map(async transaction => {
     // filter out non zero commitments and nullifiers
@@ -68,6 +60,7 @@ async function blockProposedEventHandler(data, ivks, nsks) {
           if (Object.keys(commitment).length === 0)
             logger.info("This encrypted message isn't for this recipient");
           else {
+            isTxDecrypt = true;
             storeCommitments.push(storeCommitment(commitment, nsks[i]));
             tempTransactionStore.push(
               saveTransaction({
@@ -105,6 +98,15 @@ async function blockProposedEventHandler(data, ivks, nsks) {
 
   // await Promise.all(toStore);
   await Promise.all(dbUpdates);
+
+  if (isTxDecrypt || (await countTransactionHashes(block.transactionHashes)) > 0) {
+    await saveBlock({
+      blockNumber: currentBlockCount,
+      transactionHashL1,
+      ...block,
+    });
+  }
+
   const updatedTimber = Timber.statelessUpdate(
     latestTree,
     blockCommitments,


### PR DESCRIPTION
this PR for now fixes wallet/browser and nightfall_client
- only storing relevant transaction
- also only storing block object for which any transaction is stored to db

fixes #667 