### PR TITLE
Save invalid blocks in optimist database

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -17,6 +17,7 @@ module.exports = {
   CHALLENGER_COLLECTION: 'challengers',
   TRANSACTIONS_COLLECTION: 'transactions',
   SUBMITTED_BLOCKS_COLLECTION: 'blocks',
+  INVALID_BLOCKS_COLLECTION: 'invalid_blocks',
   NULLIFIER_COLLECTION: 'nullifiers',
   COMMIT_COLLECTION: 'commits',
   WALLETS_COLLECTION: 'wallets',

--- a/nightfall-optimist/src/event-handlers/block-proposed.mjs
+++ b/nightfall-optimist/src/event-handlers/block-proposed.mjs
@@ -13,6 +13,7 @@ import {
   getLatestTree,
   saveTree,
   getTransactionByTransactionHash,
+  saveInvalidBlock,
 } from '../services/database.mjs';
 import { getProposeBlockCalldata } from '../services/process-calldata.mjs';
 import { increaseBlockInvalidCounter } from '../services/debug-counters.mjs';
@@ -114,6 +115,13 @@ async function blockProposedEventHandler(data) {
       // This message will not be printed because event dequeuing does not run the job.
       // This is fine as we are just using it to stop running.
       increaseBlockInvalidCounter();
+      saveInvalidBlock({
+        invalidCode: err.code,
+        invalidMessage: err.message,
+        blockNumber: currentBlockCount,
+        transactionHashL1,
+        ...block,
+      });
       await enqueueEvent(() => logger.info('Stop Until Rollback'), 2);
       await createChallenge(block, transactions, err);
     } else {

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -15,6 +15,7 @@ const {
   PROPOSER_COLLECTION,
   CHALLENGER_COLLECTION,
   SUBMITTED_BLOCKS_COLLECTION,
+  INVALID_BLOCKS_COLLECTION,
   NULLIFIER_COLLECTION,
   COMMIT_COLLECTION,
   TIMBER_COLLECTION,
@@ -208,6 +209,20 @@ export async function findBlocksFromBlockNumberL2(blockNumberL2) {
     .collection(SUBMITTED_BLOCKS_COLLECTION)
     .find(query, { sort: { blockNumberL2: 1 } })
     .toArray();
+}
+
+/**
+function to save an invalid block, so that we can later search the invalid block
+and the type of invalid block.
+*/
+export async function saveInvalidBlock(_block) {
+  const block = { _id: _block.blockHash, ..._block };
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  logger.debug(`saving invalid block ${JSON.stringify(block, null, 2)}`);
+  const query = { blockHash: block.blockHash };
+  const update = { $set: block };
+  return db.collection(INVALID_BLOCKS_COLLECTION).updateOne(query, update, { upsert: true });
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "doc:build:sdk": "jsdoc -c jsdoc.json cli/lib/nf3.mjs",
     "build-adversary": "node test/adversary/transpile-adversary.mjs",
     "adversary-test": "CHALLENGE_TYPE=${CHALLENGE_TYPE} mocha --timeout 0 --bail --exit test/adversary.test.mjs",
-    "adversary-test-all": "for CHALLENGE_TYPE in IncorrectTreeRoot IncorrectLeafCount DuplicateTransaction DuplicateNullifier HistoricRootError IncorrectProof; do CHALLENGE_TYPE=${CHALLENGE_TYPE} mocha --timeout 0 --bail --exit test/adversary.test.mjs; sleep 5; done",
+    "adversary-test-all": "for CHALLENGE_TYPE in IncorrectTreeRoot IncorrectLeafCount IncorrectTreeRoot IncorrectLeafCount; do CHALLENGE_TYPE=${CHALLENGE_TYPE} mocha --timeout 0 --bail --exit test/adversary.test.mjs; sleep 5; done",
     "secrets-encryption-test": "mocha --timeout 0 --bail --exit test/encryption.test.mjs"
   },
   "repository": {

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -168,7 +168,10 @@ describe('Testing with an adversary', () => {
       }
 
       for (let i = 0; i < TEST_LENGTH; i++) {
-        await waitForSufficientBalance(nf3User, startBalance + (i + 1) * value2);
+        await waitForSufficientBalance(
+          nf3User,
+          startBalance + (i + 1) * (TRANSACTIONS_PER_BLOCK - 1) * value2,
+        );
         try {
           await nf3User.transfer(
             false,

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -61,6 +61,7 @@ describe('Testing with an adversary', () => {
   const fee = 1;
 
   before(async () => {
+    console.log(`CHALLENGE_TYPE: ${process.env.CHALLENGE_TYPE}`);
     console.log(`TRANSACTIONS_PER_BLOCK: ${TRANSACTIONS_PER_BLOCK}`);
     console.log('ENV:\n', environment);
     nf3User = new Nf3(ethereumSigningKeyUser, environment);
@@ -167,7 +168,7 @@ describe('Testing with an adversary', () => {
       }
 
       for (let i = 0; i < TEST_LENGTH; i++) {
-        await waitForSufficientBalance(nf3User, value2);
+        await waitForSufficientBalance(nf3User, startBalance + (i + 1) * value2);
         try {
           await nf3User.transfer(
             false,
@@ -211,17 +212,13 @@ describe('Testing with an adversary', () => {
       }
 
       // TODO:_ how can i check that queue 2 is empty
-      await waitForSufficientBalance(nf3User, expectedBalance);
-      // waiting sometime to ensure that all the good transactions from bad
-      // blocks were proposed in other good blocks
-      await waitForSufficientBalance(nf3User, expectedBalance);
       await new Promise(resolve => setTimeout(resolve, 20 * TX_WAIT));
       await waitForSufficientBalance(nf3User, expectedBalance);
       const endBalance = await retrieveL2Balance(nf3User);
       console.log(`Completed startBalance`, startBalance);
       console.log(`Completed endBalance`, endBalance);
       logger.debug(`N deposits: ${nDeposits} - N Transfers: ${nTransfers}`);
-      expect(expectedBalance).to.be.equal(endBalance - startBalance);
+      expect(expectedBalance).to.be.equal(endBalance);
     });
 
     it('User should have the correct balance after challenge and a series of rollbacks', async () => {
@@ -232,13 +229,12 @@ describe('Testing with an adversary', () => {
       // blocks were proposed in other good blocks
       console.log('Waiting for rollbacks...');
 
-      await waitForSufficientBalance(nf3User, expectedBalance);
       await new Promise(resolve => setTimeout(resolve, 30 * TX_WAIT));
       await waitForSufficientBalance(nf3User, expectedBalance);
       const endBalance = await retrieveL2Balance(nf3User);
       console.log(`Completed startBalance`, startBalance);
       console.log(`Completed endBalance`, endBalance);
-      expect(expectedBalance).to.be.equal(endBalance - startBalance);
+      expect(expectedBalance).to.be.equal(endBalance);
     });
   });
 


### PR DESCRIPTION
Fixes: #813 

We will store information about invalid blocks in optimist and the type of challenge they generate:

- Created collection `invalid_blocks` in optimist.
- `invalid_blocks` will store this information when an invalid block is detected:
   - invalidCode
   - invalidMessage
   - block data
- Fixed adversary test check balances when calling `npm run adversary-test-all`