### PR TITLE
Invalid Duplicate Nullifier Challenge Can Pass

### DIFF
--- a/nightfall-deployer/contracts/ChallengesUtil.sol
+++ b/nightfall-deployer/contracts/ChallengesUtil.sol
@@ -230,7 +230,8 @@ library ChallengesUtil {
         uint256 nullifierIndex2
     ) public pure {
         require(
-            tx1.nullifiers[nullifierIndex1] == tx2.nullifiers[nullifierIndex2],
+            tx1.nullifiers[nullifierIndex1] != 0 &&
+                tx1.nullifiers[nullifierIndex1] == tx2.nullifiers[nullifierIndex2],
             'Not matching nullifiers'
         );
         require(


### PR DESCRIPTION
The function libChallengeNullifier performs a duplicate nullifier challenge to prevent double spending by challenging two duplicate nullifiers from two different transactions. If either of the two transactions has a zero nullifier, which is valid for some types of transactions, the challenge would still pass. The proposer is slashed and the challenger is rewarded for an invalid challenge.

Solution:
Added a check to verify that either one of the nullifiers is non-zero:
require(tx1.nullifiers[nullifierIndex1]!=0 && tx1.nullifiers[nullifierIndex1] == tx2.nullifiers[nullifierIndex2],'Not matching nullifiers')