### PR TITLE
Implement PoS for proposers

### DIFF
--- a/.github/workflows/check-PRs.yml
+++ b/.github/workflows/check-PRs.yml
@@ -180,59 +180,59 @@ jobs:
           name: optimist-sync-test-logs
           path: ./optimist-sync-test.log
 
-#  adversary-test:
-#    runs-on: ubuntu-20.04
-#    env:
-#      TRANSACTIONS_PER_BLOCK: 32
-#      CONFIRMATIONS: 1
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: actions/setup-node@v1
-#        with:
-#          node-version: '16.17.0'
-#
-#      - name: Build adversary
-#        run: npm run build-adversary
-#
-#      - name: Start Containers with geth
-#        run: |
-#          ./setup-nightfall
-#          ./geth-standalone -s
-#          sleep 300
-#          ./start-nightfall -l -d -a &> adversary-test.log &disown
-#
-#      - name: Wait for images to be ready
-#        uses: Wandalen/wretry.action@v1.0.11
-#        with:
-#          command: |
-#            docker wait nightfall_3_deployer_1
-#          attempt_limit: 100
-#          attempt_delay: 20000
-#
-#      - name: debug logs - after container startup
-#        if: always()
-#        run: cat adversary-test.log
-#
-#      - name: Run integration test
-#        run: |
-#          VERBOSE=true npm run test-adversary
-#
-#      - name: debug logs - after integration test run
-#        if: always()
-#        run: cat adversary-test.log
-#
-#      - name: If integration test failed, shutdown the Containers
-#        if: failure()
-#        run: |
-#          npm run nightfall-down
-#          ./geth-standalone -d
-#
-#      - name: If integration test failed, upload logs files as artifacts
-#        if: failure()
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: adversary-test-logs
-#          path: ./adversary-test.log
+  #  adversary-test:
+  #    runs-on: ubuntu-20.04
+  #    env:
+  #      TRANSACTIONS_PER_BLOCK: 32
+  #      CONFIRMATIONS: 1
+  #    steps:
+  #      - uses: actions/checkout@v3
+  #      - uses: actions/setup-node@v1
+  #        with:
+  #          node-version: '16.17.0'
+  #
+  #      - name: Build adversary
+  #        run: npm run build-adversary
+  #
+  #      - name: Start Containers with geth
+  #        run: |
+  #          ./setup-nightfall
+  #          ./geth-standalone -s
+  #          sleep 300
+  #          ./start-nightfall -l -d -a &> adversary-test.log &disown
+  #
+  #      - name: Wait for images to be ready
+  #        uses: Wandalen/wretry.action@v1.0.11
+  #        with:
+  #          command: |
+  #            docker wait nightfall_3_deployer_1
+  #          attempt_limit: 100
+  #          attempt_delay: 20000
+  #
+  #      - name: debug logs - after container startup
+  #        if: always()
+  #        run: cat adversary-test.log
+  #
+  #      - name: Run integration test
+  #        run: |
+  #          VERBOSE=true npm run test-adversary
+  #
+  #      - name: debug logs - after integration test run
+  #        if: always()
+  #        run: cat adversary-test.log
+  #
+  #      - name: If integration test failed, shutdown the Containers
+  #        if: failure()
+  #        run: |
+  #          npm run nightfall-down
+  #          ./geth-standalone -d
+  #
+  #      - name: If integration test failed, upload logs files as artifacts
+  #        if: failure()
+  #        uses: actions/upload-artifact@v3
+  #        with:
+  #          name: adversary-test-logs
+  #          path: ./adversary-test.log
 
   ping-pong-test:
     runs-on: ubuntu-20.04

--- a/apps/proposer/config/default.js
+++ b/apps/proposer/config/default.js
@@ -9,6 +9,7 @@ module.exports = {
   OPTIMIST_PORT: process.env.OPTIMIST_PORT || 8081,
   OPTIMIST_WS_PORT: process.env.OPTIMIST_WS_PORT || 8082,
   BLOCKCHAIN_WS_HOST: process.env.BLOCKCHAIN_WS_HOST || 'localhost',
-  BLOCKCHAIN_PATH: process.env.BLOCKCHAIN_PATH || '',
   BLOCKCHAIN_PORT: process.env.BLOCKCHAIN_PORT || 8546,
+  BLOCKCHAIN_PATH: process.env.BLOCKCHAIN_PATH || '',
+  MINIMUM_STAKE: process.env.MINIMUM_STAKE || 100,
 };

--- a/apps/proposer/src/proposer.mjs
+++ b/apps/proposer/src/proposer.mjs
@@ -2,7 +2,10 @@
 /**
 Module that runs up as a proposer
 */
-import logger from '../common-files/utils/logger.mjs';
+import config from 'config';
+import logger from '../../../common-files/utils/logger.mjs';
+
+const { PROPOSER_PORT, MINIMUM_STAKE } = config;
 
 /**
 Does the preliminary setup and starts listening on the websocket
@@ -17,7 +20,8 @@ export default async function startProposer(nf3, proposerBaseUrl) {
   else throw new Error('Healthcheck failed');
   logger.info('Attempting to register proposer');
 
-  await nf3.registerProposer(proposerBaseUrl);
+  await nf3.registerProposer(proposerBaseUrl, MINIMUM_STAKE);
+  if (!PROPOSER_PORT) throw new Error('Please specify a proposer port');
   logger.debug('Proposer healthcheck up');
 
   // TODO subscribe to layer 1 blocks and call change proposer

--- a/apps/proposer/src/proposer.mjs
+++ b/apps/proposer/src/proposer.mjs
@@ -2,10 +2,7 @@
 /**
 Module that runs up as a proposer
 */
-import config from 'config';
-import logger from '../../../common-files/utils/logger.mjs';
-
-const { PROPOSER_PORT, MINIMUM_STAKE } = config;
+import logger from '../common-files/utils/logger.mjs';
 
 /**
 Does the preliminary setup and starts listening on the websocket
@@ -20,8 +17,7 @@ export default async function startProposer(nf3, proposerBaseUrl) {
   else throw new Error('Healthcheck failed');
   logger.info('Attempting to register proposer');
 
-  await nf3.registerProposer(proposerBaseUrl, MINIMUM_STAKE);
-  if (!PROPOSER_PORT) throw new Error('Please specify a proposer port');
+  await nf3.registerProposer(proposerBaseUrl);
   logger.debug('Proposer healthcheck up');
 
   // TODO subscribe to layer 1 blocks and call change proposer

--- a/apps/proposer/src/proposer.mjs
+++ b/apps/proposer/src/proposer.mjs
@@ -2,8 +2,10 @@
 /**
 Module that runs up as a proposer
 */
+import config from 'config';
 import logger from '../common-files/utils/logger.mjs';
 
+const { MINIMUM_STAKE } = config.TEST_OPTIONS;
 /**
 Does the preliminary setup and starts listening on the websocket
 */
@@ -17,7 +19,7 @@ export default async function startProposer(nf3, proposerBaseUrl) {
   else throw new Error('Healthcheck failed');
   logger.info('Attempting to register proposer');
 
-  await nf3.registerProposer(proposerBaseUrl);
+  await nf3.registerProposer(proposerBaseUrl, MINIMUM_STAKE);
   logger.debug('Proposer healthcheck up');
 
   // TODO subscribe to layer 1 blocks and call change proposer

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -326,6 +326,19 @@ class Nf3 {
   }
 
   /**
+    Returns the abi of a Nightfall_3 contract calling the client.
+    @method
+    @async
+    @param {string} contractName - the name of the smart contract in question. Possible
+    values are 'Shield', 'State', 'Proposers', 'Challengers'.
+    @returns {Promise} Resolves into the Ethereum address of the contract
+    */
+  async getContractAbi(contractName) {
+    const res = await axios.get(`${this.clientBaseUrl}/contract-abi/${contractName}`);
+    return res.data.abi;
+  }
+
+  /**
     Returns the address of a Nightfall_3 contract calling the client.
     @method
     @async

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -815,7 +815,7 @@ class Nf3 {
   }
 
   /**
-    Get all the list of existing proposers.
+    Get all the proposer pending payments.
     @method
     @async
     @returns {array} A promise that resolves to the Ethereum transaction receipt.

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -352,19 +352,6 @@ class Nf3 {
   }
 
   /**
-    Returns the abi of a Nightfall_3 contract calling the client.
-    @method
-    @async
-    @param {string} contractName - the name of the smart contract in question. Possible
-    values are 'Shield', 'State', 'Proposers', 'Challengers'.
-    @returns {Promise} Resolves into the Ethereum abi of the contract
-    */
-  async getContractAbi(contractName) {
-    const res = await axios.get(`${this.clientBaseUrl}/contract-abi/${contractName}`);
-    return res.data.abi;
-  }
-
-  /**
     Returns the address of a Nightfall_3 contract calling the optimist.
     @method
     @async

--- a/config/default.js
+++ b/config/default.js
@@ -196,7 +196,8 @@ module.exports = {
     gasCosts: 80000000000000000,
     fee: 1,
     BLOCK_STAKE: 1, // 1 wei
-    bond: 10, // 10 wei
+    MINIMUM_STAKE: 100, // 100 wei
+    ROTATE_PROPOSER_BLOCKS: 20,
     txPerBlock: process.env.TRANSACTIONS_PER_BLOCK || 2,
     signingKeys: {
       walletTest:

--- a/nightfall-deployer/contracts/Config.sol
+++ b/nightfall-deployer/contracts/Config.sol
@@ -6,14 +6,17 @@ import './Ownable.sol';
 import './Structures.sol';
 
 contract Config is Ownable, Structures {
-    uint256 constant REGISTRATION_BOND = 10 wei; // TODO owner can update
+    uint256 constant MINIMUM_STAKE = 100 wei; // TODO owner can update
     uint256 constant BLOCK_STAKE = 1 wei;
-    uint256 constant ROTATE_PROPOSER_BLOCKS = 4;
-    uint256 constant COOLING_OFF_PERIOD = 1 weeks;
+    uint256 constant ROTATE_PROPOSER_BLOCKS = 20;
+    uint256 constant CHALLENGE_PERIOD = 1 weeks;
     bytes32 constant ZERO = bytes32(0);
     uint256 constant TRANSACTIONS_PER_BLOCK = 32;
     uint256 constant BLOCK_STRUCTURE_SLOTS = 7;
     uint256 constant TRANSACTION_STRUCTURE_SLOTS = 24;
+    uint256 constant VALUE_PER_SLOT = 10; // amount of value of a slot
+    uint256 constant PROPOSER_SET_COUNT = 5; // number of slots to pop after shuffling slots that will build the proposer set
+    uint256 constant SPRINTS_IN_SPAN = 5; // number of sprints of a span
 
     address bootProposer;
     address bootChallenger;

--- a/nightfall-deployer/contracts/Proposers.sol
+++ b/nightfall-deployer/contracts/Proposers.sol
@@ -18,105 +18,111 @@ contract Proposers is Stateful, Config, ReentrancyGuardUpgradeable {
     }
 
     /**
-     * Each proposer gets a chance to propose blocks for a certain time, defined
-     * in Ethereum blocks.  After a certain number of blocks has passed, the
-     * proposer can be rotated by calling this function. The method for choosing
-     * the next proposer is simple rotation for now.
+     @dev register proposer with stake  
      */
-    function changeCurrentProposer() external {
-        require(
-            block.number - state.getProposerStartBlock() > ROTATE_PROPOSER_BLOCKS,
-            "It's too soon to rotate the proposer"
-        );
-        state.setProposerStartBlock(block.number);
-        LinkedAddress memory currentProposer = state.getCurrentProposer();
-        state.setCurrentProposer(currentProposer.nextAddress);
-        emit NewCurrentProposer(currentProposer.nextAddress);
-    }
-
-    //add the proposer to the circular linked list
-    function registerProposer(string calldata url) external payable nonReentrant onlyBootProposer {
-        require(REGISTRATION_BOND <= msg.value, 'The registration payment is incorrect');
+    function registerProposer(string calldata url) external payable nonReentrant {
+        TimeLockedStake memory stake = state.getStakeAccount(msg.sender);
+        stake.amount += msg.value;
+        require(MINIMUM_STAKE <= stake.amount, 'Proposers: Need MINIMUM_STAKE');
         require(
             state.getProposer(msg.sender).thisAddress == address(0),
-            'This proposer is already registered'
+            'Proposers: This proposer is already registered'
         );
-        // send the bond to the state contract
-        (bool success, ) = payable(address(state)).call{value: REGISTRATION_BOND}('');
-        require(success, 'Transfer failed.');
-        state.setBondAccount(msg.sender, REGISTRATION_BOND);
+
+        // send the stake to the state contract
+        (bool success, ) = payable(address(state)).call{value: MINIMUM_STAKE}('');
+        require(success, 'Proposers: Transfer failed.');
+        state.setStakeAccount(msg.sender, stake.amount, stake.challengeLocked);
+
         LinkedAddress memory currentProposer = state.getCurrentProposer();
         // cope with this being the first proposer
         if (currentProposer.thisAddress == address(0)) {
-            currentProposer = LinkedAddress(msg.sender, msg.sender, msg.sender, url);
+            currentProposer = LinkedAddress(msg.sender, msg.sender, msg.sender, url, false, 0);
             state.setProposer(msg.sender, currentProposer);
             state.setProposerStartBlock(block.number);
+            state.setNumProposers(1);
             emit NewCurrentProposer(currentProposer.thisAddress);
         } else {
-            // else, splice the new proposer into the circular linked list of proposers just behind the current proposer
-            // assume current proposer is (x,A,z) address of this proposer is B
-            LinkedAddress memory proposer; // proposer: (_,_,_)
-            proposer.thisAddress = msg.sender; // proposer: (_,B,_)
-            proposer.nextAddress = currentProposer.thisAddress; // proposer: (_,B,A)
-            proposer.previousAddress = currentProposer.previousAddress; // proposer: (x,B,A)
-            proposer.url = url;
-            // pull global state
-            LinkedAddress memory proposersPrevious =
-                state.getProposer(currentProposer.previousAddress);
-            LinkedAddress memory proposersCurrent = state.getProposer(currentProposer.thisAddress);
-            // updated the pulled state
-            proposersPrevious.nextAddress = proposer.thisAddress; // X: (u,v,B)
-            proposersCurrent.previousAddress = proposer.thisAddress; // current: (B,A,z)
-            if (proposersPrevious.thisAddress == proposersCurrent.thisAddress) {
-                // case register second proposer
-                proposersCurrent.nextAddress = proposer.thisAddress; // previous and next Address is the second proposer
+            // only if it's not a proposer yet
+            if (state.getProposer(msg.sender).thisAddress == address(0)) {
+                // else, splice the new proposer into the circular linked list of proposers just behind the current proposer
+                // assume current proposer is (x,A,z) address of this proposer is B
+                LinkedAddress memory proposer; // proposer: (_,_,_)
+                proposer.thisAddress = msg.sender; // proposer: (_,B,_)
+                proposer.nextAddress = currentProposer.thisAddress; // proposer: (_,B,A)
+                proposer.previousAddress = currentProposer.previousAddress; // proposer: (x,B,A)
+                // pull global state
+                LinkedAddress memory proposersPrevious = state.getProposer(
+                    currentProposer.previousAddress
+                );
+                LinkedAddress memory proposersCurrent = state.getProposer(
+                    currentProposer.thisAddress
+                );
+                // updated the pulled state
+                proposersPrevious.nextAddress = proposer.thisAddress; // X: (u,v,B)
+                proposersCurrent.previousAddress = proposer.thisAddress; // current: (B,A,z)
+                if (proposersPrevious.thisAddress == proposersCurrent.thisAddress) {
+                    // case register second proposer
+                    proposersCurrent.nextAddress = proposer.thisAddress; // previous and next Address is the second proposer
+                }
+                currentProposer = proposersCurrent; // ensure sync: currentProposer: (B,A,z)
+                // set global state to new values
+                if (proposersPrevious.thisAddress != proposersCurrent.thisAddress) {
+                    // not case register second proposer
+                    state.setProposer(proposersPrevious.thisAddress, proposersPrevious);
+                }
+                state.setProposer(proposersCurrent.thisAddress, proposersCurrent);
+                state.setProposer(msg.sender, proposer);
+                state.setNumProposers(state.getNumProposers() + 1);
             }
-            currentProposer = proposersCurrent; // ensure sync: currentProposer: (B,A,z)
-            // set global state to new values
-            if (proposersPrevious.thisAddress != proposersCurrent.thisAddress) {
-                // not case register second proposer
-                state.setProposer(proposersPrevious.thisAddress, proposersPrevious);
-            }
-            state.setProposer(proposersCurrent.thisAddress, proposersCurrent);
-            state.setProposer(msg.sender, proposer);
         }
         state.setCurrentProposer(currentProposer.thisAddress);
     }
 
     // Proposers are allowed to deregister themselves at any point (even if they are the current proposer)
-    // However, their bond is only withdrawable after the COOLING_OFF_PERIOD has passed. This ensures
+    // However, their stake is only withdrawable after the CHALLENGE_PERIOD has passed. This ensures
     // they are not the proposer of any blocks that could be challenged.
     function deRegisterProposer() external {
         require(
             state.getProposer(msg.sender).thisAddress != address(0),
-            'This proposer is not registered or you are not that proposer'
+            'Proposers: Not a proposer'
         );
         state.removeProposer(msg.sender);
-        // The msg.sender has to wait a COOLING_OFF_PERIOD from current block.timestamp
-        state.updateBondAccountTime(msg.sender, block.timestamp);
+        // The msg.sender has to wait a CHALLENGE_PERIOD from current block.timestamp
+        state.updateStakeAccountTime(msg.sender, block.timestamp);
     }
 
-    function withdrawBond() external {
-        TimeLockedBond memory bond = state.getBondAccount(msg.sender);
+    function withdrawStake() external {
+        TimeLockedStake memory stake = state.getStakeAccount(msg.sender);
         require(
-            bond.time + COOLING_OFF_PERIOD < block.timestamp,
-            'It is too soon to withdraw your bond'
+            stake.time + CHALLENGE_PERIOD < block.timestamp,
+            'Proposers: Too soon to withdraw the stake'
         );
         require(
             state.getProposer(msg.sender).thisAddress == address(0),
-            'Cannot withdraw bond while a registered proposer'
+            'Proposers: Cannot withdraw while staking as proposer'
         );
-        // Zero out the entry in the bond escrow
-        state.setBondAccount(msg.sender, 0);
-        state.addPendingWithdrawal(msg.sender, bond.amount, 0);
+        // Zero out the entry in the stake escrow
+        state.setStakeAccount(msg.sender, 0, 0);
+        // We have waited a CHALLENGE_PERIOD so we can also withdraw the pending challengeLocked still pending
+        state.addPendingWithdrawal(msg.sender, stake.amount + stake.challengeLocked, 0);
     }
 
-    // Proposers can change REST API URL
-    function updateProposer(string calldata url) external {
+    // Proposers can change REST API URL or increment stake
+    function updateProposer(string calldata url) external payable nonReentrant {
         require(
             state.getProposer(msg.sender).thisAddress != address(0),
-            'This proposer is not registered or you are not that proposer'
+            'Proposers: This proposer is not registered or you are not that proposer'
         );
         state.updateProposer(msg.sender, url);
+        if (msg.value > 0) {
+            TimeLockedStake memory stake = state.getStakeAccount(msg.sender);
+            stake.amount += msg.value;
+
+            // send the stake to the state contract
+            (bool success, ) = payable(address(state)).call{value: MINIMUM_STAKE}('');
+            require(success, 'Proposers: Transfer failed.');
+            state.setStakeAccount(msg.sender, stake.amount, stake.challengeLocked);
+        }
     }
 }

--- a/nightfall-deployer/contracts/Proposers.sol
+++ b/nightfall-deployer/contracts/Proposers.sol
@@ -82,7 +82,7 @@ contract Proposers is Stateful, Config, ReentrancyGuardUpgradeable {
     // Proposers are allowed to deregister themselves at any point (even if they are the current proposer)
     // However, their stake is only withdrawable after the CHALLENGE_PERIOD has passed. This ensures
     // they are not the proposer of any blocks that could be challenged.
-    function deRegisterProposer() external {
+    function deRegisterProposer() external nonReentrant {
         require(
             state.getProposer(msg.sender).thisAddress != address(0),
             'Proposers: Not a proposer'

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -372,9 +372,10 @@ contract State is Initializable, ReentrancyGuardUpgradeable, Pausable, Config {
             previousAddress == currentProposer.thisAddress ||
             nextAddress == currentProposer.thisAddress
         ) {
-            currentProposer = proposers[currentProposer.thisAddress]; // we need to refresh the current proposer
+            currentProposer = proposers[currentProposer.thisAddress]; // we need to refresh the current proposer addresses
         }
         if (proposer == currentProposer.thisAddress) {
+            currentProposer = proposers[currentProposer.nextAddress]; // we need to refresh the current proposer before the change
             proposerStartBlock = 0;
             changeCurrentProposer();
         }

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -502,7 +502,10 @@ contract State is Initializable, ReentrancyGuardUpgradeable, Pausable, Config {
             ProposerSet memory peer;
             uint256 totalEffectiveWeight = 0;
 
-            if (currentSprint == SPRINTS_IN_SPAN || proposerStartBlock == 0) currentSprint = 0;
+            if (currentSprint == SPRINTS_IN_SPAN || proposerStartBlock == 0) {
+                currentProposer = proposers[currentProposer.nextAddress]; // it could be removed
+                currentSprint = 0;
+            }
             if (currentSprint == 0) initializeSpan();
 
             for (uint256 i = 0; i < proposersSet.length; i++) {

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -120,22 +120,19 @@ contract State is Initializable, ReentrancyGuardUpgradeable, Pausable, Config {
         stake.challengeLocked += BLOCK_STAKE;
         stakeAccounts[msg.sender] = TimeLockedStake(stake.amount, stake.challengeLocked, 0);
 
-        uint256 feePaymentsEth = 0;
-        uint256 feePaymentsMatic = 0;
+        bytes32 input = keccak256(abi.encodePacked(b.proposer, b.blockNumberL2));
+        feeBook[input][0] = 0; // fee payments Eth
+        feeBook[input][1] = 0; // fee payments Matic
+
         for (uint256 i = 0; i < t.length; i++) {
             if (t[i].transactionType == TransactionTypes.DEPOSIT) {
-                feePaymentsEth += uint256(t[i].fee);
+                feeBook[input][0] += uint256(t[i].fee);
             } else {
-                feePaymentsMatic += uint256(t[i].fee);
+                feeBook[input][1] += uint256(t[i].fee);
             }
         }
 
-        bytes32 input = keccak256(abi.encodePacked(b.proposer, b.blockNumberL2));
-        feeBook[input][0] = feePaymentsEth;
-        feeBook[input][1] = feePaymentsMatic;
-
         bytes32 blockHash;
-
         uint256 blockSlots = BLOCK_STRUCTURE_SLOTS; //Number of slots that the block structure has
         uint256 transactionSlots = TRANSACTION_STRUCTURE_SLOTS; //Number of slots that the transaction structure has
 

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -368,6 +368,12 @@ contract State is Initializable, ReentrancyGuardUpgradeable, Pausable, Config {
         numProposers--;
         proposers[previousAddress].nextAddress = proposers[nextAddress].thisAddress;
         proposers[nextAddress].previousAddress = proposers[previousAddress].thisAddress;
+        if (
+            previousAddress == currentProposer.thisAddress ||
+            nextAddress == currentProposer.thisAddress
+        ) {
+            currentProposer = proposers[currentProposer.thisAddress]; // we need to refresh the current proposer
+        }
         if (proposer == currentProposer.thisAddress) {
             proposerStartBlock = 0;
             changeCurrentProposer();

--- a/nightfall-deployer/contracts/Structures.sol
+++ b/nightfall-deployer/contracts/Structures.sol
@@ -81,10 +81,13 @@ contract Structures {
         address previousAddress;
         address nextAddress;
         string url;
+        bool inProposerSet;
+        uint256 indexProposerSet;
     }
 
-    struct TimeLockedBond {
+    struct TimeLockedStake {
         uint256 amount; // The amount held
+        uint256 challengeLocked; // The amount locked by block proposed still in CHALLENGE_PERIOD and not claimed
         uint256 time; // The time the funds were locked from
     }
 
@@ -103,5 +106,15 @@ contract Structures {
         Transaction transaction;
         uint256 transactionIndex;
         bytes32[] transactionSiblingPath;
+    }
+
+    /**
+     * @dev Element of the proposer set for next span
+     */
+    struct ProposerSet {
+        address thisAddress;
+        uint256 weight;
+        int256 currentWeight;
+        uint256 effectiveWeight;
     }
 }

--- a/nightfall-optimist/src/routes/proposer.mjs
+++ b/nightfall-optimist/src/routes/proposer.mjs
@@ -305,10 +305,8 @@ router.get('/change', async (req, res, next) => {
   logger.debug({ msg: '/change endpoint', payload: JSON.stringify(req.body, null, 2) });
 
   try {
-    const proposersContractInstance = await getContractInstance(PROPOSERS_CONTRACT_NAME);
-    const txDataToSign = await proposersContractInstance.methods
-      .changeCurrentProposer()
-      .encodeABI();
+    const stateContractInstance = await getContractInstance(STATE_CONTRACT_NAME);
+    const txDataToSign = await stateContractInstance.methods.changeCurrentProposer().encodeABI();
 
     logger.debug({
       msg: 'Returning raw transaction data',

--- a/nightfall-optimist/src/routes/proposer.mjs
+++ b/nightfall-optimist/src/routes/proposer.mjs
@@ -18,6 +18,8 @@ import {
   deleteRegisteredProposerAddress,
   getMempoolTransactions,
   getLatestTree,
+  findBlocksByProposer,
+  getBlockByBlockHash,
 } from '../services/database.mjs';
 import { waitForContract } from '../event-handlers/subscribe.mjs';
 import transactionSubmittedEventHandler from '../event-handlers/transaction-submitted.mjs';
@@ -183,16 +185,61 @@ router.post('/de-register', async (req, res, next) => {
 });
 
 /**
- * Function to withdraw bond for a de-registered proposer
+ * Function to withdraw stake for a de-registered proposer
  */
-router.post('/withdrawBond', async (req, res, next) => {
+
+router.post('/withdrawStake', async (req, res, next) => {
+  logger.debug(`withdrawStake endpoint received GET`);
   try {
     const proposerContractInstance = await getContractInstance(PROPOSERS_CONTRACT_NAME);
-    const txDataToSign = await proposerContractInstance.methods.withdrawBond().encodeABI();
+    const txDataToSign = await proposerContractInstance.methods.withdrawStake().encodeABI();
     res.json({ txDataToSign });
   } catch (error) {
     logger.error(error);
     next(error);
+  }
+});
+
+/**
+ * Function to get pending blocks payments for a proposer.
+ */
+router.get('/pending-payments', async (req, res, next) => {
+  logger.debug(`pending-payments endpoint received GET`);
+  const { proposerPayments = proposer } = req.query;
+  logger.debug(`requested pending payments for proposer ${proposer}`);
+
+  const pendingPayments = [];
+  // get blocks by proposer
+  try {
+    const blocks = await findBlocksByProposer(proposerPayments);
+    const shieldContractInstance = await getContractInstance(SHIELD_CONTRACT_NAME);
+
+    for (let i = 0; i < blocks.length; i++) {
+      let pending;
+      let challengePeriod = false;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        pending = await shieldContractInstance.methods
+          .isBlockPaymentPending(blocks[i].blockHash, blocks[i].blockNumberL2)
+          .call();
+      } catch (e) {
+        if (e.message.includes('Too soon to get paid for this block')) {
+          challengePeriod = true;
+          pending = true;
+        } else {
+          pending = false;
+        }
+      }
+
+      if (pending) {
+        pendingPayments.push({ blockHash: blocks[i].blockHash, challengePeriod });
+      }
+    }
+    logger.debug('returning pending blocks payments');
+    res.json({ pendingPayments });
+  } catch (err) {
+    logger.error(err);
+    next(err);
   }
 });
 
@@ -226,10 +273,10 @@ router.get('/withdraw', async (req, res, next) => {
  * withdrawal and then /withdraw needs to be called to recover the money.
  */
 router.post('/payment', async (req, res, next) => {
-  logger.debug({ msg: '/payment endpoint', payload: JSON.stringify(req.body, null, 2) });
-
-  const { block } = req.body;
+  logger.debug(`payment endpoint received GET ${JSON.stringify(req.body, null, 2)}`);
+  const { blockHash } = req.body;
   try {
+    const block = await getBlockByBlockHash(blockHash);
     const shieldContractInstance = await getContractInstance(SHIELD_CONTRACT_NAME);
     const txDataToSign = await shieldContractInstance.methods
       .requestBlockPayment(block)

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -106,6 +106,17 @@ export async function getBlockByTransactionHashL1(transactionHashL1) {
 }
 
 /**
+function to get a block by blockHash, if you know the hash of the block. This
+is useful for rolling back Timber.
+*/
+export async function getBlockByBlockHash(blockHash) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  const query = { blockHash };
+  return db.collection(SUBMITTED_BLOCKS_COLLECTION).findOne(query);
+}
+
+/**
 function to get a block by root, if you know the root of the block. This
 is useful for nightfall-client to establish the layer block number containing
 a given (historic) root.
@@ -201,6 +212,19 @@ export async function saveInvalidBlock(_block) {
   const query = { blockHash: block.blockHash };
   const update = { $set: block };
   return db.collection(INVALID_BLOCKS_COLLECTION).updateOne(query, update, { upsert: true });
+}
+
+/**
+ * function to find blocks produced by a proposer
+ */
+export async function findBlocksByProposer(proposer) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  const query = { proposer };
+  return db
+    .collection(SUBMITTED_BLOCKS_COLLECTION)
+    .find(query, { sort: { blockNumberL2: 1 } })
+    .toArray();
 }
 
 /**

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -105,6 +105,24 @@ export async function getBlockByTransactionHashL1(transactionHashL1) {
   return db.collection(SUBMITTED_BLOCKS_COLLECTION).findOne(query);
 }
 
+// export async function numberOfBlockWithTransactionHash(transactionHash) {
+//   const connection = await mongo.connection(MONGO_URL);
+//   const db = connection.db(OPTIMIST_DB);
+//   const query = { transactionHashes: transactionHash };
+//   return db.collection(SUBMITTED_BLOCKS_COLLECTION).countDocuments(query);
+// }
+
+/**
+function to get a block by blockHash, if you know the hash of the block. This
+is useful for rolling back Timber.
+*/
+export async function getBlockByBlockHash(blockHash) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  const query = { blockHash };
+  return db.collection(SUBMITTED_BLOCKS_COLLECTION).findOne(query);
+}
+
 /**
 function to get a block by blockHash, if you know the hash of the block. This
 is useful for rolling back Timber.

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -124,17 +124,6 @@ export async function getBlockByBlockHash(blockHash) {
 }
 
 /**
-function to get a block by blockHash, if you know the hash of the block. This
-is useful for rolling back Timber.
-*/
-export async function getBlockByBlockHash(blockHash) {
-  const connection = await mongo.connection(MONGO_URL);
-  const db = connection.db(OPTIMIST_DB);
-  const query = { blockHash };
-  return db.collection(SUBMITTED_BLOCKS_COLLECTION).findOne(query);
-}
-
-/**
 function to get a block by root, if you know the root of the block. This
 is useful for nightfall-client to establish the layer block number containing
 a given (historic) root.

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -91,7 +91,7 @@ describe('Testing with an adversary', () => {
     await nf3AdversarialProposer.init(mnemonicProposer);
     await nf3Challenger.init(mnemonicChallenger);
 
-    if (!(await nf3User.healthcheck('optimist'))) throw new Error('Healthcheck failed');
+    if (!(await nf3User.healthcheck('client'))) throw new Error('Healthcheck failed');
     if (!(await nf3AdversarialProposer.healthcheck('optimist')))
       throw new Error('Healthcheck failed');
     if (!(await nf3Challenger.healthcheck('optimist'))) throw new Error('Healthcheck failed');

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -24,6 +24,7 @@ chai.use(chaiHttp);
 chai.use(chaiAsPromised);
 
 const { TRANSACTIONS_PER_BLOCK } = config;
+const { MINIMUM_STAKE } = config.TEST_OPTIONS;
 const TX_WAIT = 12000;
 const TEST_LENGTH = 6;
 
@@ -100,7 +101,7 @@ describe('Testing with an adversary', () => {
     startBalance = await retrieveL2Balance(nf3User);
 
     // Proposer registration
-    await nf3AdversarialProposer.registerProposer();
+    await nf3AdversarialProposer.registerProposer('', MINIMUM_STAKE);
     // Proposer listening for incoming events
     const blockProposeEmitter = await nf3AdversarialProposer.startProposer();
     blockProposeEmitter

--- a/test/circuits.test.mjs
+++ b/test/circuits.test.mjs
@@ -41,13 +41,7 @@ describe('General Circuit Test', () => {
   before(async () => {
     await nf3Proposer.init(mnemonics.proposer);
     // we must set the URL from the point of view of the client container
-<<<<<<< HEAD
-    await nf3Proposer.registerProposer('http://optimis1');
-||||||| parent of 34a3c451 (fix: register proposer in tests)
-    await nf3Proposer.registerProposer('http://optimist1');
-=======
     await nf3Proposer.registerProposer('http://optimist1', MINIMUM_STAKE);
->>>>>>> 34a3c451 (fix: register proposer in tests)
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer.startProposer();

--- a/test/circuits.test.mjs
+++ b/test/circuits.test.mjs
@@ -19,6 +19,7 @@ const {
   tokenConfigs: { tokenType, tokenId },
   mnemonics,
   signingKeys,
+  MINIMUM_STAKE,
 } = config.TEST_OPTIONS;
 
 const nf3Users = [new Nf3(signingKeys.user1, environment), new Nf3(signingKeys.user2, environment)];
@@ -40,7 +41,13 @@ describe('General Circuit Test', () => {
   before(async () => {
     await nf3Proposer.init(mnemonics.proposer);
     // we must set the URL from the point of view of the client container
+<<<<<<< HEAD
     await nf3Proposer.registerProposer('http://optimis1');
+||||||| parent of 34a3c451 (fix: register proposer in tests)
+    await nf3Proposer.registerProposer('http://optimist1');
+=======
+    await nf3Proposer.registerProposer('http://optimist1', MINIMUM_STAKE);
+>>>>>>> 34a3c451 (fix: register proposer in tests)
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer.startProposer();

--- a/test/e2e/protocol/proposer.test.mjs
+++ b/test/e2e/protocol/proposer.test.mjs
@@ -4,7 +4,7 @@ import chaiHttp from 'chai-http';
 import chaiAsPromised from 'chai-as-promised';
 import config from 'config';
 import Nf3 from '../../../cli/lib/nf3.mjs';
-import logger from '../../../common-files/utils/logger.mjs';
+// import logger from '../../../common-files/utils/logger.mjs';
 import { Web3Client, expectTransaction } from '../../utils.mjs';
 
 // so we can use require with mjs file
@@ -14,17 +14,11 @@ chai.use(chaiAsPromised);
 
 const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
 
-const {
-  // txPerBlock,
-  mnemonics,
-  signingKeys,
-  // tokenConfigs: { tokenType, tokenId },
-  // transferValue,
-  // fee,
-} = config.TEST_OPTIONS;
+const { mnemonics, signingKeys, MINIMUM_STAKE, ROTATE_PROPOSER_BLOCKS } = config.TEST_OPTIONS;
 
 const bootProposer = new Nf3(signingKeys.proposer1, environment);
-const testProposer = new Nf3(signingKeys.proposer2, environment);
+const secondProposer = new Nf3(signingKeys.proposer2, environment);
+const thirdProposer = new Nf3(signingKeys.proposer3, environment);
 
 const testProposersUrl = [
   'http://test-proposer1',
@@ -33,60 +27,325 @@ const testProposersUrl = [
   'http://test-proposer4',
 ];
 
-// const totalDeposits = txPerBlock * 3;
 const nf3User = new Nf3(signingKeys.user1, environment);
 
 const web3Client = new Web3Client();
+let web3;
+
+const miniStateABI = [
+  {
+    inputs: [{ internalType: 'address', name: 'addr', type: 'address' }],
+    name: 'getStakeAccount',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'uint256',
+            name: 'amount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'challengeLocked',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'time',
+            type: 'uint256',
+          },
+        ],
+        internalType: 'struct Structures.TimeLockedStake',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getCurrentProposer',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'address',
+            name: 'thisAddress',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'previousAddress',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'nextAddress',
+            type: 'address',
+          },
+          {
+            internalType: 'string',
+            name: 'url',
+            type: 'string',
+          },
+        ],
+        internalType: 'struct Structures.LinkedAddress',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'currentSprint',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+let stateAddress;
+
+const getStakeAccount = async ethAccount => {
+  const stateContractInstance = new web3.eth.Contract(miniStateABI, stateAddress);
+  const stakeAccount = await stateContractInstance.methods.getStakeAccount(ethAccount).call();
+  return stakeAccount;
+};
+
+const getCurrentProposer = async () => {
+  const stateContractInstance = new web3.eth.Contract(miniStateABI, stateAddress);
+  const currentProposer = await stateContractInstance.methods.getCurrentProposer().call();
+  return currentProposer;
+};
+
+const getCurrentSprint = async () => {
+  const stateContractInstance = new web3.eth.Contract(miniStateABI, stateAddress);
+  const currentSprint = await stateContractInstance.methods.currentSprint().call();
+  return currentSprint;
+};
 
 describe('Basic Proposer tests', () => {
   before(async () => {
+    web3 = web3Client.getWeb3();
     await nf3User.init(mnemonics.user1);
 
     await bootProposer.init(mnemonics.proposer);
-    await testProposer.init(mnemonics.proposer);
-    // Proposer registration
-    await bootProposer.registerProposer(testProposersUrl[0]);
-    const blockProposeEmitter = await bootProposer.startProposer();
-    blockProposeEmitter
-      .on('receipt', (receipt, block) => {
-        logger.debug(
-          `L2 Block with L2 block number ${block.blockNumberL2} was proposed. The L1 transaction hash is ${receipt.transactionHash}`,
-        );
-      })
-      .on('error', (error, block) => {
-        logger.error(
-          `Proposing L2 Block with L2 block number ${block.blockNumberL2} failed due to error: ${error} `,
-        );
-      });
-  });
+    await secondProposer.init(mnemonics.proposer);
+    await thirdProposer.init(mnemonics.proposer);
 
-  it('should fail to register a proposer other than the boot proposer', async () => {
-    try {
-      const res = await testProposer.registerProposer();
-      expectTransaction(res);
-    } catch (error) {
-      expect(error.message).to.satisfy(message =>
-        message.includes('Transaction has been reverted by the EVM'),
-      );
+    stateAddress = await bootProposer.getContractAddress('State');
+
+    let proposers;
+    ({ proposers } = await bootProposer.getProposers());
+
+    let findProposer = proposers.filter(p => p.thisAddress === secondProposer.ethereumAddress);
+    if (findProposer.length === 1) {
+      console.log('De-register second proposer...');
+      try {
+        await secondProposer.deregisterProposer();
+      } catch (e) {
+        console.log(e);
+      }
+    }
+
+    findProposer = proposers.filter(p => p.thisAddress === thirdProposer.ethereumAddress);
+    if (findProposer.length === 1) {
+      console.log('De-register third proposer...');
+      try {
+        await secondProposer.deregisterProposer();
+      } catch (e) {
+        console.log(e);
+      }
+    }
+
+    findProposer = proposers.filter(p => p.thisAddress === bootProposer.ethereumAddress);
+    if (findProposer.length === 1) {
+      console.log('De-register boot proposer...');
+      try {
+        await bootProposer.deregisterProposer();
+      } catch (e) {
+        console.log(e);
+      }
     }
   });
 
-  it('should update proposers url', async () => {
+  it('should register the boot proposer', async () => {
     let proposers;
     ({ proposers } = await bootProposer.getProposers());
-    // we have to pay 10 ETH to be registered
-    const res = await bootProposer.updateProposer(testProposersUrl[3]);
+    const currentProposer = proposers.filter(p => p.thisAddress === bootProposer.ethereumAddress);
+    // In order to begin from 0 producing L2 blocks
+    if (currentProposer.length === 1) {
+      console.log('De-register proposer...');
+      try {
+        await bootProposer.deregisterProposer();
+      } catch (e) {
+        console.log(e);
+      }
+    }
+
+    const stakeAccount1 = await getStakeAccount(bootProposer.ethereumAddress);
+    const res = await bootProposer.registerProposer(testProposersUrl[0], MINIMUM_STAKE);
+    expectTransaction(res);
+    const stakeAccount2 = await getStakeAccount(bootProposer.ethereumAddress);
+    ({ proposers } = await bootProposer.getProposers());
+    const thisProposer = proposers.filter(p => p.thisAddress === bootProposer.ethereumAddress);
+    expect(thisProposer.length).to.be.equal(1);
+    expect(Number(stakeAccount2.amount)).equal(
+      Number(stakeAccount1.amount) + Number(MINIMUM_STAKE),
+    );
+  });
+
+  it('should allow to register a second proposer other than the boot proposer', async () => {
+    let proposers;
+    ({ proposers } = await secondProposer.getProposers());
+    const currentProposer = proposers.filter(p => p.thisAddress === secondProposer.ethereumAddress);
+    // In order to begin from 0 producing L2 blocks
+    if (currentProposer.length === 1) {
+      console.log('De-register proposer...');
+      try {
+        await secondProposer.deregisterProposer();
+      } catch (e) {
+        console.log(e);
+      }
+    }
+
+    const stakeAccount1 = await getStakeAccount(secondProposer.ethereumAddress);
+    const res = await secondProposer.registerProposer(testProposersUrl[0], MINIMUM_STAKE);
+    expectTransaction(res);
+    const stakeAccount2 = await getStakeAccount(secondProposer.ethereumAddress);
+    ({ proposers } = await secondProposer.getProposers());
+    const thisProposer = proposers.filter(p => p.thisAddress === secondProposer.ethereumAddress);
+    expect(thisProposer.length).to.be.equal(1);
+    expect(Number(stakeAccount2.amount)).equal(
+      Number(stakeAccount1.amount) + Number(MINIMUM_STAKE),
+    );
+  });
+
+  it('should allow to register a third proposer other than the boot proposer', async () => {
+    let proposers;
+    ({ proposers } = await thirdProposer.getProposers());
+    const currentProposer = proposers.filter(p => p.thisAddress === thirdProposer.ethereumAddress);
+    // In order to begin from 0 producing L2 blocks
+    if (currentProposer.length === 1) {
+      console.log('De-register proposer...');
+      try {
+        await thirdProposer.deregisterProposer();
+      } catch (e) {
+        console.log(e);
+      }
+    }
+
+    const stakeAccount1 = await getStakeAccount(thirdProposer.ethereumAddress);
+    const res = await thirdProposer.registerProposer(testProposersUrl[0], MINIMUM_STAKE);
+    expectTransaction(res);
+    const stakeAccount2 = await getStakeAccount(thirdProposer.ethereumAddress);
+    ({ proposers } = await thirdProposer.getProposers());
+    const thisProposer = proposers.filter(p => p.thisAddress === thirdProposer.ethereumAddress);
+    expect(thisProposer.length).to.be.equal(1);
+    expect(Number(stakeAccount2.amount)).equal(
+      Number(stakeAccount1.amount) + Number(MINIMUM_STAKE),
+    );
+  });
+
+  it('should update proposer url', async () => {
+    let proposers;
+    ({ proposers } = await bootProposer.getProposers());
+    // we have to pay stake to be registered
+    const res = await bootProposer.updateProposer(testProposersUrl[3], 0);
     expectTransaction(res);
     ({ proposers } = await bootProposer.getProposers());
     const thisProposer = proposers.filter(p => p.thisAddress === bootProposer.ethereumAddress);
     expect(thisProposer.length).to.be.equal(1);
-    expect(proposers[0].url).to.be.equal(testProposersUrl[3]);
+    expect(thisProposer[0].url).to.be.equal(testProposersUrl[3]);
+  });
+
+  it('should increment the stake of the proposer', async () => {
+    const initialStake = await getStakeAccount(bootProposer.ethereumAddress);
+    const res = await bootProposer.updateProposer(testProposersUrl[0], MINIMUM_STAKE);
+    expectTransaction(res);
+    const finalStake = await getStakeAccount(bootProposer.ethereumAddress);
+    expect(Number(finalStake.amount)).to.be.equal(
+      Number(initialStake.amount) + Number(MINIMUM_STAKE),
+    );
   });
 
   it('should fail to register a proposer twice', async () => {
-    const res = await bootProposer.registerProposer(testProposersUrl[2]);
+    const res = await bootProposer.registerProposer(testProposersUrl[2], MINIMUM_STAKE);
     // eslint-disable-next-line @babel/no-unused-expressions
     expect(res).to.be.false;
+  });
+
+  it('should create a failing changeCurrentProposer (because insufficient blocks has passed)', async function () {
+    let error = null;
+    try {
+      const res = await secondProposer.changeCurrentProposer();
+      expectTransaction(res);
+    } catch (err) {
+      error = err;
+    }
+    expect(error.message).to.satisfy(message =>
+      message.includes('Transaction has been reverted by the EVM'),
+    );
+  });
+
+  it('Should create a valid changeCurrentProposer (because blocks has passed)', async function () {
+    for (let i = 0; i < 10; i++) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const currentSprint = await getCurrentSprint();
+        // eslint-disable-next-line no-await-in-loop
+        const currentProposer = await getCurrentProposer();
+        console.log(
+          `     [ Current sprint: ${currentSprint}, Current proposer: ${currentProposer.thisAddress} ]`,
+        );
+        console.log('     Waiting blocks to rotate current proposer...');
+        const initBlock = await web3.eth.getBlockNumber();
+        let currentBlock = initBlock;
+
+        while (currentBlock - initBlock < ROTATE_PROPOSER_BLOCKS) {
+          await new Promise(resolve => setTimeout(resolve, 10000));
+          currentBlock = await web3.eth.getBlockNumber();
+        }
+
+        const res = await secondProposer.changeCurrentProposer();
+        expectTransaction(res);
+      } catch (err) {
+        console.log(err);
+      }
+    }
+  });
+
+  it('should unregister the third proposer', async () => {
+    let proposers;
+    ({ proposers } = await thirdProposer.getProposers());
+    let thisProposer = proposers.filter(p => p.thisAddress === thirdProposer.ethereumAddress);
+    expect(thisProposer.length).to.be.equal(1);
+    const res = await thirdProposer.deregisterProposer();
+    expectTransaction(res);
+    ({ proposers } = await thirdProposer.getProposers());
+    thisProposer = proposers.filter(p => p.thisAddress === thirdProposer.ethereumAddress);
+    expect(thisProposer.length).to.be.equal(0);
+  });
+
+  it('should unregister the second proposer', async () => {
+    let proposers;
+    ({ proposers } = await secondProposer.getProposers());
+    let thisProposer = proposers.filter(p => p.thisAddress === secondProposer.ethereumAddress);
+    expect(thisProposer.length).to.be.equal(1);
+    const res = await secondProposer.deregisterProposer();
+    expectTransaction(res);
+    ({ proposers } = await secondProposer.getProposers());
+    thisProposer = proposers.filter(p => p.thisAddress === secondProposer.ethereumAddress);
+    expect(thisProposer.length).to.be.equal(0);
   });
 
   it('should unregister the boot proposer', async () => {
@@ -101,10 +360,10 @@ describe('Basic Proposer tests', () => {
     expect(thisProposer.length).to.be.equal(0);
   });
 
-  it('Should create a failing withdrawBond (because insufficient time has passed)', async () => {
+  it('Should create a failing withdrawStake (because insufficient time has passed)', async () => {
     let error = null;
     try {
-      await bootProposer.withdrawBond();
+      await bootProposer.withdrawStake();
     } catch (err) {
       error = err;
     }
@@ -116,15 +375,15 @@ describe('Basic Proposer tests', () => {
     );
   });
 
-  it('Should create a passing withdrawBond (because sufficient time has passed)', async () => {
+  it('Should create a passing withdrawStake (because sufficient time has passed)', async () => {
     if ((await web3Client.getInfo()).includes('TestRPC')) await web3Client.timeJump(3600 * 24 * 10); // jump in time by 7 days
     if ((await web3Client.getInfo()).includes('TestRPC')) {
-      const res = await bootProposer.withdrawBond();
+      const res = await bootProposer.withdrawStake();
       expectTransaction(res);
     } else {
       let error = null;
       try {
-        await bootProposer.withdrawBond();
+        await bootProposer.withdrawStake();
       } catch (err) {
         error = err;
       }
@@ -134,7 +393,8 @@ describe('Basic Proposer tests', () => {
 
   after(async () => {
     // After the proposer tests, unregister proposers
-    await testProposer.close();
+    await thirdProposer.close();
+    await secondProposer.close();
     await bootProposer.close();
     web3Client.closeWeb3();
   });

--- a/test/e2e/protocol/proposer.test.mjs
+++ b/test/e2e/protocol/proposer.test.mjs
@@ -303,7 +303,7 @@ describe('Basic Proposer tests', () => {
   });
 
   it('Should create a valid changeCurrentProposer (because blocks has passed)', async function () {
-    for (let i = 0; i < 6; i++) {
+    for (let i = 0; i < 8; i++) {
       try {
         // eslint-disable-next-line no-await-in-loop
         const currentSprint = await getCurrentSprint();
@@ -330,6 +330,9 @@ describe('Basic Proposer tests', () => {
   });
 
   it('should unregister the third proposer', async () => {
+    const currentProposer = await getCurrentProposer();
+    console.log('currentProposer', currentProposer);
+    await new Promise(resolve => setTimeout(resolve, 10000));
     let proposers;
     ({ proposers } = await thirdProposer.getProposers());
     let thisProposer = proposers.filter(p => p.thisAddress === thirdProposer.ethereumAddress);
@@ -342,6 +345,9 @@ describe('Basic Proposer tests', () => {
   });
 
   it('should unregister the second proposer', async () => {
+    const currentProposer = await getCurrentProposer();
+    console.log('currentProposer', currentProposer);
+    await new Promise(resolve => setTimeout(resolve, 10000));
     let proposers;
     ({ proposers } = await secondProposer.getProposers());
     let thisProposer = proposers.filter(p => p.thisAddress === secondProposer.ethereumAddress);
@@ -354,6 +360,9 @@ describe('Basic Proposer tests', () => {
   });
 
   it('should unregister the boot proposer', async () => {
+    const currentProposer = await getCurrentProposer();
+    console.log('currentProposer', currentProposer);
+    await new Promise(resolve => setTimeout(resolve, 10000));
     let proposers;
     ({ proposers } = await bootProposer.getProposers());
     let thisProposer = proposers.filter(p => p.thisAddress === bootProposer.ethereumAddress);

--- a/test/e2e/protocol/proposer.test.mjs
+++ b/test/e2e/protocol/proposer.test.mjs
@@ -330,9 +330,6 @@ describe('Basic Proposer tests', () => {
   });
 
   it('should unregister the third proposer', async () => {
-    const currentProposer = await getCurrentProposer();
-    console.log('currentProposer', currentProposer);
-    await new Promise(resolve => setTimeout(resolve, 10000));
     let proposers;
     ({ proposers } = await thirdProposer.getProposers());
     let thisProposer = proposers.filter(p => p.thisAddress === thirdProposer.ethereumAddress);
@@ -345,9 +342,6 @@ describe('Basic Proposer tests', () => {
   });
 
   it('should unregister the second proposer', async () => {
-    const currentProposer = await getCurrentProposer();
-    console.log('currentProposer', currentProposer);
-    await new Promise(resolve => setTimeout(resolve, 10000));
     let proposers;
     ({ proposers } = await secondProposer.getProposers());
     let thisProposer = proposers.filter(p => p.thisAddress === secondProposer.ethereumAddress);
@@ -360,9 +354,6 @@ describe('Basic Proposer tests', () => {
   });
 
   it('should unregister the boot proposer', async () => {
-    const currentProposer = await getCurrentProposer();
-    console.log('currentProposer', currentProposer);
-    await new Promise(resolve => setTimeout(resolve, 10000));
     let proposers;
     ({ proposers } = await bootProposer.getProposers());
     let thisProposer = proposers.filter(p => p.thisAddress === bootProposer.ethereumAddress);

--- a/test/e2e/protocol/proposer.test.mjs
+++ b/test/e2e/protocol/proposer.test.mjs
@@ -143,9 +143,7 @@ describe('Basic Proposer tests', () => {
     await thirdProposer.init(mnemonics.proposer);
 
     stateAddress = await bootProposer.getContractAddress('State');
-
-    let proposers;
-    ({ proposers } = await bootProposer.getProposers());
+    const { proposers } = await bootProposer.getProposers();
 
     let findProposer = proposers.filter(p => p.thisAddress === secondProposer.ethereumAddress);
     if (findProposer.length === 1) {

--- a/test/e2e/protocol/proposer.test.mjs
+++ b/test/e2e/protocol/proposer.test.mjs
@@ -330,6 +330,9 @@ describe('Basic Proposer tests', () => {
   });
 
   it('should unregister the third proposer', async () => {
+    const currentProposer = await getCurrentProposer();
+    console.log('currentProposer', currentProposer);
+    await new Promise(resolve => setTimeout(resolve, 10000));
     let proposers;
     ({ proposers } = await thirdProposer.getProposers());
     let thisProposer = proposers.filter(p => p.thisAddress === thirdProposer.ethereumAddress);
@@ -342,6 +345,9 @@ describe('Basic Proposer tests', () => {
   });
 
   it('should unregister the second proposer', async () => {
+    const currentProposer = await getCurrentProposer();
+    console.log('currentProposer', currentProposer);
+    await new Promise(resolve => setTimeout(resolve, 10000));
     let proposers;
     ({ proposers } = await secondProposer.getProposers());
     let thisProposer = proposers.filter(p => p.thisAddress === secondProposer.ethereumAddress);
@@ -354,6 +360,9 @@ describe('Basic Proposer tests', () => {
   });
 
   it('should unregister the boot proposer', async () => {
+    const currentProposer = await getCurrentProposer();
+    console.log('currentProposer', currentProposer);
+    await new Promise(resolve => setTimeout(resolve, 10000));
     let proposers;
     ({ proposers } = await bootProposer.getProposers());
     let thisProposer = proposers.filter(p => p.thisAddress === bootProposer.ethereumAddress);

--- a/test/e2e/protocol/proposer.test.mjs
+++ b/test/e2e/protocol/proposer.test.mjs
@@ -340,6 +340,8 @@ describe('Basic Proposer tests', () => {
     }
 
     await emptyL2();
+    await new Promise(resolve => setTimeout(resolve, 10000));
+
     const afterZkpPublicKeyBalance =
       (await nf3User.getLayer2Balances())[erc20Address]?.[0].balance || 0;
     expect(afterZkpPublicKeyBalance - currentZkpPublicKeyBalance).to.be.equal(

--- a/test/e2e/tokens/erc1155.test.mjs
+++ b/test/e2e/tokens/erc1155.test.mjs
@@ -24,6 +24,7 @@ const {
   tokenConfigs: { tokenTypeERC1155, tokenType, tokenId },
   mnemonics,
   signingKeys,
+  MINIMUM_STAKE,
 } = config.TEST_OPTIONS;
 
 const nf3Users = [new Nf3(signingKeys.user1, environment), new Nf3(signingKeys.user2, environment)];
@@ -55,7 +56,7 @@ const emptyL2 = async () => {
 describe('ERC1155 tests', () => {
   before(async () => {
     await nf3Proposer1.init(mnemonics.proposer);
-    await nf3Proposer1.registerProposer();
+    await nf3Proposer1.registerProposer('', MINIMUM_STAKE);
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer1.startProposer();

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -28,6 +28,7 @@ const {
   mnemonics,
   signingKeys,
   restrictions: { erc20default },
+  MINIMUM_STAKE,
 } = config.TEST_OPTIONS;
 
 const {
@@ -72,7 +73,7 @@ describe('ERC20 tests', () => {
   before(async () => {
     await nf3Proposer.init(mnemonics.proposer);
     // we must set the URL from the point of view of the client container
-    await nf3Proposer.registerProposer('http://optimist');
+    await nf3Proposer.registerProposer('http://optimist1', MINIMUM_STAKE);
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer.startProposer();

--- a/test/e2e/tokens/erc721.test.mjs
+++ b/test/e2e/tokens/erc721.test.mjs
@@ -22,6 +22,7 @@ const {
   tokenConfigs: { tokenTypeERC721, tokenType, tokenId },
   mnemonics,
   signingKeys,
+  MINIMUM_STAKE,
 } = config.TEST_OPTIONS;
 
 const nf3Users = [new Nf3(signingKeys.user1, environment), new Nf3(signingKeys.user2, environment)];
@@ -59,7 +60,7 @@ const emptyL2 = async () => {
 describe('ERC721 tests', () => {
   before(async () => {
     await nf3Proposer1.init(mnemonics.proposer);
-    await nf3Proposer1.registerProposer();
+    await nf3Proposer1.registerProposer('', MINIMUM_STAKE);
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer1.startProposer();

--- a/test/gas.test.mjs
+++ b/test/gas.test.mjs
@@ -26,6 +26,7 @@ const {
   tokenConfigs: { tokenType, tokenId },
   mnemonics,
   signingKeys,
+  MINIMUM_STAKE,
 } = config.TEST_OPTIONS;
 
 const txPerBlock = process.env.TRANSACTIONS_PER_BLOCK || 32;
@@ -46,7 +47,7 @@ describe('Gas test', () => {
   let gasCost = 0;
   before(async () => {
     await nf3Proposer1.init(mnemonics.proposer);
-    await nf3Proposer1.registerProposer();
+    await nf3Proposer1.registerProposer('', MINIMUM_STAKE);
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer1.startProposer();

--- a/test/optimist-resync.test.mjs
+++ b/test/optimist-resync.test.mjs
@@ -25,6 +25,7 @@ const {
   tokenConfigs: { tokenType, tokenId },
   mnemonics,
   signingKeys,
+  MINIMUM_STAKE,
 } = config.TEST_OPTIONS;
 
 const { PROPOSE_BLOCK } = config.SIGNATURES;
@@ -57,7 +58,7 @@ describe('Optimist synchronisation tests', () => {
     await nf3Proposer1.init(mnemonics.proposer);
     await nf3Challenger.init(mnemonics.challenger);
     // we must set the URL from the point of view of the client container
-    await nf3Proposer1.registerProposer('http://optimist');
+    await nf3Proposer1.registerProposer('http://optimist', MINIMUM_STAKE);
 
     // Proposer listening for incoming events
     blockProposeEmitter = await nf3Proposer1.startProposer();
@@ -148,7 +149,7 @@ describe('Optimist synchronisation tests', () => {
       await restartOptimist();
 
       // we need to remind optimist which proposer it's connected to
-      await nf3Proposer1.registerProposer('http://optimist');
+      await nf3Proposer1.registerProposer('http://optimist', MINIMUM_STAKE);
       // TODO - get optimist to do this automatically.
       // Now we'll add another block and check that it's blocknumber is correct, indicating
       // that a resync correctly occured
@@ -231,7 +232,7 @@ describe('Optimist synchronisation tests', () => {
       logger.debug('rollback complete event received');
       // the rollback will have removed us as proposer. We need to re-register because we
       // were the only proposer in town!
-      await nf3Proposer1.registerProposer('http://optimist');
+      await nf3Proposer1.registerProposer('http://optimist', MINIMUM_STAKE);
       // Now we'll add another block and check that it's blocknumber is correct, indicating
       // that a rollback correctly occured
       logger.debug(`      Sending ${txPerBlock} deposits...`);

--- a/test/ping-pong/ping-pong.test.mjs
+++ b/test/ping-pong/ping-pong.test.mjs
@@ -4,18 +4,15 @@ import Nf3 from '../../cli/lib/nf3.mjs';
 
 const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
 
-const { mnemonics, signingKeys } = config.TEST_OPTIONS;
+const { mnemonics, signingKeys, MINIMUM_STAKE } = config.TEST_OPTIONS;
 const nf3Proposer = new Nf3(signingKeys.proposer1, environment);
 
 describe('Ping-pong tests', () => {
   before(async () => {
-    if (process.env.ENVIRONMENT !== 'aws') {
-      console.log('Start proposer');
-      await nf3Proposer.init(mnemonics.proposer);
-      // we must set the URL from the point of view of the client container
-      await nf3Proposer.registerProposer('http://optimist');
-      await nf3Proposer.startProposer();
-    }
+    await nf3Proposer.init(mnemonics.proposer);
+    // we must set the URL from the point of view of the client container
+    await nf3Proposer.registerProposer('http://optimist', MINIMUM_STAKE);
+    await nf3Proposer.startProposer();
   });
 
   it('Runs ping-pong tests', async () => {

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -7,7 +7,7 @@ import logger from '../common-files/utils/logger.mjs';
 import { rand } from '../common-files/utils/crypto/crypto-random.mjs';
 
 const { expect } = chai;
-const { WEB3_PROVIDER_OPTIONS } = config;
+const { WEB3_PROVIDER_OPTIONS, MINIMUM_STAKE } = config;
 const ENVIRONMENT = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
 
 const USE_EXTERNAL_NODE = config.USE_EXTERNAL_NODE === 'true';
@@ -445,7 +445,7 @@ export const retrieveL2Balance = async (client, ercAddress) => {
 */
 export const registerProposerOnNoProposer = async proposer => {
   if ((await proposer.getCurrentProposer()) === '0x0000000000000000000000000000000000000000') {
-    await proposer.registerProposer();
+    await proposer.registerProposer('', MINIMUM_STAKE);
   }
 };
 


### PR DESCRIPTION
Feat #726
Fixes #724

Implement proposer selection and staking based on the PR #506 that was developed in a feature branch following the proposal #283.


## Features
- Add operations in the contracts for staking ETH. In the future decide if it's ETH or MATIC.
- Add/Update endpoints for this proposers staking in optimist.
- Add/Update operations to SDK for this proposers staking.
- This staking will be the base of the staking power when running spans of the weighted round robin algorithm for proposers selection in next task
- Implement weighted round robin algorithm based on the proposer staking for proposer selection


## Actions
- registerProposer now pass the amount to stake instead of bond. 
- updateProposer could update the URL and increment the stake .
- No REGISTRATION_BOND now but a MINIMUM_STAKE (100 wei for testing now).
- COOLING_OFF_PERIOD moved to CHALLENGE_PERIOD (1 week) for clarity.
- Changed messages from require statements in contracts to best practices used by Openzeppelin. <contract name>: <message>. So you know the contract where the message has been thrown. Useful now when debugging.
`withdrawBond` moved to `withdrawStake` and used in the same way but with the stake of the proposer instead of the bond, so the proposer can do the withdraw of their stake. Previously to that, the proposer should call `deregisterProposer` to stop being proposer and wait this CHALLENGE_PERIOD to be allowed to do the withdraw.
- `TimeLockedBond` moved to `TimeLockedStake` and added `challengeLocked` to store the amount locked by blocks proposed still in CHALLENGE_PERIOD and not claimed yet.
```
    struct TimeLockedStake {
        uint256 amount; // The amount held
        uint256 challengeLocked; // The amount locked by block proposed still in CHALLENGE_PERIOD
        uint256 time; // The time the funds were locked from
    }
```
- `changeCurrentProposer` will be based on this new proposer selection.
- Update test `e2e/protocol/proposer.test.mjs` for testing PoS features. `npm run test-e2e-protocol`.

Regarding issue of testing https://github.com/EYBlockchain/nightfall_3_private/issues/205 for testing the proposer, they were missing tests for:
- [x] Block Propose
- [x] Change proposer
- [x] Request block payment
- [x] Restrictions to add more than boot proposer


## Discuss
- Define first approach with a set of parameter numbers for testnet (minimum stake, proposer count, number of springs in a span, ...) that we should analyze the suitable numbers for testnet/mainnet.
