### PR TITLE
Value calculation with bigint and bigfloat

### DIFF
--- a/wallet/src/components/TokenItem/index.jsx
+++ b/wallet/src/components/TokenItem/index.jsx
@@ -6,6 +6,7 @@ import { getWalletBalance } from '@Nightfall/services/commitment-storage';
 import metamaskIcon from '../../assets/svg/metamask.svg';
 import { UserContext } from '../../hooks/User/index.jsx';
 import SendModal from '../Modals/sendModal';
+import BigFloat from '../../common-files/classes/bigFloat';
 
 import '../../styles/tokenItem.scss';
 
@@ -63,18 +64,16 @@ export default function TokenItem(props) {
           <div className="balancesDetails">
             <div className="balancesWrapper">
               <div className="balancesDetailsUpperSection" id={tokenBalanceId}>
-                {(Number(props.l2Balance) / 10 ** Number(props.decimals)).toFixed(4)}
+                {new BigFloat(BigInt(props.l2Balance), props.decimals).toFixed(4)}
               </div>
               <div className="balancesDetailsLowerSection">
                 <span className="seperatingDot" id={tokenBalanceUsdId}>
                   {' '}
                   •{' '}
                 </span>
-                $
-                {(
-                  Number(props.currencyValue) *
-                  (Number(props.l2Balance) / 10 ** props.decimals)
-                ).toFixed(4)}
+                {'$' + new BigFloat(BigInt(props.l2Balance), props.decimals)
+                          .mul(props.currencyValue)
+                          .toFixed(4)}
               </div>
             </div>
           </div>

--- a/wallet/src/components/TokenItem/index.jsx
+++ b/wallet/src/components/TokenItem/index.jsx
@@ -71,9 +71,10 @@ export default function TokenItem(props) {
                   {' '}
                   •{' '}
                 </span>
-                {'$' + new BigFloat(BigInt(props.l2Balance), props.decimals)
-                          .mul(props.currencyValue)
-                          .toFixed(4)}
+                $
+                {new BigFloat(BigInt(props.l2Balance), props.decimals)
+                  .mul(props.currencyValue)
+                  .toFixed(4)}
               </div>
             </div>
           </div>

--- a/wallet/src/components/Transactions/index.jsx
+++ b/wallet/src/components/Transactions/index.jsx
@@ -15,7 +15,7 @@ import './index.scss';
 import { getContractInstance } from '../../common-files/utils/contract';
 import useInterval from '../../hooks/useInterval';
 import { getPricing, setPricing, shieldAddressGet } from '../../utils/lib/local-storage';
-// import BigFloat from '../../common-files/classes/bigFloat';
+import BigFloat from '../../common-files/classes/bigFloat';
 
 const supportedTokens = importTokens();
 
@@ -219,8 +219,7 @@ const Transactions = () => {
                     show: true,
                     transactionhash: tx.transactionHash,
                     symbol: tx.symbol,
-                    // value: new BigFloat(BigInt(tx.value), tx.decimals).toFixed(4),
-                    value: (Number(tx.value) / 10 ** tx.decimals).toFixed(4),
+                    value: new BigFloat(BigInt(tx.value), tx.decimals).toFixed(4),
                     _id: tx._id,
                     recipientaddress: tx.recipientAddress,
                     withdrawready: tx.withdrawReady ? 1 : 0,
@@ -290,8 +289,7 @@ const Transactions = () => {
                     >
                       {/* amount-details */}
                       <div style={{ fontWeight: '600', fontSize: '14px', lineHeight: '20px' }}>
-                        {/* {new BigFloat(BigInt(tx.value), tx.decimals).toFixed(4)} {tx.symbol} */}
-                        {(Number(tx.value) / 10 ** tx.decimals).toFixed(4)} {tx.symbol}
+                        {new BigFloat(BigInt(tx.value), tx.decimals).toFixed(4)} {tx.symbol}
                       </div>
                       <div
                         style={{
@@ -303,10 +301,9 @@ const Transactions = () => {
                           lineHeight: '16px',
                         }}
                       >
-                        $ {((Number(tx.value) / 10 ** tx.decimals) * tx.currencyValue).toFixed(4)}
-                        {/* {new BigFloat(BigInt(tx.value), tx.decimals)
+                        {'$' + new BigFloat(BigInt(tx.value), tx.decimals)
                           .mul(tx.currencyValue)
-                          .toFixed(4)} */}
+                          .toFixed(4)}
                       </div>
                     </div>
                     <div

--- a/wallet/src/components/Transactions/index.jsx
+++ b/wallet/src/components/Transactions/index.jsx
@@ -301,7 +301,8 @@ const Transactions = () => {
                           lineHeight: '16px',
                         }}
                       >
-                        {'$' + new BigFloat(BigInt(tx.value), tx.decimals)
+                        $
+                        {new BigFloat(BigInt(tx.value), tx.decimals)
                           .mul(tx.currencyValue)
                           .toFixed(4)}
                       </div>


### PR DESCRIPTION
The gas calculation has already been fixed previously:
line: 255 file: wallet/src/components/BridgeComponent/index.jsx
line: 289 file: wallet/src/components/BridgeComponent/index.jsx

In this pr the calculation of the amounts displayed in the wallet was changed, using bigint and bigfloat, making it consistent with the gas calculation
