### PR TITLE
Incorrect right-sibling hash

### DIFF
--- a/nightfall-deployer/contracts/MerkleTree_Stateless.sol
+++ b/nightfall-deployer/contracts/MerkleTree_Stateless.sol
@@ -166,7 +166,7 @@ library MerkleTree_Stateless {
         for (uint256 level = slot + 1; level <= treeHeight; level++) {
             if (nodeIndex % 2 == 0) {
                 // even nodeIndex
-                output = Poseidon.poseidon(uint256(_frontier[level - 1]), 0); // poseidon hash of concatenation of each node
+                output = Poseidon.poseidon(uint256(_frontier[level - 1]), nodeValue); // poseidon hash of concatenation of each node
 
                 nodeValue = output; // the parentValue, but will become the nodeValue of the next level
                 prevNodeIndex = nodeIndex;


### PR DESCRIPTION
When the node index is even, we need to hash the frontier slot with `nodeValue` not with 0 (that is only when the node index is odd). 