### PR TITLE
Block Explorer: add mempool endpoint in the proposer

### DIFF
--- a/apps/proposer/src/routes/proposer.mjs
+++ b/apps/proposer/src/routes/proposer.mjs
@@ -22,4 +22,12 @@ router.post('/offchain-transaction', async (req, res) => {
   res.sendStatus(200);
 });
 
+router.get('/mempool', async (req, res) => {
+  const nf3 = req.app.get('nf3');
+  logger.debug(`Proposer/mempool endpoint received POST`);
+  logger.debug(`With content ${JSON.stringify(req.body, null, 2)}`);
+  const mempoolTransactions = await nf3.getMempoolTransactions();
+  res.json({ mempoolTransactions });
+});
+
 export default router;

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -200,6 +200,16 @@ class Nf3 {
   }
 
   /**
+  Gets the mempool transactions on the optimist
+  @method
+  @async
+  */
+  async getMempoolTransactions() {
+    const { result: mempool } = (await axios.get(`${this.optimistBaseUrl}/proposer/mempool`)).data;
+    return mempool;
+  }
+
+  /**
   Forces optimist to make a block with whatever transactions it has to hand i.e. it won't wait
   until it has TRANSACTIONS_PER_BLOCK of them
   @method


### PR DESCRIPTION
Fixes: #877 

We need to add mempool endpoint in the proposer for the block explorer to know information about pending transactions.

- `proposer/mempool` endpoint created in proposer that calls existing `proposer/mempool` from optimist.
