### PR TITLE
ErcAddress and fee address check 

### DIFF
--- a/nightfall-client/src/services/transfer.mjs
+++ b/nightfall-client/src/services/transfer.mjs
@@ -50,7 +50,9 @@ async function transfer(transferParams) {
 
   const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
 
-  const maticAddress = generalise(await shieldContractInstance.methods.getMaticAddress().call());
+  const maticAddress = generalise(
+    (await shieldContractInstance.methods.getMaticAddress().call()).toLowerCase(),
+  );
 
   logger.debug(
     `The erc address of the token transferred is the following: ${ercAddress
@@ -58,9 +60,7 @@ async function transfer(transferParams) {
       .toLowerCase()}`,
   );
 
-  logger.debug(
-    `The erc address of the fee is the following: ${maticAddress.hex(32).toLowerCase()}`,
-  );
+  logger.debug(`The erc address of the fee is the following: ${maticAddress.hex(32)}`);
   const addedFee =
     maticAddress.hex(32).toLowerCase() === ercAddress.hex(32).toLowerCase() ? fee.bigInt : 0n;
 

--- a/nightfall-client/src/services/transfer.mjs
+++ b/nightfall-client/src/services/transfer.mjs
@@ -50,11 +50,19 @@ async function transfer(transferParams) {
 
   const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
 
-  const maticAddress = generalise(
-    (await shieldContractInstance.methods.getMaticAddress().call()).toLowerCase(),
+  const maticAddress = generalise(await shieldContractInstance.methods.getMaticAddress().call());
+
+  logger.debug(
+    `The erc address of the token transferred is the following: ${ercAddress
+      .hex(32)
+      .toLowerCase()}`,
   );
 
-  const addedFee = maticAddress.hex(32) === ercAddress.hex(32) ? fee.bigInt : 0n;
+  logger.debug(
+    `The erc address of the fee is the following: ${maticAddress.hex(32).toLowerCase()}`,
+  );
+  const addedFee =
+    maticAddress.hex(32).toLowerCase() === ercAddress.hex(32).toLowerCase() ? fee.bigInt : 0n;
 
   const totalValueToSend = values.reduce((acc, value) => acc + value.bigInt, 0n);
   const commitmentsInfo = await getCommitmentInfo({

--- a/nightfall-client/src/services/withdraw.mjs
+++ b/nightfall-client/src/services/withdraw.mjs
@@ -43,11 +43,17 @@ async function withdraw(withdrawParams) {
 
   const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
 
-  const maticAddress = generalise(
-    (await shieldContractInstance.methods.getMaticAddress().call()).toLowerCase(),
+  const maticAddress = generalise(await shieldContractInstance.methods.getMaticAddress().call());
+
+  logger.debug(
+    `The erc address of the token withdrawn is the following: ${ercAddress.hex(32).toLowerCase()}`,
   );
 
-  const addedFee = maticAddress.hex(32) === ercAddress.hex(32) ? fee.bigInt : 0n;
+  logger.debug(
+    `The erc address of the fee is the following: ${maticAddress.hex(32).toLowerCase()}`,
+  );
+  const addedFee =
+    maticAddress.hex(32).toLowerCase() === ercAddress.hex(32).toLowerCase() ? fee.bigInt : 0n;
 
   const withdrawValue = value.bigInt > MAX_WITHDRAW ? MAX_WITHDRAW : value;
 

--- a/nightfall-client/src/services/withdraw.mjs
+++ b/nightfall-client/src/services/withdraw.mjs
@@ -43,15 +43,15 @@ async function withdraw(withdrawParams) {
 
   const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
 
-  const maticAddress = generalise(await shieldContractInstance.methods.getMaticAddress().call());
+  const maticAddress = generalise(
+    (await shieldContractInstance.methods.getMaticAddress().call()).toLowerCase(),
+  );
 
   logger.debug(
     `The erc address of the token withdrawn is the following: ${ercAddress.hex(32).toLowerCase()}`,
   );
 
-  logger.debug(
-    `The erc address of the fee is the following: ${maticAddress.hex(32).toLowerCase()}`,
-  );
+  logger.debug(`The erc address of the fee is the following: ${maticAddress.hex(32)}`);
   const addedFee =
     maticAddress.hex(32).toLowerCase() === ercAddress.hex(32).toLowerCase() ? fee.bigInt : 0n;
 


### PR DESCRIPTION
This PR addresses a small fix found in the SDK related to ercAddress comparison. To avoid mistakes, both maticAddress and ercAddress are converted to lower case