### PR TITLE
Mac workaround for NF setup

### DIFF
--- a/setup-nightfall
+++ b/setup-nightfall
@@ -2,5 +2,14 @@
 
 # Install node dependencies
 npm ci
-docker build -t ghcr.io/eyblockchain/local-zokrates:0.7.13 -f zokrates.Dockerfile .
-docker-compose -f docker-compose.yml -f docker-compose.dev.yml build
+
+OS_ARCH=$(uname -m)
+NO_CACHE_FLAG=''
+
+# Workaround when building in a Mac
+if [ $OS_ARCH != "x86_64" ]; then
+  NO_CACHE_FLAG='--no-cache'
+fi
+
+docker build ${NO_CACHE_FLAG} -t ghcr.io/eyblockchain/local-zokrates:0.7.13 -f zokrates.Dockerfile .
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml build ${NO_CACHE_FLAG}


### PR DESCRIPTION
Adding `no-cache` flag when running `setupNightfall.sh`.