### PR TITLE
fix: mempool endpoint filter

### DIFF
--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -446,7 +446,8 @@ export async function resetUnsuccessfulBlockProposedTransactions() {
 export async function getMempoolTransactions() {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
-  return db.collection(TRANSACTIONS_COLLECTION).find().toArray();
+  const query = { mempool: true }; // Transactions in the mempool
+  return db.collection(TRANSACTIONS_COLLECTION).find(query).toArray();
 }
 
 /**


### PR DESCRIPTION
## What does this implement/fix? 
Fix: #974 
Proposer endpoint `/mempool` doesn't filter mempool transactions and gets all the transactions.

## Does this close any currently open issues?
Closes: #974  

