### PR TITLE
fix: change the query by compressedZkpPublicKeys based in the last me…

### DIFF
--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -720,7 +720,7 @@ export async function getCommitmentsByCompressedZkpPublicKeyList(listOfCompresse
   const commitmentsByListOfCompressedZkpPublicKey = await db
     .collection(COMMITMENTS_COLLECTION)
     .find({
-      'preimage.compressedZkpPublicKey': { $in: listOfCompressedZkpPublicKey },
+      compressedZkpPublicKey: { $in: listOfCompressedZkpPublicKey },
     })
     .toArray();
   return commitmentsByListOfCompressedZkpPublicKey;


### PR DESCRIPTION
### What was done?
This commit just change the query for get commitments by compressed Zkp Public Key, based in the last changes did in these names.