### PR TITLE
Containerizing proposer

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,13 +196,13 @@ SDK API is documented in `./doc/lib/Nf3.html` and is provided by the NF_3 class 
 
 ## Apps
 
-Nightfall_3 provides some reference applications (which make use of the SDK) so that you can exercise its features. To
-use it:
+Nightfall_3 provides some reference applications (which make use of the SDK) so that you can
+exercise its features. To use it:
 
 - run up nightfall_3 as described above and wait for the deployment to complete;
 - in the `apps` folder there are small applications like `proposer` or `challenger` you can run with
-  `npm start`. For example, `proposer` will start a small application running which will sign block
-  proposal transactions;
+  `./start-apps`. For example, `proposer` will start a small application running which will sign
+  block proposal transactions;
 
 ## Limitations
 

--- a/docker-compose.apps.yml
+++ b/docker-compose.apps.yml
@@ -1,0 +1,38 @@
+version: '3.5'
+# Use this script for making nightfall_3 use stubs.
+services:
+
+  proposer:
+    build:
+      dockerfile: proposer.Dockerfile
+      context: .
+    ports:
+      # to use with postman and etc
+      - 8083:8080
+    environment:
+      BLOCKCHAIN_WS_HOST: blockchain
+      BLOCKCHAIN_PORT: 8546
+      ENABLE_QUEUE: 1
+      OPTIMIST_HOST: optimist
+      OPTIMIST_PORT: 80
+      OPTIMIST_WS_PORT: 8080
+      CLIENT_HOST: client
+      CLIENT_PORT: 8080
+    networks:
+      - nightfall_network
+    volumes:
+      - type: bind
+        source: ./apps/proposer/src
+        target: /app/src
+      - type: bind
+        source: ./cli
+        target: /app/cli
+
+networks:
+  nightfall_network:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.16.238.0/24
+          gateway: 172.16.238.1

--- a/docker-compose.apps.yml
+++ b/docker-compose.apps.yml
@@ -8,7 +8,7 @@ services:
       context: .
     ports:
       # to use with postman and etc
-      - 8083:8080
+      - 8092:8092
     environment:
       BLOCKCHAIN_WS_HOST: blockchain
       BLOCKCHAIN_PORT: 8546

--- a/proposer.Dockerfile
+++ b/proposer.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17
+FROM node:16.17
 
 WORKDIR /app
 COPY common-files common-files

--- a/start-apps
+++ b/start-apps
@@ -1,0 +1,2 @@
+#! /bin/bash
+docker-compose -f docker-compose.apps.yml up proposer


### PR DESCRIPTION
This PR proposes that the proposer (pun intended) is containerized so all its paths match with our deployment repo. A new script is born that simply runs this new `docker-compose` file