### PR TITLE
refactor: updating tests to use make block now

### DIFF
--- a/test/e2e/tokens/erc1155.test.mjs
+++ b/test/e2e/tokens/erc1155.test.mjs
@@ -4,9 +4,10 @@ import chai from 'chai';
 import chaiHttp from 'chai-http';
 import chaiAsPromised from 'chai-as-promised';
 import config from 'config';
+import { generalise } from 'general-number';
 import Nf3 from '../../../cli/lib/nf3.mjs';
 import logger from '../../../common-files/utils/logger.mjs';
-import { expectTransaction, Web3Client, depositNTransactions } from '../../utils.mjs';
+import { expectTransaction, Web3Client } from '../../utils.mjs';
 import { getERCInfo } from '../../../cli/lib/tokens.mjs';
 
 // so we can use require with mjs file
@@ -35,47 +36,20 @@ let erc1155Address;
 // let me tell you I also don't know, but I guess we just want to fill some blocks?
 let erc20Address;
 let stateAddress;
-let eventLogs = [];
+const eventLogs = [];
 let availableTokenIds;
 
-/*
-  This function tries to zero the number of unprocessed transactions in the optimist node
-  that nf3 is connected to. We call it extensively on the tests, as we want to query stuff from the
-  L2 layer, which is dependent on a block being made. We also need 0 unprocessed transactions by the end
-  of the tests, otherwise the optimist will become out of sync with the L2 block count on-chain.
-*/
-const emptyL2 = async nf3Instance => {
-  let count = await nf3Instance.unprocessedTransactionCount();
+const emptyL2 = async () => {
+  let count = await nf3Users[0].unprocessedTransactionCount();
+
   while (count !== 0) {
-    if (count % txPerBlock) {
-      await depositNTransactions(
-        nf3Instance,
-        count % txPerBlock ? count % txPerBlock : txPerBlock,
-        erc20Address,
-        tokenType,
-        transferValue,
-        tokenId,
-        fee,
-      );
-
-      eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-    } else {
-      eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-    }
-
-    count = await nf3Instance.unprocessedTransactionCount();
+    await nf3Users[0].makeBlockNow();
+    await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+    count = await nf3Users[0].unprocessedTransactionCount();
   }
 
-  await depositNTransactions(
-    nf3Instance,
-    txPerBlock,
-    erc20Address,
-    tokenType,
-    transferValue,
-    tokenId,
-    fee,
-  );
-  eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+  await nf3Users[0].makeBlockNow();
+  await web3Client.waitForEvent(eventLogs, ['blockProposed']);
 };
 
 describe('ERC1155 tests', () => {
@@ -107,167 +81,173 @@ describe('ERC1155 tests', () => {
 
     availableTokenIds = availableTokens.map(t => t.tokenId);
 
-    for (let i = 0; i < txPerBlock * 2; i++) {
-      await nf3Users[0].deposit(
-        erc1155Address,
-        tokenTypeERC1155,
-        transferValue,
-        availableTokenIds[0],
-        fee,
-      );
-    }
-    eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed'], 2);
+    await nf3Users[0].deposit(erc20Address, tokenType, transferValue, tokenId, 0);
 
-    await emptyL2(nf3Users[0]);
-  });
-
-  afterEach(async () => {
-    await emptyL2(nf3Users[0]);
+    await emptyL2();
   });
 
   describe('Deposit', () => {
     it('should deposit some ERC1155 crypto into a ZKP commitment', async function () {
-      let balances = await nf3Users[0].getLayer2Balances();
-      const balanceBefore = [
-        balances[erc1155Address]?.find(e => Number(e.tokenId) === 0)?.balance || 0,
-        balances[erc1155Address]?.find(e => Number(e.tokenId) === 1)?.balance || 0,
-      ];
+      const tokenToDeposit = availableTokenIds.shift();
+
+      const beforeBalance =
+        (await nf3Users[0].getLayer2Balances())[erc1155Address]?.find(
+          e => e.tokenId === generalise(tokenToDeposit).hex(32),
+        )?.balance || 0;
+
       // We create enough transactions to fill blocks full of deposits.
-      let res = await nf3Users[0].deposit(
-        erc1155Address,
-        tokenTypeERC1155,
-        transferValue,
-        availableTokenIds[0],
-        fee,
-      );
-      expectTransaction(res);
-
-      res = await nf3Users[0].deposit(
-        erc1155Address,
-        tokenTypeERC1155,
-        transferValue,
-        availableTokenIds[1],
-        fee,
-      );
-      expectTransaction(res);
-      // Wait until we see the right number of blocks appear
-      eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-
-      await emptyL2(nf3Users[0]);
-      balances = await nf3Users[0].getLayer2Balances();
-
-      const balanceAfter = [
-        balances[erc1155Address]?.find(e => Number(e.tokenId) === 0).balance,
-        balances[erc1155Address]?.find(e => Number(e.tokenId) === 1).balance,
-      ];
-
-      expect(balanceAfter[0] - balanceBefore[0]).to.be.equal(transferValue);
-      expect(balanceAfter[1] - balanceBefore[1]).to.be.equal(transferValue);
-    });
-
-    it('should deposit some ERC1155 crypto into a ZKP commitment and make a block with a single transaction', async function () {
-      // We create enough transactions to fill blocks full of deposits.
-      const res0 = await nf3Proposer1.makeBlockNow();
-      expect(res0.data).to.be.equal('Making short block');
       const res = await nf3Users[0].deposit(
         erc1155Address,
         tokenTypeERC1155,
         transferValue,
-        availableTokenIds[2],
+        tokenToDeposit,
         fee,
       );
       expectTransaction(res);
 
-      // Wait until we see the right number of blocks appear
-      eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await emptyL2();
 
-      await emptyL2(nf3Users[0]);
+      const afterBalance =
+        (await nf3Users[0].getLayer2Balances())[erc1155Address]?.find(
+          e => e.tokenId === generalise(tokenToDeposit).hex(32),
+        )?.balance || 0;
+
+      expect(afterBalance - beforeBalance).to.be.equal(transferValue);
     });
   });
 
   describe('Transfer', () => {
     it('should decrement the balance after transfer ERC1155 to other wallet and increment the other wallet', async function () {
-      let balances;
+      const tokenToTransfer = availableTokenIds.shift();
+
       async function getBalances() {
-        balances = [
-          (await nf3Users[0].getLayer2Balances())[erc1155Address].find(e => Number(e.tokenId) === 0)
-            .balance,
-          (await nf3Users[1].getLayer2Balances())[erc1155Address]?.find(
-            e => Number(e.tokenId) === 0,
+        return Promise.all([
+          (await nf3Users[0].getLayer2Balances())[erc1155Address]?.find(
+            e => e.tokenId === generalise(tokenToTransfer).hex(32),
           )?.balance || 0,
-        ];
+          (await nf3Users[1].getLayer2Balances())[erc1155Address]?.find(
+            e => e.tokenId === generalise(tokenToTransfer).hex(32),
+          )?.balance || 0,
+          (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0,
+        ]);
       }
 
-      await getBalances();
-      // weird way to clone an array, but we need a deep clone as it's a multidimensional array
-      const beforeBalances = JSON.parse(JSON.stringify(balances));
+      await nf3Users[0].deposit(
+        erc1155Address,
+        tokenTypeERC1155,
+        transferValue,
+        tokenToTransfer,
+        fee,
+      );
 
-      for (let i = 0; i < txPerBlock; i++) {
-        const res = await nf3Users[0].transfer(
-          false,
-          erc1155Address,
-          tokenTypeERC1155,
-          transferValue,
-          availableTokenIds[0],
-          nf3Users[1].zkpKeys.compressedZkpPublicKey,
-          fee,
-        );
-        expectTransaction(res);
-      }
-      eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await emptyL2();
 
-      await getBalances();
+      const beforeBalances = await getBalances();
 
-      expect(balances[0] - beforeBalances[0]).to.be.equal(-transferValue * txPerBlock);
-      expect(balances[1] - beforeBalances[1]).to.be.equal(transferValue * txPerBlock);
+      const res = await nf3Users[0].transfer(
+        false,
+        erc1155Address,
+        tokenTypeERC1155,
+        transferValue,
+        tokenToTransfer,
+        nf3Users[1].zkpKeys.compressedZkpPublicKey,
+        fee,
+      );
+      expectTransaction(res);
+
+      await emptyL2();
+
+      const afterBalances = await getBalances();
+
+      expect(afterBalances[0] - beforeBalances[0]).to.be.equal(-transferValue);
+      expect(afterBalances[1] - beforeBalances[1]).to.be.equal(transferValue);
+      expect(afterBalances[2] - beforeBalances[2]).to.be.equal(-fee);
     });
   });
 
   describe('Withdraw', () => {
     it('should withdraw from L2, checking for missing commitment', async function () {
-      const beforeBalance = (await nf3Users[0].getLayer2Balances())[erc1155Address].find(
-        e => Number(e.tokenId) === 0,
+      const tokenToWithdraw = availableTokenIds.shift();
+
+      await nf3Users[0].deposit(
+        erc1155Address,
+        tokenTypeERC1155,
+        transferValue,
+        tokenToWithdraw,
+        fee,
+      );
+
+      await emptyL2();
+
+      const beforeBalanceERC1155 = (await nf3Users[0].getLayer2Balances())[erc1155Address].find(
+        e => e.tokenId === generalise(tokenToWithdraw).hex(32),
       ).balance;
+      const beforeBalanceERC20 =
+        (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
 
       const rec = await nf3Users[0].withdraw(
         false,
         erc1155Address,
         tokenTypeERC1155,
         transferValue,
-        availableTokenIds[0],
+        tokenToWithdraw,
         nf3Users[0].ethereumAddress,
+        fee,
       );
+
+      await emptyL2();
+
       expectTransaction(rec);
-      logger.debug(`     Gas used was ${Number(rec.gasUsed)}`);
+      logger.debug(`Gas used was ${Number(rec.gasUsed)}`);
 
-      await emptyL2(nf3Users[0]);
+      const afterBalanceERC1155 =
+        (await nf3Users[0].getLayer2Balances())[erc1155Address]?.find(
+          e => e.tokenId === generalise(tokenToWithdraw).hex(32),
+        )?.balance || 0;
 
-      const balanceAfter =
-        (await nf3Users[0].getLayer2Balances())[erc1155Address]?.find(e => Number(e.tokenId) === 0)
-          ?.balance || 0;
+      const afterBalanceERC20 =
+        (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
 
-      expect(balanceAfter).to.be.lessThan(beforeBalance);
+      expect(afterBalanceERC1155 - beforeBalanceERC1155).to.be.equal(-transferValue);
+      expect(afterBalanceERC20 - beforeBalanceERC20).to.be.equal(-fee);
     });
 
     it('should withdraw from L2, checking for L1 balance (only with time-jump client)', async function () {
       const nodeInfo = await web3Client.getInfo();
       if (nodeInfo.includes('TestRPC')) {
-        const beforeBalance = (await nf3Users[0].getLayer2Balances())[erc1155Address]?.find(
-          e => Number(e.tokenId) === 0,
-        )?.balance;
+        const tokenToWithdraw = availableTokenIds.shift();
+
+        await nf3Users[0].deposit(
+          erc1155Address,
+          tokenTypeERC1155,
+          transferValue,
+          tokenToWithdraw,
+          fee,
+        );
+
+        await emptyL2();
+
+        const beforeBalanceERC1155 =
+          (await nf3Users[0].getLayer2Balances())[erc1155Address]?.find(
+            e => e.tokenId === generalise(tokenToWithdraw).hex(32),
+          )?.balance || 0;
+
+        const beforeBalanceERC20 =
+          (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
 
         const rec = await nf3Users[0].withdraw(
           false,
           erc1155Address,
           tokenTypeERC1155,
           transferValue,
-          availableTokenIds[0],
+          tokenToWithdraw,
           nf3Users[0].ethereumAddress,
+          fee,
         );
         expectTransaction(rec);
-        const withdrawal = await nf3Users[0].getLatestWithdrawHash();
+        await emptyL2();
 
-        await emptyL2(nf3Users[0]);
+        const withdrawal = nf3Users[0].getLatestWithdrawHash();
 
         await web3Client.timeJump(3600 * 24 * 10); // jump in time by 10 days
 
@@ -285,12 +265,17 @@ describe('ERC1155 tests', () => {
         const res = await nf3Users[0].finaliseWithdrawal(withdrawal);
         expectTransaction(res);
 
-        const endBalance = (await nf3Users[0].getLayer2Balances())[erc1155Address]?.find(
-          e => Number(e.tokenId) === 0,
-        )?.balance;
-        expect(endBalance).to.be.lessThan(beforeBalance);
+        const afterBalanceERC1155 =
+          (await nf3Users[0].getLayer2Balances())[erc1155Address]?.find(
+            e => e.tokenId === generalise(tokenToWithdraw).hex(32),
+          )?.balance || 0;
+
+        const afterBalanceERC20 =
+          (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
+        expect(afterBalanceERC1155 - beforeBalanceERC1155).to.be.equal(-transferValue);
+        expect(afterBalanceERC20 - beforeBalanceERC20).to.be.equal(-fee);
       } else {
-        console.log('     Not using a time-jump capable test client so this test is skipped');
+        console.log('Not using a time-jump capable test client so this test is skipped');
         this.skip();
       }
     });

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -4,7 +4,7 @@ import chaiHttp from 'chai-http';
 import chaiAsPromised from 'chai-as-promised';
 import config from 'config';
 import Nf3 from '../../../cli/lib/nf3.mjs';
-import { expectTransaction, depositNTransactions, Web3Client } from '../../utils.mjs';
+import { depositNTransactions, expectTransaction, Web3Client } from '../../utils.mjs';
 import logger from '../../../common-files/utils/logger.mjs';
 
 import { approve } from '../../../cli/lib/tokens.mjs';
@@ -39,7 +39,7 @@ const web3Client = new Web3Client();
 
 let erc20Address;
 let stateAddress;
-let eventLogs = [];
+const eventLogs = [];
 const logs = {
   instantWithdraw: 0,
 };
@@ -49,44 +49,17 @@ const waitForTxExecution = async (count, txType) => {
   }
 };
 
-/*
-  This function tries to zero the number of unprocessed transactions in the optimist node
-  that nf3 is connected to. We call it extensively on the tests, as we want to query stuff from the
-  L2 layer, which is dependent on a block being made. We also need 0 unprocessed transactions by the end
-  of the tests, otherwise the optimist will become out of sync with the L2 block count on-chain.
-*/
-const emptyL2 = async nf3Instance => {
-  let count = await nf3Instance.unprocessedTransactionCount();
+const emptyL2 = async () => {
+  let count = await nf3Users[0].unprocessedTransactionCount();
+
   while (count !== 0) {
-    if (count % txPerBlock) {
-      await depositNTransactions(
-        nf3Instance,
-        count % txPerBlock ? count % txPerBlock : txPerBlock,
-        erc20Address,
-        tokenType,
-        transferValue,
-        tokenId,
-        fee,
-      );
-
-      eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-    } else {
-      eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-    }
-
-    count = await nf3Instance.unprocessedTransactionCount();
+    await nf3Users[0].makeBlockNow();
+    await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+    count = await nf3Users[0].unprocessedTransactionCount();
   }
 
-  await depositNTransactions(
-    nf3Instance,
-    txPerBlock,
-    erc20Address,
-    tokenType,
-    transferValue,
-    tokenId,
-    fee,
-  );
-  eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+  await nf3Users[0].makeBlockNow();
+  await web3Client.waitForEvent(eventLogs, ['blockProposed']);
 };
 
 describe('ERC20 tests', () => {
@@ -109,158 +82,78 @@ describe('ERC20 tests', () => {
 
     stateAddress = await nf3Users[0].stateContractAddress;
     web3Client.subscribeTo('logs', eventLogs, { address: stateAddress });
-
-    await emptyL2(nf3Users[0]);
   });
 
-  afterEach(async () => {
-    await emptyL2(nf3Users[0]);
+  beforeEach(async () => {
+    await nf3Users[0].deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+    await emptyL2();
   });
 
   describe('Deposits', () => {
-    it('should deposit some ERC20 crypto into a ZKP commitment', async function () {
-      logger.debug(`      Sending ${txPerBlock} deposits...`);
-      // We create enough transactions to fill blocks full of deposits.
-      const depositTransactions = await depositNTransactions(
-        nf3Users[0],
-        txPerBlock,
-        erc20Address,
-        tokenType,
-        transferValue,
-        tokenId,
-        fee,
-      );
-      // Wait until we see the right number of blocks appear
-      eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-      const totalGas = depositTransactions.reduce((acc, { gasUsed }) => acc + Number(gasUsed), 0);
-      logger.debug(`     Average Gas used was ${Math.ceil(totalGas / txPerBlock)}`);
-    });
-
     it('should increment the balance after deposit some ERC20 crypto', async function () {
-      const currentZkpPublicKeyBalance = (await nf3Users[0].getLayer2Balances())[erc20Address][0]
-        .balance;
-      // We do txPerBlock deposits of 10 each
-      await depositNTransactions(
-        nf3Users[0],
-        txPerBlock,
-        erc20Address,
-        tokenType,
-        transferValue,
-        tokenId,
-        fee,
-      );
-      eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-      const afterZkpPublicKeyBalance = (await nf3Users[0].getLayer2Balances())[erc20Address][0]
-        .balance;
-      expect(afterZkpPublicKeyBalance - currentZkpPublicKeyBalance).to.be.equal(
-        txPerBlock * transferValue,
-      );
+      const currentZkpPublicKeyBalance =
+        (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
+      await nf3Users[0].deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+
+      await emptyL2();
+      const afterZkpPublicKeyBalance =
+        (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
+      expect(afterZkpPublicKeyBalance - currentZkpPublicKeyBalance).to.be.equal(transferValue);
     });
   });
 
   describe('Transfers', () => {
     it('should decrement the balance after transfer ERC20 to other wallet and increment the other wallet', async function () {
-      let balances;
       async function getBalances() {
-        balances = [
+        return Promise.all([
           (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0,
           (await nf3Users[1].getLayer2Balances())[erc20Address]?.[0].balance || 0,
-        ];
+        ]);
       }
 
-      await getBalances();
-      const beforeBalances = JSON.parse(JSON.stringify(balances));
+      const beforeBalances = await getBalances();
 
-      for (let i = 0; i < txPerBlock; i++) {
-        const res = await nf3Users[0].transfer(
-          false,
-          erc20Address,
-          tokenType,
-          transferValue,
-          tokenId,
-          nf3Users[1].zkpKeys.compressedZkpPublicKey,
-          fee,
-        );
-        expectTransaction(res);
+      const res = await nf3Users[0].transfer(
+        false,
+        erc20Address,
+        tokenType,
+        transferValue,
+        tokenId,
+        nf3Users[1].zkpKeys.compressedZkpPublicKey,
+        fee,
+      );
+      expectTransaction(res);
 
-        await new Promise(resolve => setTimeout(resolve, 3000));
-      }
+      await emptyL2();
+
       // stateBalance += fee * txPerBlock + BLOCK_STAKE;
-      eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
 
-      await getBalances();
+      const afterBalances = await getBalances();
 
-      expect(balances[0] - beforeBalances[0]).to.be.equal(-txPerBlock * (transferValue + fee));
-      expect(balances[1] - beforeBalances[1]).to.be.equal(txPerBlock * transferValue);
+      expect(afterBalances[0] - beforeBalances[0]).to.be.equal(-(transferValue + fee));
+      expect(afterBalances[1] - beforeBalances[1]).to.be.equal(transferValue);
     });
 
     it('should transfer some ERC20 crypto (back to us) using ZKP', async function () {
       const before = (await nf3Users[0].getLayer2Balances())[erc20Address][0].balance;
 
-      for (let i = 0; i < txPerBlock; i++) {
-        const res = await nf3Users[0].transfer(
-          false,
-          erc20Address,
-          tokenType,
-          transferValue,
-          tokenId,
-          nf3Users[0].zkpKeys.compressedZkpPublicKey,
-          fee,
-        );
-        expectTransaction(res);
-        logger.debug(`     Gas used was ${Number(res.gasUsed)}`);
-      }
+      const res = await nf3Users[0].transfer(
+        false,
+        erc20Address,
+        tokenType,
+        transferValue,
+        tokenId,
+        nf3Users[0].zkpKeys.compressedZkpPublicKey,
+        fee,
+      );
+      expectTransaction(res);
+      await emptyL2();
+      logger.debug(`Gas used was ${Number(res.gasUsed)}`);
+
       const after = (await nf3Users[0].getLayer2Balances())[erc20Address][0].balance;
 
       // stateBalance += fee * txPerBlock + BLOCK_STAKE;
-      eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-      expect(after).to.be.lessThan(before);
-    });
-
-    it('should send a single ERC20 transfer directly to a proposer', async function () {
-      const before = (await nf3Users[0].getLayer2Balances())[erc20Address][0].balance;
-
-      // here we don't need to emptyL2 because we're sending two transactions
-      for (let i = 0; i < txPerBlock; i++) {
-        const res = await nf3Users[0].transfer(
-          true,
-          erc20Address,
-          tokenType,
-          transferValue,
-          tokenId,
-          nf3Users[1].zkpKeys.compressedZkpPublicKey,
-          fee,
-        );
-        expect(res).to.be.equal(200);
-      }
-
-      const after = (await nf3Users[0].getLayer2Balances())[erc20Address][0].balance;
-      expect(after).to.be.lessThan(before);
-    });
-
-    it('should send a double ERC20 transfer directly to a proposer', async function () {
-      // we get some different transferValue than the commitments we have (all should be of value transferValue)
-      // then we send it, the client should pick two commitments to send the transaction
-      const doubleTransferValue = Math.ceil(transferValue * 1.2);
-
-      const before = (await nf3Users[0].getLayer2Balances())[erc20Address][0].balance;
-
-      // here we don't need to emptyL2 because we're sending two transactions
-      for (let i = 0; i < txPerBlock; i++) {
-        const res = await nf3Users[0].transfer(
-          true,
-          erc20Address,
-          tokenType,
-          doubleTransferValue,
-          tokenId,
-          nf3Users[1].zkpKeys.compressedZkpPublicKey,
-          fee,
-        );
-        expect(res).to.be.equal(200);
-      }
-
-      const after = (await nf3Users[0].getLayer2Balances())[erc20Address][0].balance;
-      expect(after).to.be.lessThan(before);
+      expect(after - before).to.be.equal(-fee);
     });
   });
 
@@ -274,12 +167,15 @@ describe('ERC20 tests', () => {
         transferValue / 2,
         tokenId,
         nf3Users[0].ethereumAddress,
+        fee,
       );
       expectTransaction(rec);
 
-      logger.debug(`     Gas used was ${Number(rec.gasUsed)}`);
+      await emptyL2();
+
+      logger.debug(`Gas used was ${Number(rec.gasUsed)}`);
       const afterBalance = (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance;
-      expect(afterBalance).to.be.lessThan(beforeBalance);
+      expect(afterBalance - beforeBalance).to.be.equal(-(transferValue / 2 + fee));
     });
 
     it('Should create a failing finalise-withdrawal (because insufficient time has passed)', async function () {
@@ -292,10 +188,13 @@ describe('ERC20 tests', () => {
           Math.floor(transferValue / 2),
           tokenId,
           nf3Users[0].ethereumAddress,
+          fee,
         );
         expectTransaction(rec);
+
+        await emptyL2();
+
         const withdrawal = await nf3Users[0].getLatestWithdrawHash();
-        await emptyL2(nf3Users[0]);
         const res = await nf3Users[0].finaliseWithdrawal(withdrawal);
         expectTransaction(res);
       } catch (err) {
@@ -321,11 +220,13 @@ describe('ERC20 tests', () => {
           Math.floor(transferValue / 2),
           tokenId,
           nf3Users[0].ethereumAddress,
+          fee,
         );
         expectTransaction(rec);
-        const withdrawal = await nf3Users[0].getLatestWithdrawHash();
 
-        await emptyL2(nf3Users[0]);
+        await emptyL2();
+
+        const withdrawal = await nf3Users[0].getLatestWithdrawHash();
 
         await web3Client.timeJump(3600 * 24 * 10); // jump in time by 10 days
 
@@ -345,7 +246,7 @@ describe('ERC20 tests', () => {
         const endBalance = await web3Client.getBalance(nf3Users[0].ethereumAddress);
         expect(parseInt(endBalance, 10)).to.be.lessThan(parseInt(startBalance, 10));
       } else {
-        console.log('     Not using a time-jump capable test client so this test is skipped');
+        console.log('Not using a time-jump capable test client so this test is skipped');
         this.skip();
       }
     });
@@ -359,12 +260,15 @@ describe('ERC20 tests', () => {
         Math.floor(transferValue / 2),
         tokenId,
         nf3Users[0].ethereumAddress,
+        fee,
       );
       expectTransaction(rec);
 
-      logger.debug(`     Gas used was ${Number(rec.gasUsed)}`);
+      await emptyL2();
+
+      logger.debug(`Gas used was ${Number(rec.gasUsed)}`);
       const afterBalance = (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance;
-      expect(afterBalance).to.be.lessThan(beforeBalance);
+      expect(afterBalance - beforeBalance).to.be.equal(-(Math.floor(transferValue / 2) + fee));
     });
   });
 
@@ -414,18 +318,21 @@ describe('ERC20 tests', () => {
         nf3Users[0].ethereumAddress,
         fee,
       );
+
+      await emptyL2();
+
       const latestWithdrawTransactionHash = nf3Users[0].getLatestWithdrawHash();
       expect(latestWithdrawTransactionHash).to.be.a('string').and.to.include('0x');
 
       const count = logs.instantWithdraw;
 
-      await emptyL2(nf3Users[0]);
+      await emptyL2();
+
       // We request the instant withdraw and should wait for the liquidity provider to send the instant withdraw
       const res = await nf3Users[0].requestInstantWithdrawal(latestWithdrawTransactionHash, fee);
-      expectTransaction(res);
-      logger.debug(`     Gas used was ${Number(res.gasUsed)}`);
 
-      await emptyL2(nf3Users[0]);
+      expectTransaction(res);
+      logger.debug(`Gas used was ${Number(res.gasUsed)}`);
 
       await waitForTxExecution(count, 'instantWithdraw');
 
@@ -435,7 +342,6 @@ describe('ERC20 tests', () => {
     });
 
     it('should not allow instant withdraw of non existing withdraw or not in block yet', async function () {
-      // We create enough transactions to fill numDeposits blocks full of deposits.
       await nf3Users[0].withdraw(
         false,
         erc20Address,
@@ -453,8 +359,7 @@ describe('ERC20 tests', () => {
     });
 
     after(async () => {
-      await emptyL2(nf3Users[0]);
-      await nf3LiquidityProvider.close();
+      nf3LiquidityProvider.close();
     });
   });
 
@@ -467,6 +372,8 @@ describe('ERC20 tests', () => {
     let maxERC20DepositValue;
 
     before(() => {
+      web3Client.subscribeTo('logs', eventLogs, { address: stateAddress });
+
       maxERC20WithdrawValue =
         maxWithdrawValue.find(e => e.address.toLowerCase() === erc20Address)?.amount ||
         erc20default;
@@ -477,17 +384,8 @@ describe('ERC20 tests', () => {
 
     it('should restrict deposits', async () => {
       // anything equal or above the restricted amount should fail
-      // console.log('depositing', maxERC20DepositValue + 1);
       try {
-        await depositNTransactions(
-          nf3Users[0],
-          txPerBlock,
-          erc20Address,
-          tokenType,
-          maxERC20DepositValue + 1,
-          tokenId,
-          fee,
-        );
+        await nf3Users[0].deposit(erc20Address, tokenType, maxERC20DepositValue + 1, tokenId, fee);
         expect.fail('Transaction has not been reverted by the EVM');
       } catch (error) {
         expect(error.message).to.satisfy(message =>
@@ -536,7 +434,7 @@ describe('ERC20 tests', () => {
             fee,
           );
 
-          await emptyL2(nf3Users[0]);
+          await emptyL2();
           await new Promise(resolve => setTimeout(resolve, 15000));
 
           for (let i = 0; i < 5; i++) {
@@ -548,9 +446,9 @@ describe('ERC20 tests', () => {
               trnsferValue * (i + 2),
               tokenId,
               nf3Users[0].zkpKeys.compressedZkpPublicKey,
-              fee,
+              0,
             );
-            await emptyL2(nf3Users[0]);
+            await emptyL2();
             await new Promise(resolve => setTimeout(resolve, 30000));
           }
 
@@ -561,13 +459,15 @@ describe('ERC20 tests', () => {
             withdrawValue,
             tokenId,
             nf3Users[0].ethereumAddress,
-            fee,
+            0,
           );
-          await new Promise(resolve => setTimeout(resolve, 15000));
+
+          await emptyL2();
+          await new Promise(resolve => setTimeout(resolve, 30000));
+
           expectTransaction(rec);
 
-          const withdrawal = await nf3Users[0].getLatestWithdrawHash();
-          await emptyL2(nf3Users[0]);
+          const withdrawal = nf3Users[0].getLatestWithdrawHash();
           await web3Client.timeJump(3600 * 24 * 10); // jump in time by 50 days
           // anything equal or above the restricted amount should fail
           await nf3Users[0].finaliseWithdrawal(withdrawal);
@@ -579,7 +479,7 @@ describe('ERC20 tests', () => {
           );
         }
       } else {
-        console.log('     Not using a time-jump capable test client so this test is skipped');
+        console.log('Not using a time-jump capable test client so this test is skipped');
         this.skip();
       }
     });

--- a/test/e2e/tokens/erc721.test.mjs
+++ b/test/e2e/tokens/erc721.test.mjs
@@ -5,7 +5,7 @@ import chaiHttp from 'chai-http';
 import chaiAsPromised from 'chai-as-promised';
 import config from 'config';
 import Nf3 from '../../../cli/lib/nf3.mjs';
-import { expectTransaction, Web3Client, depositNTransactions } from '../../utils.mjs';
+import { expectTransaction, Web3Client } from '../../utils.mjs';
 import logger from '../../../common-files/utils/logger.mjs';
 import { getERCInfo } from '../../../cli/lib/tokens.mjs';
 
@@ -34,7 +34,7 @@ let erc721Address;
 // let me tell you I also don't know, but I guess we just want to fill some blocks?
 let erc20Address;
 let stateAddress;
-let eventLogs = [];
+const eventLogs = [];
 let availableTokenIds;
 
 /*
@@ -43,38 +43,17 @@ let availableTokenIds;
   L2 layer, which is dependent on a block being made. We also need 0 unprocessed transactions by the end
   of the tests, otherwise the optimist will become out of sync with the L2 block count on-chain.
 */
-const emptyL2 = async nf3Instance => {
-  let count = await nf3Instance.unprocessedTransactionCount();
+const emptyL2 = async () => {
+  let count = await nf3Users[0].unprocessedTransactionCount();
+
   while (count !== 0) {
-    if (count % txPerBlock) {
-      await depositNTransactions(
-        nf3Instance,
-        count % txPerBlock ? count % txPerBlock : txPerBlock,
-        erc20Address,
-        tokenType,
-        transferValue,
-        tokenId,
-        fee,
-      );
-
-      eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-    } else {
-      eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-    }
-
-    count = await nf3Instance.unprocessedTransactionCount();
+    await nf3Users[0].makeBlockNow();
+    await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+    count = await nf3Users[0].unprocessedTransactionCount();
   }
 
-  await depositNTransactions(
-    nf3Instance,
-    txPerBlock,
-    erc20Address,
-    tokenType,
-    transferValue,
-    tokenId,
-    fee,
-  );
-  eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+  await nf3Users[0].makeBlockNow();
+  await web3Client.waitForEvent(eventLogs, ['blockProposed']);
 };
 
 describe('ERC721 tests', () => {
@@ -104,91 +83,96 @@ describe('ERC721 tests', () => {
       })
     ).details.map(t => t.tokenId);
 
-    for (let i = 0; i < txPerBlock * 2; i++) {
-      await nf3Users[0].deposit(erc721Address, tokenTypeERC721, 0, availableTokenIds.shift(), fee);
-    }
-    eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+    await nf3Users[0].deposit(erc20Address, tokenType, transferValue, tokenId, 0);
 
-    await emptyL2(nf3Users[0]);
-  });
-
-  afterEach(async () => {
-    await emptyL2(nf3Users[0]);
+    await emptyL2();
   });
 
   describe('Deposit', () => {
     it('should deposit some ERC721 crypto into a ZKP commitment', async function () {
-      let balances = await nf3Users[0].getLayer2Balances();
-      const balanceBefore = balances[erc721Address]?.length || 0;
+      const tokenToDeposit = availableTokenIds.shift();
+
+      const balanceBefore = (await nf3Users[0].getLayer2Balances())[erc721Address]?.length || 0;
+
       // We create enough transactions to fill blocks full of deposits.
-      let res = await nf3Users[0].deposit(
-        erc721Address,
-        tokenTypeERC721,
-        0,
-        availableTokenIds.shift(),
-        fee,
-      );
+      const res = await nf3Users[0].deposit(erc721Address, tokenTypeERC721, 0, tokenToDeposit, fee);
       expectTransaction(res);
-      res = await nf3Users[0].deposit(
-        erc721Address,
-        tokenTypeERC721,
-        0,
-        availableTokenIds.shift(),
-        fee,
-      );
-      expectTransaction(res);
-      // Wait until we see the right number of blocks appear
-      eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-      await emptyL2(nf3Users[0]);
-      balances = await nf3Users[0].getLayer2Balances();
-      const balanceAfter = balances[erc721Address].length;
-      expect(balanceAfter - balanceBefore).to.be.equal(2);
+
+      await emptyL2();
+
+      const balanceAfter = (await nf3Users[0].getLayer2Balances())[erc721Address]?.length || 0;
+
+      expect(balanceAfter - balanceBefore).to.be.equal(1);
     });
   });
 
   describe('Transfer', () => {
     it('should decrement the balance after transfer ERC721 to other wallet and increment the other wallet', async function () {
-      let balances;
+      const tokenToTransfer = availableTokenIds.shift();
+
+      const deposit = await nf3Users[0].deposit(
+        erc721Address,
+        tokenTypeERC721,
+        0,
+        tokenToTransfer,
+        fee,
+      );
+      expectTransaction(deposit);
+      await emptyL2();
+
       async function getBalances() {
-        balances = [
-          (await nf3Users[0].getLayer2Balances())[erc721Address],
-          (await nf3Users[1].getLayer2Balances())[erc721Address],
-        ];
+        return Promise.all([
+          await nf3Users[0].getLayer2Balances(),
+          await nf3Users[1].getLayer2Balances(),
+        ]);
       }
 
-      await getBalances();
-      // weird way to clone an array, but we need a deep clone as it's a multidimensional array
-      const beforeBalances = JSON.parse(JSON.stringify(balances));
+      const balancesBefore = await getBalances();
 
-      for (let i = 0; i < txPerBlock; i++) {
-        const res = await nf3Users[0].transfer(
-          false,
-          erc721Address,
-          tokenTypeERC721,
-          0,
-          balances[0].shift().tokenId,
-          nf3Users[1].zkpKeys.compressedZkpPublicKey,
-          fee,
-        );
-        expectTransaction(res);
-      }
-      eventLogs = await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-      // await new Promise(resolve => setTimeout(resolve, 3000));
+      const res = await nf3Users[0].transfer(
+        false,
+        erc721Address,
+        tokenTypeERC721,
+        0,
+        tokenToTransfer,
+        nf3Users[1].zkpKeys.compressedZkpPublicKey,
+        fee,
+      );
+      expectTransaction(res);
 
-      // depositing some ERC20 transactions to fill the block
-      await emptyL2(nf3Users[0]);
+      await emptyL2();
 
-      await getBalances();
-      expect((balances[0]?.length || 0) - (beforeBalances[0]?.length || 0)).to.be.equal(-2);
-      expect((balances[1]?.length || 0) - (beforeBalances[1]?.length || 0)).to.be.equal(2);
+      const balancesAfter = await getBalances();
+      expect(
+        (balancesAfter[0][erc721Address]?.length || 0) -
+          (balancesBefore[0][erc721Address]?.length || 0),
+      ).to.be.equal(-1);
+      expect(
+        (balancesAfter[1][erc721Address]?.length || 0) -
+          (balancesBefore[1][erc721Address]?.length || 0),
+      ).to.be.equal(1);
+      expect(
+        (balancesAfter[0][erc20Address]?.[0].balance || 0) -
+          (balancesBefore[0][erc20Address]?.[0].balance || 0),
+      ).to.be.equal(-fee);
     });
   });
 
   describe('Withdraw', () => {
     it('should withdraw from L2, checking for missing commitment', async function () {
-      const erc721balances = (await nf3Users[0].getLayer2Balances())[erc721Address];
-      const beforeBalance = erc721balances.length;
-      const tokenToWithdraw = erc721balances.shift().tokenId;
+      const tokenToWithdraw = availableTokenIds.shift();
+
+      const res = await nf3Users[0].deposit(
+        erc721Address,
+        tokenTypeERC721,
+        0,
+        tokenToWithdraw,
+        fee,
+      );
+      expectTransaction(res);
+      await emptyL2();
+
+      const balancesBefore = await nf3Users[0].getLayer2Balances();
 
       const rec = await nf3Users[0].withdraw(
         false,
@@ -197,22 +181,39 @@ describe('ERC721 tests', () => {
         0,
         tokenToWithdraw,
         nf3Users[0].ethereumAddress,
+        fee,
       );
       expectTransaction(rec);
-      logger.debug(`     Gas used was ${Number(rec.gasUsed)}`);
+      logger.debug(`Gas used was ${Number(rec.gasUsed)}`);
 
-      await emptyL2(nf3Users[0]);
+      await emptyL2();
 
-      const balanceAfter = (await nf3Users[0].getLayer2Balances())[erc721Address].length;
-      expect(balanceAfter).to.be.lessThan(beforeBalance);
+      const balancesAfter = await nf3Users[0].getLayer2Balances();
+      expect(
+        (balancesAfter[erc721Address]?.length || 0) - (balancesBefore[erc721Address]?.length || 0),
+      ).to.be.equal(-1);
+      expect(
+        (balancesAfter[erc20Address]?.[0].balance || 0) -
+          (balancesBefore[erc20Address]?.[0].balance || 0),
+      ).to.be.equal(-fee);
     });
 
     it('should withdraw from L2, checking for L1 balance (only with time-jump client)', async function () {
       const nodeInfo = await web3Client.getInfo();
       if (nodeInfo.includes('TestRPC')) {
-        let erc721balances = (await nf3Users[0].getLayer2Balances())[erc721Address];
-        const beforeBalance = erc721balances.length;
-        const tokenToWithdraw = erc721balances.shift().tokenId;
+        const tokenToWithdraw = availableTokenIds.shift();
+
+        const deposit = await nf3Users[0].deposit(
+          erc721Address,
+          tokenTypeERC721,
+          0,
+          tokenToWithdraw,
+          fee,
+        );
+        expectTransaction(deposit);
+        await emptyL2();
+
+        const balancesBefore = await nf3Users[0].getLayer2Balances();
 
         const rec = await nf3Users[0].withdraw(
           false,
@@ -221,11 +222,14 @@ describe('ERC721 tests', () => {
           0,
           tokenToWithdraw,
           nf3Users[0].ethereumAddress,
+          fee,
         );
         expectTransaction(rec);
-        const withdrawal = await nf3Users[0].getLatestWithdrawHash();
+        await emptyL2();
 
-        await emptyL2(nf3Users[0]);
+        const withdrawal = nf3Users[0].getLatestWithdrawHash();
+
+        const balancesAfter = await nf3Users[0].getLayer2Balances();
 
         await web3Client.timeJump(3600 * 24 * 10); // jump in time by 10 days
 
@@ -239,16 +243,19 @@ describe('ERC721 tests', () => {
           ).length,
         ).to.be.greaterThan(0);
 
-        await new Promise(resolve => setTimeout(resolve, 15000));
-
         const res = await nf3Users[0].finaliseWithdrawal(withdrawal);
         expectTransaction(res);
 
-        erc721balances = (await nf3Users[0].getLayer2Balances())[erc721Address];
-        const endBalance = erc721balances.length;
-        expect(parseInt(endBalance, 10)).to.be.lessThan(parseInt(beforeBalance, 10));
+        expect(
+          (balancesAfter[erc721Address]?.length || 0) -
+            (balancesBefore[erc721Address]?.length || 0),
+        ).to.be.equal(-1);
+        expect(
+          (balancesAfter[erc20Address]?.[0].balance || 0) -
+            (balancesBefore[erc20Address]?.[0].balance || 0),
+        ).to.be.equal(-fee);
       } else {
-        console.log('     Not using a time-jump capable test client so this test is skipped');
+        console.log('Not using a time-jump capable test client so this test is skipped');
         this.skip();
       }
     });


### PR DESCRIPTION
This PR solves #803 and implements `makeBlockNow` function for the circuits tests. 
The ganache test run time is reduced by approximately a 40%. 
In addition, tests are can be run now independently (so we can use .skip to only test specific tests). However, I'd strongly suggest modifying even more the tests so that the commitments are deleted afterEach test. This would completely decouple each test and will help to test new circuit features more easily.