### PR TITLE
remove escrow transfer function and admin bugfix

### DIFF
--- a/nightfall-administrator/src/services/contract-transactions.mjs
+++ b/nightfall-administrator/src/services/contract-transactions.mjs
@@ -2,7 +2,7 @@ import config from 'config';
 import { waitForContract, web3 } from '../../../common-files/utils/contract.mjs';
 import logger from '../../../common-files/utils/logger.mjs';
 import constants from '../../../common-files/constants/index.mjs';
-import { addMultiSigSignature, getTokenAddress } from './helpers.mjs';
+import { addMultiSigSignature } from './helpers.mjs';
 
 const { RESTRICTIONS } = config;
 const { SHIELD_CONTRACT_NAME } = constants;
@@ -86,22 +86,6 @@ export function unpauseContracts(signingKey, executorAddress, nonce) {
         nonce,
       );
     }),
-  );
-}
-
-export async function transferShieldBalance(tokenName, amount, signingKey, executorAddress, nonce) {
-  const tokenAddress = getTokenAddress(tokenName);
-  if (tokenAddress === 'unknown') throw new Error('Unknown token name');
-  const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
-  const data = shieldContractInstance.methods
-    .transferShieldBalance(tokenAddress, amount)
-    .encodeABI();
-  return addMultiSigSignature(
-    data,
-    signingKey,
-    shieldContractInstance.options.address,
-    executorAddress,
-    nonce,
   );
 }
 

--- a/nightfall-administrator/src/services/contract-transactions.mjs
+++ b/nightfall-administrator/src/services/contract-transactions.mjs
@@ -25,14 +25,15 @@ export async function setTokenRestrictions(
       const data = shieldContractInstance.methods
         .setRestriction(token.address, depositRestriction, withdrawRestriction)
         .encodeABI();
-      const temp = addMultiSigSignature(
-        data,
-        signingKey,
-        shieldContractInstance.options.address,
-        executorAddress,
-        nonce,
-      );
-      return temp;
+      return Promise.all([
+        addMultiSigSignature(
+          data,
+          signingKey,
+          shieldContractInstance.options.address,
+          executorAddress,
+          nonce,
+        ),
+      ]);
     }
   }
   return false;
@@ -43,13 +44,15 @@ export async function removeTokenRestrictions(tokenName, signingKey, executorAdd
   for (const token of RESTRICTIONS.tokens[process.env.ETH_NETWORK]) {
     if (token.name === tokenName) {
       const data = shieldContractInstance.methods.removeRestriction(token.address).encodeABI();
-      return addMultiSigSignature(
-        data,
-        signingKey,
-        shieldContractInstance.options.address,
-        executorAddress,
-        nonce,
-      );
+      return Promise.all([
+        addMultiSigSignature(
+          data,
+          signingKey,
+          shieldContractInstance.options.address,
+          executorAddress,
+          nonce,
+        ),
+      ]);
     }
   }
   return false;
@@ -58,7 +61,7 @@ export async function removeTokenRestrictions(tokenName, signingKey, executorAdd
 export function pauseContracts(signingKey, executorAddress, nonce) {
   logger.info('All pausable contracts being paused');
   return Promise.all(
-    pausables.map(async pausable => {
+    pausables.map(async (pausable, i) => {
       const contractInstance = await waitForContract(pausable);
       const data = contractInstance.methods.pause().encodeABI();
       return addMultiSigSignature(
@@ -66,7 +69,7 @@ export function pauseContracts(signingKey, executorAddress, nonce) {
         signingKey,
         contractInstance.options.address,
         executorAddress,
-        nonce,
+        nonce + i,
       );
     }),
   );
@@ -75,7 +78,7 @@ export function pauseContracts(signingKey, executorAddress, nonce) {
 export function unpauseContracts(signingKey, executorAddress, nonce) {
   logger.info('All pausable contracts being unpaused');
   return Promise.all(
-    pausables.map(async pausable => {
+    pausables.map(async (pausable, i) => {
       const contractInstance = await waitForContract(pausable);
       const data = contractInstance.methods.unpause().encodeABI();
       return addMultiSigSignature(
@@ -83,7 +86,7 @@ export function unpauseContracts(signingKey, executorAddress, nonce) {
         signingKey,
         contractInstance.options.address,
         executorAddress,
-        nonce,
+        nonce + i,
       );
     }),
   );
@@ -92,7 +95,7 @@ export function unpauseContracts(signingKey, executorAddress, nonce) {
 export function transferOwnership(newOwnerPrivateKey, signingKey, executorAddress, nonce) {
   const newOwner = web3.eth.accounts.privateKeyToAccount(newOwnerPrivateKey, true).address;
   return Promise.all(
-    pausables.map(async pausable => {
+    pausables.map(async (pausable, i) => {
       const contractInstance = await waitForContract(pausable);
       const data = contractInstance.methods.transferOwnership(newOwner).encodeABI();
       return addMultiSigSignature(
@@ -100,7 +103,7 @@ export function transferOwnership(newOwnerPrivateKey, signingKey, executorAddres
         signingKey,
         contractInstance.options.address,
         executorAddress,
-        nonce,
+        nonce + i,
       );
     }),
   );
@@ -110,13 +113,15 @@ export async function setBootProposer(newProposerPrivateKey, signingKey, executo
   const newProposer = web3.eth.accounts.privateKeyToAccount(newProposerPrivateKey, true).address;
   const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
   const data = shieldContractInstance.methods.setBootProposer(newProposer).encodeABI();
-  return addMultiSigSignature(
-    data,
-    signingKey,
-    shieldContractInstance.options.address,
-    executorAddress,
-    nonce,
-  );
+  return Promise.all([
+    addMultiSigSignature(
+      data,
+      signingKey,
+      shieldContractInstance.options.address,
+      executorAddress,
+      nonce,
+    ),
+  ]);
 }
 
 export async function setBootChallenger(
@@ -132,11 +137,13 @@ export async function setBootChallenger(
   console.log('BOOT CHALLENGER', newChallenger);
   const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
   const data = shieldContractInstance.methods.setBootChallenger(newChallenger).encodeABI();
-  return addMultiSigSignature(
-    data,
-    signingKey,
-    shieldContractInstance.options.address,
-    executorAddress,
-    nonce,
-  );
+  return Promise.all([
+    addMultiSigSignature(
+      data,
+      signingKey,
+      shieldContractInstance.options.address,
+      executorAddress,
+      nonce,
+    ),
+  ]);
 }

--- a/nightfall-administrator/src/services/helpers.mjs
+++ b/nightfall-administrator/src/services/helpers.mjs
@@ -95,7 +95,7 @@ export async function addMultiSigSignature(
     contractAddress,
     0,
     unsignedTransactionData,
-    nonce,
+    nonce, // eslint-disable-line no-param-reassign
     executorAddress,
     WEB3_OPTIONS.gas,
   );
@@ -143,10 +143,13 @@ export function verifyTransactions(transactions) {
     return false;
   }
   if (!Array.isArray(parsed)) return false;
-  for (const el of parsed) {
-    if (!el.v || !el.r || !el.s) return false;
-    if (!el.messageHash) return false;
-    if (!el.by || !el.contractAddress || !el.data) return false;
+  for (const elt of parsed) {
+    if (!Array.isArray(elt)) return false;
+    for (const el of elt) {
+      if (!el.v || !el.r || !el.s) return false;
+      if (!el.messageHash) return false;
+      if (!el.by || !el.contractAddress || !el.data) return false;
+    }
   }
   return parsed;
 }

--- a/nightfall-administrator/src/services/helpers.mjs
+++ b/nightfall-administrator/src/services/helpers.mjs
@@ -18,13 +18,6 @@ export function getTokenNames() {
   return tokenNames;
 }
 
-export function getTokenAddress(tokenName) {
-  for (const token of RESTRICTIONS.tokens[process.env.ETH_NETWORK]) {
-    if (token.name === tokenName) return token.address;
-  }
-  return 'unknown';
-}
-
 async function sendTransaction(unsignedTransaction, signingKey, contractAddress) {
   const tx = {
     from: web3.eth.accounts.privateKeyToAccount(signingKey).address,

--- a/nightfall-administrator/src/ui/get-info.mjs
+++ b/nightfall-administrator/src/ui/get-info.mjs
@@ -7,7 +7,6 @@ import {
   removeTokenRestrictions,
   pauseContracts,
   unpauseContracts,
-  transferShieldBalance,
   transferOwnership,
   setBootProposer,
   setBootChallenger,
@@ -34,7 +33,6 @@ async function start() {
     withdrawRestriction,
     pause,
     unpause,
-    amount,
     newEthereumSigningKey,
     executorAddress,
     nonce,
@@ -78,15 +76,6 @@ async function start() {
       case 'Pause contracts': {
         if (!pause) break;
         approved = await pauseContracts(ethereumSigningKey, executorAddress);
-        break;
-      }
-      case 'Transfer Shield contract balance': {
-        approved = await transferShieldBalance(
-          tokenName,
-          Number(amount),
-          ethereumSigningKey,
-          executorAddress,
-        );
         break;
       }
       case 'Transfer ownership': {

--- a/nightfall-administrator/src/ui/menu.mjs
+++ b/nightfall-administrator/src/ui/menu.mjs
@@ -38,7 +38,7 @@ export async function askQuestions(approved) {
       name: 'workflow',
       type: 'list',
       message: 'Add an existing signed transaction or create a new one?',
-      choices: ['add', 'create'],
+      choices: ['add', 'create', 'get nonce'],
       when: () => !approved,
     },
     {

--- a/nightfall-administrator/src/ui/menu.mjs
+++ b/nightfall-administrator/src/ui/menu.mjs
@@ -75,7 +75,6 @@ export async function askQuestions(approved) {
         'Remove token restrictions',
         'Pause contracts',
         'Unpause contracts',
-        'Transfer Shield contract balance',
         'Transfer ownership',
         'Set new boot proposer',
         'Set new boot challenger',

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -34,16 +34,6 @@ contract Shield is Stateful, Config, Key_Registry, ReentrancyGuardUpgradeable, P
         Pausable.initialize();
     }
 
-    function transferShieldBalance(address ercAddress, uint256 value) public onlyOwner {
-        if (value == uint256(0)) {
-            uint256 balance = IERC20Upgradeable(ercAddress).balanceOf(address(this));
-            IERC20Upgradeable(ercAddress).safeTransfer(owner(), balance);
-        } else {
-            IERC20Upgradeable(ercAddress).safeTransfer(owner(), value);
-        }
-        emit ShieldBalanceTransferred(ercAddress, value);
-    }
-
     function submitTransaction(Transaction memory t) external payable nonReentrant whenNotPaused {
         // let everyone know what you did
         emit TransactionSubmitted();


### PR DESCRIPTION
fixes #835 

This PR removes the ability to transfer funds from the Shield escrow pools. It's no longer required as withdrawals can be paused in the event of an emergency.

It also fixes a bug in the administrator container whereby actions that required more than one function call to the blockchain were not correctly handled.

There is no specific test for the removal of the transfer function (because it was not tested in any case).  The normal test suite suffices.  To test the administrator function, refer to the instructions [here](https://github.com/EYBlockchain/nightfall_3/blob/westlad/escrow-removal/nightfall-administrator/README.md)