### PR TITLE
correctly handle error produced when double transfer matches sum of commitments' values

### DIFF
--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -685,6 +685,8 @@ async function findUsableCommitments(compressedZkpPublicKey, ercAddress, tokenId
     logger.info(
       `Found commitments suitable for two-token transfer: ${JSON.stringify(commitmentsToUse)}`,
     );
+  } else {
+    return null;
   }
   await Promise.all(commitmentsToUse.map(commitment => markPending(commitment)));
   return commitmentsToUse;


### PR DESCRIPTION
Fix #836 

When double transfer value matches sum of both commitments, there is a 500 error. This PR fixes that and returns `null` (No commitments found).