### PR TITLE
bit fix

### DIFF
--- a/nightfall-client/src/classes/commitment.mjs
+++ b/nightfall-client/src/classes/commitment.mjs
@@ -34,7 +34,7 @@ class Commitment {
     // we encode the top four bytes of the tokenId into the empty bytes at the top of the erc address.
     // this is consistent to what we do in the ZKP circuits
     const [top4Bytes, remainder] = this.preimage.tokenId.limbs(224, 2).map(l => BigInt(l));
-    const SHIFT = 2923003274661805836407369665432566039311865085952n;
+    const SHIFT = 1461501637330902918203684832716283019655932542976n;
     this.hash = poseidon(
       generalise([
         this.preimage.ercAddress.bigInt + top4Bytes * SHIFT,

--- a/nightfall-deployer/circuits/deposit.zok
+++ b/nightfall-deployer/circuits/deposit.zok
@@ -10,7 +10,7 @@ from "./common/casts/u32_array_to_field.zok" import main as u32_array_to_field
 
 type Point = field[2]
 
-// 2 ^ 161
+// 2 ^ 160
 const field SHIFT = 1461501637330902918203684832716283019655932542976
 
 def main(\

--- a/nightfall-deployer/circuits/deposit.zok
+++ b/nightfall-deployer/circuits/deposit.zok
@@ -11,7 +11,7 @@ from "./common/casts/u32_array_to_field.zok" import main as u32_array_to_field
 type Point = field[2]
 
 // 2 ^ 161
-const field SHIFT = 2923003274661805836407369665432566039311865085952
+const field SHIFT = 1461501637330902918203684832716283019655932542976
 
 def main(\
 	field ercContractAddress,\

--- a/nightfall-deployer/circuits/double_transfer.zok
+++ b/nightfall-deployer/circuits/double_transfer.zok
@@ -15,7 +15,7 @@ from "./common/merkle-tree/path-check.zok" import main as pathCheck
 type Point = field[2]
 
 // 2 ^ 161
-const field SHIFT = 2923003274661805836407369665432566039311865085952
+const field SHIFT = 1461501637330902918203684832716283019655932542976
 
 struct OldCommitmentPreimage {
 	u32[8] id

--- a/nightfall-deployer/circuits/double_transfer.zok
+++ b/nightfall-deployer/circuits/double_transfer.zok
@@ -14,7 +14,7 @@ from "./common/merkle-tree/path-check.zok" import main as pathCheck
 
 type Point = field[2]
 
-// 2 ^ 161
+// 2 ^ 160
 const field SHIFT = 1461501637330902918203684832716283019655932542976
 
 struct OldCommitmentPreimage {

--- a/nightfall-deployer/circuits/single_transfer.zok
+++ b/nightfall-deployer/circuits/single_transfer.zok
@@ -14,7 +14,7 @@ from "./common/casts/u32_array_to_field.zok" import main as u32_array_to_field
 
 type Point = field[2]
 
-// 2 ^ 161
+// 2 ^ 160
 const field SHIFT = 1461501637330902918203684832716283019655932542976
 
 struct OldCommitmentPreimage {

--- a/nightfall-deployer/circuits/single_transfer.zok
+++ b/nightfall-deployer/circuits/single_transfer.zok
@@ -15,7 +15,7 @@ from "./common/casts/u32_array_to_field.zok" import main as u32_array_to_field
 type Point = field[2]
 
 // 2 ^ 161
-const field SHIFT = 2923003274661805836407369665432566039311865085952
+const field SHIFT = 1461501637330902918203684832716283019655932542976
 
 struct OldCommitmentPreimage {
 	u32[8] id

--- a/nightfall-deployer/circuits/withdraw.zok
+++ b/nightfall-deployer/circuits/withdraw.zok
@@ -10,7 +10,7 @@ from "./common/casts/u32_array_to_field.zok" import main as u32_array_to_field
 from "hashes/poseidon/poseidon.zok" import main as poseidon
 from "./common/merkle-tree/path-check.zok" import main as pathCheck
 
-// 2 ^ 161
+// 2 ^ 160
 const field SHIFT = 1461501637330902918203684832716283019655932542976
 
 struct OldCommitmentPreimage {

--- a/nightfall-deployer/circuits/withdraw.zok
+++ b/nightfall-deployer/circuits/withdraw.zok
@@ -11,7 +11,7 @@ from "hashes/poseidon/poseidon.zok" import main as poseidon
 from "./common/merkle-tree/path-check.zok" import main as pathCheck
 
 // 2 ^ 161
-const field SHIFT = 2923003274661805836407369665432566039311865085952
+const field SHIFT = 1461501637330902918203684832716283019655932542976
 
 struct OldCommitmentPreimage {
 	field salt


### PR DESCRIPTION
The Poseidon hash code incorrectly encodes the top four bytes of the `tokenId` at bit 161 (*2^161) in the ERC address field.  This should of course be at bit 160 (*2^160). This PR fixes that.