### PR TITLE
Remove dev option in start-client

### DIFF
--- a/nightfall-client/README.md
+++ b/nightfall-client/README.md
@@ -53,15 +53,7 @@ To run the script with existing images of the different services based on the
 ./start-client
 ```
 
-A developer who is adding some functionality or fixing some bug in the `nightfall-client` repository
-should run the script in development mode with the changes in his local `nightfall-client`
-repository with binding his local files:
-
-```
-./start-client -d
-```
-
-Also for development purposes you can pass CIRCUIT_FILES_URL and CONTRACT_FILES_URL.
+For development purposes you can pass CIRCUIT_FILES_URL and CONTRACT_FILES_URL.
 
 ```
 CIRCUIT_FILES_URL=url of the repository for the circuit files

--- a/nightfall-client/start-client
+++ b/nightfall-client/start-client
@@ -10,19 +10,16 @@ else
 fi
 
 VOLUME_LIST=$(docker volume ls -q)
-FILE="-f ../docker-compose.client.yml"
+FILE="-f ../docker-compose.client.yml -f ../docker-compose.client.dev.yml"
 
 usage()
 {
   echo "Usage:"
-  echo "  -d or --dev; to bind mount the filesystem and use it for development"
   echo "  -r; to remove existing volumes for mongodb and abi contracts"
 }
 
 while [ -n "$1" ]; do
   case $1 in
-      -d  | --dev )                 DEV="-f ../docker-compose.client.dev.yml"
-                                    ;;
       -r )                          REMOVE_VOLUMES="true"
                                     ;;
       -h  | --help )                usage


### PR DESCRIPTION
Remove `-d` option in start-client and always run as dev mode building the client from the nightfall-client files of the local repository.