### PR TITLE
Optimizing challenges

### DIFF
--- a/nightfall-deployer/contracts/Challenges.sol
+++ b/nightfall-deployer/contracts/Challenges.sol
@@ -248,23 +248,29 @@ contract Challenges is Stateful, Key_Registry, Config {
         challengeAccepted(transactionBlock.blockL2);
     }
 
-    function challengeHistoricRoot(
-        Block calldata blockL2,
-        Transaction[] calldata transactions,
-        uint256 transactionIndex
-    ) external onlyBootChallenger {
+    function challengeHistoricRoot(TransactionBlock calldata transactionBlock)
+        external
+        onlyBootChallenger
+    {
         checkCommit(msg.data);
-        state.areBlockAndTransactionsReal(blockL2, transactions);
-        require(
-          (
-            transactions[transactionIndex].historicRootBlockNumberL2[0] >= state.getNumberOfL2Blocks() ||
-            transactions[transactionIndex].historicRootBlockNumberL2[1] >= state.getNumberOfL2Blocks() ||
-            transactions[transactionIndex].historicRootBlockNumberL2[2] >= state.getNumberOfL2Blocks() ||
-            transactions[transactionIndex].historicRootBlockNumberL2[3] >= state.getNumberOfL2Blocks()
-          ),
-          'Historic roots are not greater than L2BlockNumber on chain'
+        state.areBlockAndTransactionReal(
+            transactionBlock.blockL2,
+            transactionBlock.transaction,
+            transactionBlock.transactionIndex,
+            transactionBlock.transactionSiblingPath
         );
-        challengeAccepted(blockL2);
+        require(
+            (transactionBlock.transaction.historicRootBlockNumberL2[0] >=
+                state.getNumberOfL2Blocks() ||
+                transactionBlock.transaction.historicRootBlockNumberL2[1] >=
+                state.getNumberOfL2Blocks() ||
+                transactionBlock.transaction.historicRootBlockNumberL2[2] >=
+                state.getNumberOfL2Blocks() ||
+                transactionBlock.transaction.historicRootBlockNumberL2[3] >=
+                state.getNumberOfL2Blocks()),
+            'Historic roots are not greater than L2BlockNumber on chain'
+        );
+        challengeAccepted(transactionBlock.blockL2);
     }
 
     // This gets called when a challenge succeeds

--- a/nightfall-deployer/contracts/Challenges.sol
+++ b/nightfall-deployer/contracts/Challenges.sol
@@ -23,12 +23,9 @@ contract Challenges is Stateful, Key_Registry, Config {
         Config.initialize();
     }
 
-    /**
+  /**
   Check that the block correctly updates the leafCount.  Note that the leafCount
-  is actually the value BEFORE the commitments are added to the Merkle tree.
-  Thus we need the prior block so that we can check it because the value should
-  be the prior block leafcount plus the number of non-zero commitments in the
-  prior block.
+  is actually the value AFTER the commitments are added to the Merkle tree.
   */
     function challengeLeafCountCorrect(
         Block calldata priorBlockL2, // the block immediately prior to this one

--- a/nightfall-deployer/contracts/Challenges.sol
+++ b/nightfall-deployer/contracts/Challenges.sol
@@ -89,8 +89,8 @@ contract Challenges is Stateful, Key_Registry, Config {
   (i.e. a trivial duplicate).
   */
     function challengeCommitment(
-        TransactionBlock calldata transactionBlock1,
-        TransactionBlock calldata transactionBlock2,
+        TransactionInfoBlock calldata transaction1,
+        TransactionInfoBlock calldata transaction2,
         uint256 commitment1Index,
         uint256 commitment2Index,
         bytes32 salt
@@ -99,35 +99,35 @@ contract Challenges is Stateful, Key_Registry, Config {
 
         // first, check we have real, in-train, contiguous blocks
         state.areBlockAndTransactionReal(
-            transactionBlock1.blockL2,
-            transactionBlock1.transaction,
-            transactionBlock1.transactionIndex,
-            transactionBlock1.transactionSiblingPath
+            transaction1.blockL2,
+            transaction1.transaction,
+            transaction1.transactionIndex,
+            transaction1.transactionSiblingPath
         );
         state.areBlockAndTransactionReal(
-            transactionBlock2.blockL2,
-            transactionBlock2.transaction,
-            transactionBlock2.transactionIndex,
-            transactionBlock2.transactionSiblingPath
+            transaction2.blockL2,
+            transaction2.transaction,
+            transaction2.transactionIndex,
+            transaction2.transactionSiblingPath
         );
 
         require(
-            transactionBlock1.blockL2.blockNumberL2 != transactionBlock2.blockL2.blockNumberL2,
+            transaction1.blockL2.blockNumberL2 != transaction2.blockL2.blockNumberL2,
             'Cannot be the same block'
         );
 
         ChallengesUtil.libChallengeCommitment(
-            transactionBlock1.transaction,
+            transaction1.transaction,
             commitment1Index,
-            transactionBlock2.transaction,
+            transaction2.transaction,
             commitment2Index
         );
 
         // Delete the latest block of the two
-        if (transactionBlock1.blockL2.blockNumberL2 > transactionBlock2.blockL2.blockNumberL2) {
-            challengeAccepted(transactionBlock1.blockL2);
+        if (transaction1.blockL2.blockNumberL2 > transaction2.blockL2.blockNumberL2) {
+            challengeAccepted(transaction1.blockL2);
         } else {
-            challengeAccepted(transactionBlock2.blockL2);
+            challengeAccepted(transaction2.blockL2);
         }
     }
 
@@ -137,8 +137,8 @@ contract Challenges is Stateful, Key_Registry, Config {
   (i.e. a trivial duplicate).
   */
     function challengeNullifier(
-        TransactionBlock calldata transactionBlock1,
-        TransactionBlock calldata transactionBlock2,
+        TransactionInfoBlock calldata transaction1,
+        TransactionInfoBlock calldata transaction2,
         uint256 nullifier1Index,
         uint256 nullifier2Index,
         bytes32 salt
@@ -147,50 +147,50 @@ contract Challenges is Stateful, Key_Registry, Config {
 
         // first, check we have real, in-train, contiguous blocks
         state.areBlockAndTransactionReal(
-            transactionBlock1.blockL2,
-            transactionBlock1.transaction,
-            transactionBlock1.transactionIndex,
-            transactionBlock1.transactionSiblingPath
+            transaction1.blockL2,
+            transaction1.transaction,
+            transaction1.transactionIndex,
+            transaction1.transactionSiblingPath
         );
         state.areBlockAndTransactionReal(
-            transactionBlock2.blockL2,
-            transactionBlock2.transaction,
-            transactionBlock2.transactionIndex,
-            transactionBlock2.transactionSiblingPath
+            transaction2.blockL2,
+            transaction2.transaction,
+            transaction2.transactionIndex,
+            transaction2.transactionSiblingPath
         );
 
         require(
-            transactionBlock1.blockL2.blockNumberL2 != transactionBlock2.blockL2.blockNumberL2,
+            transaction1.blockL2.blockNumberL2 != transaction2.blockL2.blockNumberL2,
             'Cannot be the same block'
         );
 
         ChallengesUtil.libChallengeNullifier(
-            transactionBlock1.transaction,
+            transaction1.transaction,
             nullifier1Index,
-            transactionBlock2.transaction,
+            transaction2.transaction,
             nullifier2Index
         );
 
         // Delete the latest block of the two
-        if (transactionBlock1.blockL2.blockNumberL2 > transactionBlock2.blockL2.blockNumberL2) {
-            challengeAccepted(transactionBlock1.blockL2);
+        if (transaction1.blockL2.blockNumberL2 > transaction2.blockL2.blockNumberL2) {
+            challengeAccepted(transaction1.blockL2);
         } else {
-            challengeAccepted(transactionBlock2.blockL2);
+            challengeAccepted(transaction2.blockL2);
         }
     }
 
     function challengeProofVerification(
-        TransactionBlock calldata transactionBlock,
+        TransactionInfoBlock calldata transaction,
         Block[4] calldata blockL2ContainingHistoricRoot,
         uint256[8] memory uncompressedProof,
         bytes32 salt
     ) external onlyBootChallenger {
         checkCommit(msg.data);
         state.areBlockAndTransactionReal(
-            transactionBlock.blockL2,
-            transactionBlock.transaction,
-            transactionBlock.transactionIndex,
-            transactionBlock.transactionSiblingPath
+            transaction.blockL2,
+            transaction.transaction,
+            transaction.transactionIndex,
+            transaction.transactionSiblingPath
         );
 
         PublicInputs memory extraPublicInputs = PublicInputs(
@@ -198,40 +198,40 @@ contract Challenges is Stateful, Key_Registry, Config {
             super.getMaticAddress()
         );
 
-        if (uint256(transactionBlock.transaction.nullifiers[0]) != 0) {
+        if (uint256(transaction.transaction.nullifiers[0]) != 0) {
             state.isBlockReal(blockL2ContainingHistoricRoot[0]);
             require(
-                transactionBlock.transaction.historicRootBlockNumberL2[0] ==
+                transaction.transaction.historicRootBlockNumberL2[0] ==
                     blockL2ContainingHistoricRoot[0].blockNumberL2,
                 'Incorrect historic root block'
             );
             extraPublicInputs.roots[0] = uint256(blockL2ContainingHistoricRoot[0].root);
         }
 
-        if (uint256(transactionBlock.transaction.nullifiers[1]) != 0) {
+        if (uint256(transaction.transaction.nullifiers[1]) != 0) {
             state.isBlockReal(blockL2ContainingHistoricRoot[1]);
             require(
-                transactionBlock.transaction.historicRootBlockNumberL2[1] ==
+                transaction.transaction.historicRootBlockNumberL2[1] ==
                     blockL2ContainingHistoricRoot[1].blockNumberL2,
                 'Incorrect historic root block'
             );
             extraPublicInputs.roots[1] = uint256(blockL2ContainingHistoricRoot[1].root);
         }
 
-        if (uint256(transactionBlock.transaction.nullifiers[2]) != 0) {
+        if (uint256(transaction.transaction.nullifiers[2]) != 0) {
             state.isBlockReal(blockL2ContainingHistoricRoot[2]);
             require(
-                transactionBlock.transaction.historicRootBlockNumberL2[2] ==
+                transaction.transaction.historicRootBlockNumberL2[2] ==
                     blockL2ContainingHistoricRoot[2].blockNumberL2,
                 'Incorrect historic root block'
             );
             extraPublicInputs.roots[2] = uint256(blockL2ContainingHistoricRoot[2].root);
         }
 
-        if (uint256(transactionBlock.transaction.nullifiers[3]) != 0) {
+        if (uint256(transaction.transaction.nullifiers[3]) != 0) {
             state.isBlockReal(blockL2ContainingHistoricRoot[3]);
             require(
-                transactionBlock.transaction.historicRootBlockNumberL2[3] ==
+                transaction.transaction.historicRootBlockNumberL2[3] ==
                     blockL2ContainingHistoricRoot[3].blockNumberL2,
                 'Incorrect historic root block'
             );
@@ -240,37 +240,36 @@ contract Challenges is Stateful, Key_Registry, Config {
 
         // now we need to check that the proof is correct
         ChallengesUtil.libChallengeProofVerification(
-            transactionBlock.transaction,
+            transaction.transaction,
             extraPublicInputs,
             uncompressedProof,
-            vks[transactionBlock.transaction.transactionType]
+            vks[transaction.transaction.transactionType]
         );
-        challengeAccepted(transactionBlock.blockL2);
+        challengeAccepted(transaction.blockL2);
     }
 
-    function challengeHistoricRoot(TransactionBlock calldata transactionBlock)
+    function challengeHistoricRoot(TransactionInfoBlock calldata transaction)
         external
         onlyBootChallenger
     {
         checkCommit(msg.data);
         state.areBlockAndTransactionReal(
-            transactionBlock.blockL2,
-            transactionBlock.transaction,
-            transactionBlock.transactionIndex,
-            transactionBlock.transactionSiblingPath
+            transaction.blockL2,
+            transaction.transaction,
+            transaction.transactionIndex,
+            transaction.transactionSiblingPath
         );
         require(
-            (transactionBlock.transaction.historicRootBlockNumberL2[0] >=
+            (transaction.transaction.historicRootBlockNumberL2[0] >= state.getNumberOfL2Blocks() ||
+                transaction.transaction.historicRootBlockNumberL2[1] >=
                 state.getNumberOfL2Blocks() ||
-                transactionBlock.transaction.historicRootBlockNumberL2[1] >=
+                transaction.transaction.historicRootBlockNumberL2[2] >=
                 state.getNumberOfL2Blocks() ||
-                transactionBlock.transaction.historicRootBlockNumberL2[2] >=
-                state.getNumberOfL2Blocks() ||
-                transactionBlock.transaction.historicRootBlockNumberL2[3] >=
+                transaction.transaction.historicRootBlockNumberL2[3] >=
                 state.getNumberOfL2Blocks()),
             'Historic roots are not greater than L2BlockNumber on chain'
         );
-        challengeAccepted(transactionBlock.blockL2);
+        challengeAccepted(transaction.blockL2);
     }
 
     // This gets called when a challenge succeeds

--- a/nightfall-deployer/contracts/Challenges.sol
+++ b/nightfall-deployer/contracts/Challenges.sol
@@ -182,7 +182,6 @@ contract Challenges is Stateful, Key_Registry, Config {
     function challengeProofVerification(
         TransactionBlock calldata transactionBlock,
         Block[4] calldata blockL2ContainingHistoricRoot,
-        Transaction[][4] calldata transactionsOfblockL2ContainingHistoricRoot,
         uint256[8] memory uncompressedProof,
         bytes32 salt
     ) external onlyBootChallenger {
@@ -194,14 +193,13 @@ contract Challenges is Stateful, Key_Registry, Config {
             transactionBlock.transactionSiblingPath
         );
 
-        PublicInputs memory extraPublicInputs =
-            PublicInputs([uint256(0), 0, 0, 0], super.getMaticAddress());
+        PublicInputs memory extraPublicInputs = PublicInputs(
+            [uint256(0), 0, 0, 0],
+            super.getMaticAddress()
+        );
 
         if (uint256(transactionBlock.transaction.nullifiers[0]) != 0) {
-            state.areBlockAndTransactionsReal(
-                blockL2ContainingHistoricRoot[0],
-                transactionsOfblockL2ContainingHistoricRoot[0]
-            );
+            state.isBlockReal(blockL2ContainingHistoricRoot[0]);
             require(
                 transactionBlock.transaction.historicRootBlockNumberL2[0] ==
                     blockL2ContainingHistoricRoot[0].blockNumberL2,
@@ -211,10 +209,7 @@ contract Challenges is Stateful, Key_Registry, Config {
         }
 
         if (uint256(transactionBlock.transaction.nullifiers[1]) != 0) {
-            state.areBlockAndTransactionsReal(
-                blockL2ContainingHistoricRoot[1],
-                transactionsOfblockL2ContainingHistoricRoot[1]
-            );
+            state.isBlockReal(blockL2ContainingHistoricRoot[1]);
             require(
                 transactionBlock.transaction.historicRootBlockNumberL2[1] ==
                     blockL2ContainingHistoricRoot[1].blockNumberL2,
@@ -224,10 +219,7 @@ contract Challenges is Stateful, Key_Registry, Config {
         }
 
         if (uint256(transactionBlock.transaction.nullifiers[2]) != 0) {
-            state.areBlockAndTransactionsReal(
-                blockL2ContainingHistoricRoot[2],
-                transactionsOfblockL2ContainingHistoricRoot[2]
-            );
+            state.isBlockReal(blockL2ContainingHistoricRoot[2]);
             require(
                 transactionBlock.transaction.historicRootBlockNumberL2[2] ==
                     blockL2ContainingHistoricRoot[2].blockNumberL2,
@@ -237,10 +229,7 @@ contract Challenges is Stateful, Key_Registry, Config {
         }
 
         if (uint256(transactionBlock.transaction.nullifiers[3]) != 0) {
-            state.areBlockAndTransactionsReal(
-                blockL2ContainingHistoricRoot[3],
-                transactionsOfblockL2ContainingHistoricRoot[3]
-            );
+            state.isBlockReal(blockL2ContainingHistoricRoot[3]);
             require(
                 transactionBlock.transaction.historicRootBlockNumberL2[3] ==
                     blockL2ContainingHistoricRoot[3].blockNumberL2,

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -49,7 +49,7 @@ contract State is Initializable, ReentrancyGuardUpgradeable, Pausable, Config {
         initialize();
     }
 
-    modifier onlyRegistered {
+    modifier onlyRegistered() {
         require(
             msg.sender == proposersAddress ||
                 msg.sender == challengesAddress ||
@@ -59,7 +59,7 @@ contract State is Initializable, ReentrancyGuardUpgradeable, Pausable, Config {
         _;
     }
 
-    modifier onlyCurrentProposer {
+    modifier onlyCurrentProposer() {
         // Modifier
         require(
             msg.sender == currentProposer.thisAddress,
@@ -317,7 +317,8 @@ contract State is Initializable, ReentrancyGuardUpgradeable, Pausable, Config {
 
     // Checks if a block is actually referenced in the queue of blocks waiting
     // to go into the Shield state (stops someone challenging with a non-existent
-    // block).
+    // block). It also checks that the transactions sent as a calldata are all contained
+    //in the block by performing its hash and comparing it to the value stored in the block
     function areBlockAndTransactionsReal(Block calldata b, Transaction[] calldata ts)
         public
         view
@@ -333,6 +334,9 @@ contract State is Initializable, ReentrancyGuardUpgradeable, Pausable, Config {
         return blockHash;
     }
 
+    // Checks if a block is actually referenced in the queue of blocks waiting
+    // to go into the Shield state (stops someone challenging with a non-existent
+    // block).
     function isBlockReal(Block calldata b) public view returns (bytes32) {
         bytes32 blockHash = Utils.hashBlock(b);
         require(blockHashes[b.blockNumberL2].blockHash == blockHash, 'This block does not exist');
@@ -340,6 +344,9 @@ contract State is Initializable, ReentrancyGuardUpgradeable, Pausable, Config {
         return blockHash;
     }
 
+    // Checks if a block is actually referenced in the queue of blocks waiting
+    // to go into the Shield state (stops someone challenging with a non-existent
+    // block). It also checks if a transaction is contained in a block using its sibling path
     function areBlockAndTransactionReal(
         Block calldata b,
         Transaction calldata t,

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -333,6 +333,13 @@ contract State is Initializable, ReentrancyGuardUpgradeable, Pausable, Config {
         return blockHash;
     }
 
+    function isBlockReal(Block calldata b) public view returns (bytes32) {
+        bytes32 blockHash = Utils.hashBlock(b);
+        require(blockHashes[b.blockNumberL2].blockHash == blockHash, 'This block does not exist');
+
+        return blockHash;
+    }
+
     function areBlockAndTransactionReal(
         Block calldata b,
         Transaction calldata t,

--- a/nightfall-deployer/contracts/Structures.sol
+++ b/nightfall-deployer/contracts/Structures.sol
@@ -89,7 +89,7 @@ contract Structures {
         address maticAddress;
     }
 
-    struct TransactionBlock {
+    struct TransactionInfoBlock {
         Block blockL2;
         Transaction transaction;
         uint256 transactionIndex;

--- a/nightfall-deployer/contracts/Structures.sol
+++ b/nightfall-deployer/contracts/Structures.sol
@@ -88,4 +88,11 @@ contract Structures {
         uint256[4] roots;
         address maticAddress;
     }
+
+    struct TransactionBlock {
+        Block blockL2;
+        Transaction transaction;
+        uint256 transactionIndex;
+        bytes32[] transactionSiblingPath;
+    }
 }

--- a/nightfall-optimist/src/routes/transaction.mjs
+++ b/nightfall-optimist/src/routes/transaction.mjs
@@ -8,11 +8,8 @@ const router = express.Router();
 router.post('/advanceWithdrawal', async (req, res, next) => {
   try {
     const { transactionHash } = req.body;
-
     const withdrawTransaction = await getTransactionByTransactionHash(transactionHash);
-
     logger.info({ msg: 'Performing advanceWithdraw', transactionHash, withdrawTransaction });
-
     const result = await advanceWithdrawal(withdrawTransaction);
     res.json(result);
   } catch (err) {

--- a/nightfall-optimist/src/services/challenges.mjs
+++ b/nightfall-optimist/src/services/challenges.mjs
@@ -255,7 +255,7 @@ export async function createChallenge(block, transactions, err) {
         transactions[transactionIndex].transactionHash,
       );
       txDataToSign = await challengeContractInstance.methods
-        .challengeHistoricRoot({
+        .challengeHistoricRootBlockNumber({
           blockL2: Block.buildSolidityStruct(block),
           transaction: Transaction.buildSolidityStruct(transactions[transactionIndex]),
           transactionIndex,

--- a/nightfall-optimist/src/services/challenges.mjs
+++ b/nightfall-optimist/src/services/challenges.mjs
@@ -220,24 +220,13 @@ export async function createChallenge(block, transactions, err) {
       const { transactionHashIndex: transactionIndex } = err.metadata;
       // Create a challenge
       const uncompressedProof = transactions[transactionIndex].proof;
-      const [
-        historicNullifierInfo1,
-        historicNullifierInfo2,
-        historicNullifierInfo3,
-        historicNullifierInfo4,
-      ] = await Promise.all(
+      const [historicBlock1, historicBlock2, historicBlock3, historicBlock4] = await Promise.all(
         transactions[transactionIndex].historicRootBlockNumberL2.map(async (b, i) => {
           if (transactions[transactionIndex].nullifiers[i] === 0) {
-            return {
-              historicBlock: {},
-              historicTxs: [],
-            };
+            return {};
           }
-          const historicBlock = Block.buildSolidityStruct(await getBlockByBlockNumberL2(b));
-          const historicTxs = await getTransactionsByTransactionHashes(
-            historicBlock.transactionHashes,
-          );
-          return { historicBlock, historicTxs };
+          const historicBlock = await getBlockByBlockNumberL2(b);
+          return Block.buildSolidityStruct(historicBlock);
         }),
       );
 
@@ -253,18 +242,7 @@ export async function createChallenge(block, transactions, err) {
             transactionIndex,
             transactionSiblingPath,
           },
-          [
-            historicNullifierInfo1.historicBlock,
-            historicNullifierInfo2.historicBlock,
-            historicNullifierInfo3.historicBlock,
-            historicNullifierInfo4.historicBlock,
-          ],
-          [
-            historicNullifierInfo1.historicTxs.map(t => Transaction.buildSolidityStruct(t)),
-            historicNullifierInfo2.historicTxs.map(t => Transaction.buildSolidityStruct(t)),
-            historicNullifierInfo3.historicTxs.map(t => Transaction.buildSolidityStruct(t)),
-            historicNullifierInfo4.historicTxs.map(t => Transaction.buildSolidityStruct(t)),
-          ],
+          [historicBlock1, historicBlock2, historicBlock3, historicBlock4],
           uncompressedProof,
           salt,
         )

--- a/nightfall-optimist/src/services/challenges.mjs
+++ b/nightfall-optimist/src/services/challenges.mjs
@@ -10,6 +10,7 @@ import {
   getTransactionsByTransactionHashes,
   getBlockByBlockNumberL2,
   getTreeByRoot,
+  getTransactionHashSiblingInfo,
 } from './database.mjs';
 import Block from '../classes/block.mjs';
 import { Transaction } from '../classes/index.mjs';
@@ -96,13 +97,9 @@ export async function createChallenge(block, transactions, err) {
     // challenge incorrect leaf count
     case 0: {
       const priorBlockL2 = await getBlockByBlockNumberL2(block.blockNumberL2 - 1);
-      const priorBlockTransactions = await getTransactionsByTransactionHashes(
-        priorBlockL2.transactionHashes,
-      );
       txDataToSign = await challengeContractInstance.methods
         .challengeLeafCountCorrect(
           Block.buildSolidityStruct(priorBlockL2), // the block immediately prior to this one
-          priorBlockTransactions.map(t => Transaction.buildSolidityStruct(t)), // the transactions in the prior block
           Block.buildSolidityStruct(block),
           transactions.map(t => Transaction.buildSolidityStruct(t)),
           salt,
@@ -152,22 +149,30 @@ export async function createChallenge(block, transactions, err) {
     case 2: {
       const {
         block1,
-        transactions1,
+        transaction1,
         transaction1Index,
+        siblingPath1,
         duplicateCommitment1Index,
         block2,
-        transactions2,
+        transaction2,
         transaction2Index,
+        siblingPath2,
         duplicateCommitment2Index,
       } = err.metadata;
       txDataToSign = await challengeContractInstance.methods
         .challengeCommitment(
-          Block.buildSolidityStruct(block1),
-          Block.buildSolidityStruct(block2),
-          transactions1.map(t => Transaction.buildSolidityStruct(t)),
-          transactions2.map(t => Transaction.buildSolidityStruct(t)),
-          transaction1Index,
-          transaction2Index,
+          {
+            blockL2: Block.buildSolidityStruct(block1),
+            transaction: Transaction.buildSolidityStruct(transaction1),
+            transactionIndex: transaction1Index,
+            transactionSiblingPath: siblingPath1,
+          },
+          {
+            blockL2: Block.buildSolidityStruct(block2),
+            transaction: Transaction.buildSolidityStruct(transaction2),
+            transactionIndex: transaction2Index,
+            transactionSiblingPath: siblingPath2,
+          },
           duplicateCommitment1Index,
           duplicateCommitment2Index,
           salt,
@@ -179,22 +184,30 @@ export async function createChallenge(block, transactions, err) {
     case 3: {
       const {
         block1,
-        transactions1,
+        transaction1,
         transaction1Index,
+        siblingPath1,
         duplicateNullifier1Index,
         block2,
-        transactions2,
+        transaction2,
         transaction2Index,
+        siblingPath2,
         duplicateNullifier2Index,
       } = err.metadata;
       txDataToSign = await challengeContractInstance.methods
         .challengeNullifier(
-          Block.buildSolidityStruct(block1),
-          Block.buildSolidityStruct(block2),
-          transactions1.map(t => Transaction.buildSolidityStruct(t)),
-          transactions2.map(t => Transaction.buildSolidityStruct(t)),
-          transaction1Index,
-          transaction2Index,
+          {
+            blockL2: Block.buildSolidityStruct(block1),
+            transaction: Transaction.buildSolidityStruct(transaction1),
+            transactionIndex: transaction1Index,
+            transactionSiblingPath: siblingPath1,
+          },
+          {
+            blockL2: Block.buildSolidityStruct(block2),
+            transaction: Transaction.buildSolidityStruct(transaction2),
+            transactionIndex: transaction2Index,
+            transactionSiblingPath: siblingPath2,
+          },
           duplicateNullifier1Index,
           duplicateNullifier2Index,
           salt,
@@ -207,7 +220,12 @@ export async function createChallenge(block, transactions, err) {
       const { transactionHashIndex: transactionIndex } = err.metadata;
       // Create a challenge
       const uncompressedProof = transactions[transactionIndex].proof;
-      const [historicInput1, historicInput2, historicInput3, historicInput4] = await Promise.all(
+      const [
+        historicNullifierInfo1,
+        historicNullifierInfo2,
+        historicNullifierInfo3,
+        historicNullifierInfo4,
+      ] = await Promise.all(
         transactions[transactionIndex].historicRootBlockNumberL2.map(async (b, i) => {
           if (transactions[transactionIndex].nullifiers[i] === 0) {
             return {
@@ -223,22 +241,29 @@ export async function createChallenge(block, transactions, err) {
         }),
       );
 
+      const transactionSiblingPath = await getTransactionHashSiblingInfo(
+        transactions[transactionIndex].transactionHash,
+      );
+
       txDataToSign = await challengeContractInstance.methods
         .challengeProofVerification(
-          Block.buildSolidityStruct(block),
-          transactions.map(t => Transaction.buildSolidityStruct(t)),
-          transactionIndex,
+          {
+            blockL2: Block.buildSolidityStruct(block),
+            transaction: Transaction.buildSolidityStruct(transactions[transactionIndex]),
+            transactionIndex,
+            transactionSiblingPath,
+          },
           [
-            historicInput1.historicBlock,
-            historicInput2.historicBlock,
-            historicInput3.historicBlock,
-            historicInput4.historicBlock,
+            historicNullifierInfo1.historicBlock,
+            historicNullifierInfo2.historicBlock,
+            historicNullifierInfo3.historicBlock,
+            historicNullifierInfo4.historicBlock,
           ],
           [
-            historicInput1.historicTxs.map(t => Transaction.buildSolidityStruct(t)),
-            historicInput2.historicTxs.map(t => Transaction.buildSolidityStruct(t)),
-            historicInput3.historicTxs.map(t => Transaction.buildSolidityStruct(t)),
-            historicInput4.historicTxs.map(t => Transaction.buildSolidityStruct(t)),
+            historicNullifierInfo1.historicTxs.map(t => Transaction.buildSolidityStruct(t)),
+            historicNullifierInfo2.historicTxs.map(t => Transaction.buildSolidityStruct(t)),
+            historicNullifierInfo3.historicTxs.map(t => Transaction.buildSolidityStruct(t)),
+            historicNullifierInfo4.historicTxs.map(t => Transaction.buildSolidityStruct(t)),
           ],
           uncompressedProof,
           salt,

--- a/nightfall-optimist/src/services/challenges.mjs
+++ b/nightfall-optimist/src/services/challenges.mjs
@@ -250,13 +250,17 @@ export async function createChallenge(block, transactions, err) {
       break;
     }
     case 5: {
-      const { transactionHashIndex } = err.metadata;
+      const { transactionHashIndex: transactionIndex } = err.metadata;
+      const transactionSiblingPath = await getTransactionHashSiblingInfo(
+        transactions[transactionIndex].transactionHash,
+      );
       txDataToSign = await challengeContractInstance.methods
-        .challengeHistoricRoot(
-          Block.buildSolidityStruct(block),
-          transactions.map(t => Transaction.buildSolidityStruct(t)),
-          transactionHashIndex,
-        )
+        .challengeHistoricRoot({
+          blockL2: Block.buildSolidityStruct(block),
+          transaction: Transaction.buildSolidityStruct(transactions[transactionIndex]),
+          transactionIndex,
+          transactionSiblingPath,
+        })
         .encodeABI();
       break;
     }

--- a/nightfall-optimist/src/services/check-block.mjs
+++ b/nightfall-optimist/src/services/check-block.mjs
@@ -3,9 +3,13 @@ Module to check that submitted Blocks and Transactions are valid
 */
 import logger from 'common-files/utils/logger.mjs';
 import constants from 'common-files/constants/index.mjs';
-import { BlockError } from '../classes/index.mjs';
+import { BlockError, Transaction } from '../classes/index.mjs';
 import checkTransaction from './transaction-checker.mjs';
-import { getBlockByBlockNumberL2, getTreeByLeafCount } from './database.mjs';
+import {
+  getBlockByBlockNumberL2,
+  getTransactionHashSiblingInfo,
+  getTreeByLeafCount,
+} from './database.mjs';
 
 const { ZERO } = constants;
 
@@ -18,18 +22,14 @@ const { ZERO } = constants;
  */
 async function checkLeafCount(block) {
   logger.debug(`Checking block with leafCount ${block.leafCount}`);
+  const currentBlock = await getBlockByBlockNumberL2(block.blockNumberL2);
 
   if (block.blockNumberL2 > 0) {
     const priorBlock = await getBlockByBlockNumberL2(block.blockNumberL2 - 1);
-
-    if (priorBlock === null) {
-      logger.warn('Could not find prior block while checking leaf count');
-    }
-
-    if (priorBlock.leafCount + priorBlock.nCommitments !== block.leafCount) {
+    if (priorBlock === null) logger.warn('Could not find prior block while checking leaf count');
+    if (priorBlock.leafCount + currentBlock.nCommitments !== block.leafCount)
       throw new BlockError('The leaf count in the block is not correct', 0);
-    }
-  } else if (block.leafCount !== 0) {
+  } else if (currentBlock.nCommitments !== block.leafCount) {
     // this throws if it's the first block and leafCount!=0, which is impossible
     throw new BlockError('The leaf count in the block is not correct', 0);
   }
@@ -48,7 +48,7 @@ async function checkBlockRoot(block) {
   } else {
     while (!history) {
       // eslint-disable-next-line no-await-in-loop
-      history = await getTreeByLeafCount(block.leafCount + block.nCommitments);
+      history = await getTreeByLeafCount(block.leafCount);
       logger.debug(`Block has commitments - retrieved history from Timber`);
       logger.trace(`Timber history was ${JSON.stringify(history, null, 2)}`);
 
@@ -66,59 +66,94 @@ async function checkBlockRoot(block) {
 }
 
 // check if there are duplicate commitments in different transactions of the same block
-export function checkDuplicateCommitmentsWithinBlock(block, transactions) {
-  const blockCommitments = transactions.map(transaction => transaction.commitments).flat(Infinity);
-  blockCommitments.forEach((blockCommitment, index) => {
-    const lastIndex = blockCommitments.lastIndexOf(blockCommitment);
-    if (
-      blockCommitment !== ZERO &&
-      // blockCommitments.indexOf(blockCommitment) !== blockCommitments.lastIndexOf(blockCommitment)
-      index !== lastIndex
-    ) {
+export async function checkDuplicateCommitmentsWithinBlock(block, transactions) {
+  const blockCommitments = transactions
+    .map(transaction => transaction.commitments)
+    .flat(Infinity)
+    .filter(c => c !== ZERO)
+    .map((c, i) => {
+      return { transactionIndex: i, commitment: c };
+    });
+  for (const [index, blockCommitment] of blockCommitments.entries()) {
+    const lastIndex = blockCommitments
+      .map(c => c.commitment)
+      .lastIndexOf(blockCommitment.commitment);
+
+    if (index !== lastIndex) {
+      const transaction1Index = blockCommitments[index].transactionIndex;
+      const transaction1Hash = Transaction.calcHash(transactions[transaction1Index]);
+      const siblingPath1 = await getTransactionHashSiblingInfo(transaction1Hash);
+
+      const transaction2Index = blockCommitments[lastIndex].transactionIndex;
+      const transaction2Hash = Transaction.calcHash(transactions[transaction2Index]);
+      const siblingPath2 = await getTransactionHashSiblingInfo(transaction2Hash);
+
       throw new BlockError(
         `The block check failed due to duplicate commitments in different transactions of the same block`,
         2,
         {
           block1: block,
-          transactions1: transactions,
-          transaction1Index: index % 2 === 0 ? index / 2 : (index - 1) / 2,
-          duplicateCommitment1Index: index % 2 === 0 ? 0 : 1,
+          transaction1: transactions[transaction1Index],
+          transaction1Index,
+          siblingPath1,
+          duplicateCommitment1Index: transactions[transaction1Index].commitments.find(
+            c => c === blockCommitment.commitment,
+          ),
           block2: block,
-          transactions2: transactions,
-          transaction2Index: lastIndex % 2 === 0 ? lastIndex / 2 : (lastIndex - 1) / 2,
-          duplicateCommitment2Index: lastIndex % 2 === 0 ? 0 : 1,
+          transaction2: transactions[transaction2Index],
+          transaction2Index,
+          siblingPath2,
+          duplicateCommitment2Index: transactions[transaction2Index].commitments.find(
+            c => c === blockCommitment.commitment,
+          ),
         },
       );
     }
-  });
+  }
 }
 
 // check if there are duplicate nullifiers in different transactions of the same block
-export function checkDuplicateNullifiersWithinBlock(block, transactions) {
-  const blockNullifiers = transactions.map(transaction => transaction.nullifiers).flat(Infinity);
-  blockNullifiers.forEach((blockNullifier, index) => {
-    const lastIndex = blockNullifiers.lastIndexOf(blockNullifier);
-    if (
-      blockNullifier !== ZERO &&
-      // blockNullifiers.indexOf(blockNullifier) !== blockNullifiers.lastIndexOf(blockNullifier)
-      index !== lastIndex
-    ) {
+export async function checkDuplicateNullifiersWithinBlock(block, transactions) {
+  const blockNullifiers = transactions
+    .map(transaction => transaction.nullifiers)
+    .flat(Infinity)
+    .filter(n => n !== ZERO)
+    .map((n, i) => {
+      return { transactionIndex: i, nullifier: n };
+    });
+  for (const [index, blockNullifier] of blockNullifiers.entries()) {
+    const lastIndex = blockNullifiers.map(n => n.nullifier).lastIndexOf(blockNullifier.nullifier);
+    if (index !== lastIndex) {
+      const transaction1Index = blockNullifiers[index].transactionIndex;
+      const transaction1Hash = Transaction.calcHash(transactions[transaction1Index]);
+      const siblingPath1 = await getTransactionHashSiblingInfo(transaction1Hash);
+
+      const transaction2Index = blockNullifiers[lastIndex].transactionIndex;
+      const transaction2Hash = Transaction.calcHash(transactions[transaction2Index]);
+      const siblingPath2 = await getTransactionHashSiblingInfo(transaction2Hash);
+
       throw new BlockError(
         `The block check failed due to duplicate nullifiers in different transactions of the same block`,
         3,
         {
           block1: block,
-          transactions1: transactions,
-          transaction1Index: index % 2 === 0 ? index / 2 : (index - 1) / 2,
-          duplicateNullifier1Index: index % 2 === 0 ? 0 : 1,
+          transaction1: transactions[transaction1Index],
+          transaction1Index,
+          siblingPath1,
+          duplicateNullifier1Index: transactions[transaction1Index].nullifiers.find(
+            n => n === blockNullifier.nullifier,
+          ),
           block2: block,
-          transactions2: transactions,
-          transaction2Index: lastIndex % 2 === 0 ? lastIndex / 2 : (lastIndex - 1) / 2,
-          duplicateNullifier2Index: lastIndex % 2 === 0 ? 0 : 1,
+          transaction2: transactions[transaction2Index],
+          transaction2Index,
+          siblingPath2,
+          duplicateNullifier2Index: transactions[transaction2Index].nullifiers.find(
+            n => n === blockNullifier.nullifier,
+          ),
         },
       );
     }
-  });
+  }
 }
 
 /**
@@ -138,24 +173,28 @@ export async function checkBlock(block, transactions) {
   await checkDuplicateNullifiersWithinBlock(block, transactions);
 
   // check if the transactions are valid - transaction type, public input hash and proof verification are all checked
-  for (let i = 0; i < transactions.length; i++) {
+  for (const transaction of transactions) {
     try {
-      await checkTransaction(transactions[i], false, { blockNumberL2: block.blockNumberL2 }); // eslint-disable-line no-await-in-loop
+      await checkTransaction(transaction, false, { blockNumberL2: block.blockNumberL2 }); // eslint-disable-line no-await-in-loop
     } catch (err) {
-      if (err.code + 2 === 2 || err.code + 2 === 3)
+      if (err.code + 2 === 2 || err.code + 2 === 3) {
+        console.log(transaction.transactionHash);
+        const siblingPath1 = await getTransactionHashSiblingInfo(transaction.transactionHash);
         err.metadata = {
           ...err.metadata,
           block1: block,
-          transactions1: transactions,
-          transaction1Index: block.transactionHashes.indexOf(transactions[i].transactionHash),
+          transaction1: transaction,
+          transaction1Index: block.transactionHashes.indexOf(transaction.transactionHash),
+          siblingPath1,
         };
+      }
+
       throw new BlockError(
         `The transaction check failed with error: ${err.message}`,
         err.code + 2, // mapping transaction error to block error
         {
           ...err.metadata,
-          transaction: transactions[i],
-          transactionHashIndex: block.transactionHashes.indexOf(transactions[i].transactionHash),
+          transactionHashIndex: block.transactionHashes.indexOf(transaction.transactionHash),
         },
       );
     }

--- a/nightfall-optimist/src/services/check-block.mjs
+++ b/nightfall-optimist/src/services/check-block.mjs
@@ -67,6 +67,7 @@ async function checkBlockRoot(block) {
 
 // check if there are duplicate commitments in different transactions of the same block
 export async function checkDuplicateCommitmentsWithinBlock(block, transactions) {
+  // Create an array containing all the commitments different than zero in a block and also the transaction index in which belongs to
   const blockCommitments = transactions
     .map(transaction => transaction.commitments)
     .flat(Infinity)
@@ -75,26 +76,30 @@ export async function checkDuplicateCommitmentsWithinBlock(block, transactions) 
       return { transactionIndex: i, commitment: c };
     });
 
-  let lastIndexDuplicated = 0;
-  let indexDuplicated = 0;
+  let index1 = 0;
+  let index2 = 0;
   for (let index = 0; index < blockCommitments.length; ++index) {
+    // The idea here is to check if all commitments in a block are unique. To do so, we get the last index of each commitment
+    // and if it doesn't match with the current loop index means that there is more than one instance.
     const lastIndex = blockCommitments
       .map(c => c.commitment)
       .lastIndexOf(blockCommitments[index].commitment);
 
     if (index !== lastIndex) {
-      indexDuplicated = index;
-      lastIndexDuplicated = lastIndex;
+      index1 = index;
+      index2 = lastIndex;
       break;
     }
   }
 
-  if (lastIndexDuplicated !== 0) {
-    const transaction1Index = blockCommitments[indexDuplicated].transactionIndex;
+  // If index2 is different than zero means that the loop above was exited due to a duplicated commitment.
+  // Note that we cannot check the first index (index1) since it is possible that it was pointing to the first element of the array (so index1 can be 0)
+  if (index2 !== 0) {
+    const transaction1Index = blockCommitments[index1].transactionIndex;
     const transaction1Hash = Transaction.calcHash(transactions[transaction1Index]);
     const siblingPath1 = await getTransactionHashSiblingInfo(transaction1Hash);
 
-    const transaction2Index = blockCommitments[lastIndexDuplicated].transactionIndex;
+    const transaction2Index = blockCommitments[index2].transactionIndex;
     const transaction2Hash = Transaction.calcHash(transactions[transaction2Index]);
     const siblingPath2 = await getTransactionHashSiblingInfo(transaction2Hash);
 
@@ -107,14 +112,14 @@ export async function checkDuplicateCommitmentsWithinBlock(block, transactions) 
         transaction1Index,
         siblingPath1,
         duplicateCommitment1Index: transactions[transaction1Index].commitments.find(
-          c => c === blockCommitments[indexDuplicated].commitment,
+          c => c === blockCommitments[index1].commitment,
         ),
         block2: block,
         transaction2: transactions[transaction2Index],
         transaction2Index,
         siblingPath2,
         duplicateCommitment2Index: transactions[transaction2Index].commitments.find(
-          c => c === blockCommitments[indexDuplicated].commitment,
+          c => c === blockCommitments[index1].commitment,
         ),
       },
     );
@@ -123,6 +128,7 @@ export async function checkDuplicateCommitmentsWithinBlock(block, transactions) 
 
 // check if there are duplicate nullifiers in different transactions of the same block
 export async function checkDuplicateNullifiersWithinBlock(block, transactions) {
+  // Create an array containing all the nullifiers different than zero in a block and also the transaction index in which belongs to
   const blockNullifiers = transactions
     .map(transaction => transaction.nullifiers)
     .flat(Infinity)
@@ -131,26 +137,30 @@ export async function checkDuplicateNullifiersWithinBlock(block, transactions) {
       return { transactionIndex: i, nullifier: n };
     });
 
-  let lastIndexDuplicated = 0;
-  let indexDuplicated = 0;
+  let index1 = 0;
+  let index2 = 0;
   for (let index = 0; index < blockNullifiers.length; ++index) {
+    // The idea here is to check if all nullifiers in a block are unique. To do so, we get the last index of each nullifier
+    // and if it doesn't match with the current loop index means that there is more than one instance.
     const lastIndex = blockNullifiers
       .map(n => n.nullifier)
       .lastIndexOf(blockNullifiers[index].nullifier);
 
     if (index !== lastIndex) {
-      indexDuplicated = index;
-      lastIndexDuplicated = lastIndex;
+      index1 = index;
+      index2 = lastIndex;
       break;
     }
   }
 
-  if (lastIndexDuplicated !== 0) {
-    const transaction1Index = blockNullifiers[indexDuplicated].transactionIndex;
+  // If index2 is different than zero means that the loop above was exited due to a duplicated nullifier.
+  // Note that we cannot check the first index (index1) since it is possible that it was pointing to the first element of the array (so index1 can be 0)
+  if (index2 !== 0) {
+    const transaction1Index = blockNullifiers[index1].transactionIndex;
     const transaction1Hash = Transaction.calcHash(transactions[transaction1Index]);
     const siblingPath1 = await getTransactionHashSiblingInfo(transaction1Hash);
 
-    const transaction2Index = blockNullifiers[lastIndexDuplicated].transactionIndex;
+    const transaction2Index = blockNullifiers[index2].transactionIndex;
     const transaction2Hash = Transaction.calcHash(transactions[transaction2Index]);
     const siblingPath2 = await getTransactionHashSiblingInfo(transaction2Hash);
 
@@ -163,14 +173,14 @@ export async function checkDuplicateNullifiersWithinBlock(block, transactions) {
         transaction1Index,
         siblingPath1,
         duplicateNullifier1Index: transactions[transaction1Index].nullifiers.find(
-          n => n === blockNullifiers[indexDuplicated].nullifier,
+          n => n === blockNullifiers[index1].nullifier,
         ),
         block2: block,
         transaction2: transactions[transaction2Index],
         transaction2Index,
         siblingPath2,
         duplicateNullifier2Index: transactions[transaction2Index].nullifiers.find(
-          n => n === blockNullifiers[indexDuplicated].nullifier,
+          n => n === blockNullifiers[index1].nullifier,
         ),
       },
     );

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -558,3 +558,36 @@ export async function deleteTreeByBlockNumberL2(blockNumberL2) {
   await new Promise(resolve => setTimeout(() => resolve(), 1000));
   return db.collection(TIMBER_COLLECTION).deleteMany({ blockNumberL2: { $gte: blockNumberL2 } });
 }
+
+// function to set the path of the transaction hash leaf in transaction hash timber
+export async function setTransactionHashSiblingInfo(
+  transactionHash,
+  transactionHashSiblingPath,
+  transactionHashLeafIndex,
+  transactionHashesRoot,
+) {
+  const connection = await mongo.connection(MONGO_URL);
+  const query = { transactionHash };
+  const update = {
+    $set: { transactionHashSiblingPath, transactionHashLeafIndex, transactionHashesRoot },
+  };
+  const db = connection.db(OPTIMIST_DB);
+  return db.collection(TIMBER_COLLECTION).updateMany(query, update);
+}
+
+// function to get the path of the transaction hash leaf in transaction hash timber
+export async function getTransactionHashSiblingInfo(transactionHash) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  return db.collection(TIMBER_COLLECTION).findOne(
+    { transactionHash },
+    {
+      projection: {
+        transactionHashSiblingPath: 1,
+        transactionHashLeafIndex: 1,
+        transactionHashesRoot: 1,
+        isOnChain: 1,
+      },
+    },
+  );
+}

--- a/nightfall-optimist/src/services/process-calldata.mjs
+++ b/nightfall-optimist/src/services/process-calldata.mjs
@@ -75,8 +75,6 @@ export async function getProposeBlockCalldata(eventData) {
     .map(t => t.commitments.filter(c => c !== ZERO))
     .flat(Infinity).length;
   block.transactionHashes = transactions.map(t => t.transactionHash);
-  // currentLeafCount holds the count of the next leaf to be added
-  // const currentLeafCount = Number(block.nCommitments) + Number(leafCount);
   return { block, transactions };
 }
 

--- a/nightfall-optimist/src/services/state-sync.mjs
+++ b/nightfall-optimist/src/services/state-sync.mjs
@@ -76,10 +76,10 @@ const checkBlocks = async () => {
     // Existing blocks found stored locally
     let expectedLeafCount = 0;
     // Loop through all our blocks to find any gaps in our internal block data
-    for (let i = 0; i < blocks.length - 1; i++) {
+    for (let i = 0; i < blocks.length; i++) {
       // If the leafCount of the next block stored internally does not match what we expect the leaf count to be
       // it means we may have a gap in our blockData
-      expectedLeafCount += blocks[i + 1].nCommitments;
+      expectedLeafCount += blocks[i].nCommitments;
       if (blocks[i].leafCount !== expectedLeafCount) {
         // if we are in the first iteration it means we have a problem with our internal data
         // let's just restart the sync from earliest,

--- a/nightfall-optimist/src/services/state-sync.mjs
+++ b/nightfall-optimist/src/services/state-sync.mjs
@@ -76,9 +76,10 @@ const checkBlocks = async () => {
     // Existing blocks found stored locally
     let expectedLeafCount = 0;
     // Loop through all our blocks to find any gaps in our internal block data
-    for (let i = 0; i < blocks.length; i++) {
+    for (let i = 0; i < blocks.length - 1; i++) {
       // If the leafCount of the next block stored internally does not match what we expect the leaf count to be
       // it means we may have a gap in our blockData
+      expectedLeafCount += blocks[i + 1].nCommitments;
       if (blocks[i].leafCount !== expectedLeafCount) {
         // if we are in the first iteration it means we have a problem with our internal data
         // let's just restart the sync from earliest,
@@ -90,7 +91,6 @@ const checkBlocks = async () => {
         // reset so we can find more
         expectedLeafCount = blocks[i].leafCount;
       }
-      expectedLeafCount += blocks[i].nCommitments;
     }
     if (gapArray.length > 0) return gapArray; // We found some missing blocks
     const fromBlock = blocks[blocks.length - 1].blockNumber + 1;

--- a/test/adversary/transpile-adversary.mjs
+++ b/test/adversary/transpile-adversary.mjs
@@ -92,7 +92,7 @@ const transpileBlockBuilder = (_pathToSrc, _pathToInject) => {
   const reRoute = `const badBlock = createBadBlock({
       proposer,
       root: updatedTimber.root,
-      leafCount: timber.leafCount,
+      leafCount: updatedTimber.leafCount,
       nCommitments,
       blockNumberL2,
       previousBlockHash,


### PR DESCRIPTION
This PR adds a series of optimizations for the current challenges. It does the following changes:

- leafCount is no longer the amount of commitments in the merkle tree before insertion. With this change, leafCount is now the amount of commitments **after** insertion.
- The siblingPath info is stored for the transactions merkle tree.
- The whole set of transactions contained in a block is no longer sent as part of the calldata in challengeDuplicateNullifier and challengeDuplicateCommitment. Instead, we verify that the transaction is real by verifying its sibling path.
- For the challengeProofVerification, there's no need of sending the whole transactions contained in a block. We just need to check that the historicBlock is real. A new function that only validates the block is created in State.sol to do that. 
- The way check-block was detecting duplicated commitments / nullifiers was outdated since it was relying in the fact that each transaction has two commits and two nullifiers, which is no longer true. The corresponding functions has been fixed.
- Transaction checker does no longer check for duplicate nullifiers or commitments in the same transaction, since this is no possible because the circuits will not allow it. Hence, it makes no sense checking it. 

