### PR TITLE
Modifying Nullifier Struct in the circuits

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -31,7 +31,7 @@ module.exports = {
   TXHASH_TREE_HASH_TYPE: 'keccak256',
   STATE_GENESIS_BLOCK: process.env.STATE_GENESIS_BLOCK,
   CIRCUITS_HOME: process.env.CIRCUITS_HOME || '/app/circuits/',
-  ALWAYS_DO_TRUSTED_SETUP: process.env.ALWAYS_DO_TRUSTED_SETUP || true,
+  ALWAYS_DO_TRUSTED_SETUP: process.env.ALWAYS_DO_TRUSTED_SETUP || false,
   LOG_LEVEL: process.env.LOG_LEVEL || 'debug',
   MONGO_URL: process.env.MONGO_URL || 'mongodb://localhost:27017/',
   PROTOCOL: 'http://', // connect to zokrates microservice like this

--- a/nightfall-client/src/services/transfer.mjs
+++ b/nightfall-client/src/services/transfer.mjs
@@ -90,7 +90,7 @@ async function transfer(transferParams) {
     });
 
     const privateData = {
-      rootKey: [rootKey, rootKey, rootKey, rootKey],
+      rootKey,
       oldCommitmentPreimage: commitmentsInfo.oldCommitments.map(o => {
         return { value: o.preimage.value, salt: o.preimage.salt };
       }),

--- a/nightfall-client/src/services/withdraw.mjs
+++ b/nightfall-client/src/services/withdraw.mjs
@@ -70,7 +70,7 @@ async function withdraw(withdrawParams) {
     });
 
     const privateData = {
-      rootKey: [rootKey, rootKey, rootKey, rootKey],
+      rootKey,
       oldCommitmentPreimage: commitmentsInfo.oldCommitments.map(o => {
         return { value: o.preimage.value, salt: o.preimage.salt };
       }),

--- a/nightfall-client/src/utils/computeCircuitInputs.mjs
+++ b/nightfall-client/src/utils/computeCircuitInputs.mjs
@@ -51,12 +51,11 @@ const computePrivateInputsNullifiers = (oldCommitmentPreimage, paths, orders, ro
   const paddedOldCommitmentPreimage = padArray(oldCommitmentPreimage, NULL_COMMITMENT, 4);
   const paddedPaths = padArray(paths, new Array(32).fill(0), 4);
   const paddedOrders = padArray(orders, 0, 4);
-  const paddedRootKeys = padArray(rootKey, 0, 4);
 
   const privateInputsNullifiers = [
+    rootKey.field(BN128_GROUP_ORDER),
     paddedOldCommitmentPreimage.map(commitment => commitment.value.limbs(8, 31)),
     paddedOldCommitmentPreimage.map(commitment => commitment.salt.field(BN128_GROUP_ORDER)),
-    paddedRootKeys.map(r => r.field(BN128_GROUP_ORDER)),
     paddedPaths.map(ps => ps.map(p => p.field(BN128_GROUP_ORDER))),
     paddedOrders.map(m => m.field(BN128_GROUP_ORDER)),
   ].flat(Infinity);

--- a/nightfall-deployer/circuits/common/generic_circuit/Stubs/nullifiers_stub.zok
+++ b/nightfall-deployer/circuits/common/generic_circuit/Stubs/nullifiers_stub.zok
@@ -4,19 +4,19 @@ def main<NumNullifiers>(\
     field[NumNullifiers] nullifierRoots,\
     private field[NumNullifiers] oldCommitmentValues,\
     private field[NumNullifiers] oldCommitmentSalts,\
-    private field[NumNullifiers] rootKey,\
     private field[NumNullifiers][32] paths,\
-	private field[NumNullifiers] orders\
+	private field[NumNullifiers] orders,\
+    private field rootKey\
 )-> bool {
     
     for u32 i in 0..NumNullifiers {
         field s = nullifierRoots[i] * sum([\
-            rootKey[i], oldCommitmentValues[i],\
+            rootKey, oldCommitmentValues[i],\
             oldCommitmentSalts[i],...paths[i], orders[i]\
         ]);
 
         field t = nullifierRoots[i] * sum([\
-            rootKey[i], oldCommitmentValues[i],\
+            rootKey, oldCommitmentValues[i],\
             oldCommitmentSalts[i],...paths[i], orders[i]\
         ]);
         assert(s == t);

--- a/nightfall-deployer/circuits/common/generic_circuit/Verifiers/verify_nullifiers.zok
+++ b/nightfall-deployer/circuits/common/generic_circuit/Verifiers/verify_nullifiers.zok
@@ -1,6 +1,3 @@
-from "ecc/babyjubjubParams" import BabyJubJubParams, main as curveParams;
-from "ecc/edwardsScalarMult" import main as scalarMult;
-from "utils/pack/bool/nonStrictUnpack256.zok" import main as field_to_bool_256;
 from "hashes/poseidon/poseidon.zok" import main as poseidon;
 from "../../utils/structures.zok" import Point, PRIVATE_KEY_DOMAIN, NULLIFIER_KEY_DOMAIN;
 from "../../merkle-tree/path-check.zok" import main as pathCheck;
@@ -15,29 +12,15 @@ def main<MinNullifiers, MaxNullifiers>(\
     field[MaxNullifiers] roots,\
     private field[MaxNullifiers] oldCommitmentValues,\
     private field[MaxNullifiers] oldCommitmentSalts,\
-    private field[MaxNullifiers] rootKey,\
     private field[MaxNullifiers][32] paths,\
 	private field[MaxNullifiers] orders,\
+    private field nullifierKeys,\
+    private Point zkpPublicKeys,\
     field maticAddress\
-) -> Point {
-    // Get Curve Params
-    BabyJubJubParams context = curveParams();
-    Point g = [context.Gu, context.Gv];
-
-    //If the transaction contains change, the receiver of that change MUST be the same user that 
-    //created the transaction. In this field[2] we will store the zkpPublicKey of the sender in case
-    //we need it to check the change. 
-    Point mut firstInputZkpPublicKeys = [0,0];
-
+) -> bool {
+   
     //Check that all the nullifiers are valid. If NumNullifiers equals zero this loop will be ignored
     for u32 i in 0..MaxNullifiers {
-        // Calculation of zkpPrivateKey and nullifierKey from rootKey
-        field zkpPrivateKeys = poseidon([rootKey[i], PRIVATE_KEY_DOMAIN]);
-        field nullifierKeys = poseidon([rootKey[i], NULLIFIER_KEY_DOMAIN]);
-
-        // Calculate zkpPublicKey
-        Point zkpPublicKeys = scalarMult(field_to_bool_256(zkpPrivateKeys), g, context);
-
         /*
             Calculate the nullifier hash from the oldCommitment parameters
             We can check if nullifier is supposed to be null or non-null by the following
@@ -76,10 +59,7 @@ def main<MinNullifiers, MaxNullifiers>(\
         //Check that the nullifier is contained in the tree
         bool pathValidity = if(oldCommitmentValues[i] != 0 || (i+1) == MinNullifiers) { pathCheck([roots[i], ...paths[i]], orders[i], validCalculatedOldCommitmentHash) } else { true };
         assert(pathValidity);
-
-        //Set the changeZkpPublicKeys if i = 0. Otherwise just set the same value
-        firstInputZkpPublicKeys = i == 0 ? zkpPublicKeys : firstInputZkpPublicKeys;
     }
     
-    return firstInputZkpPublicKeys;
+    return true;
 }

--- a/nightfall-deployer/circuits/common/utils/calculateKeys.zok
+++ b/nightfall-deployer/circuits/common/utils/calculateKeys.zok
@@ -1,0 +1,24 @@
+from "./structures.zok" import Point, PRIVATE_KEY_DOMAIN, NULLIFIER_KEY_DOMAIN;
+from "ecc/babyjubjubParams" import BabyJubJubParams, main as curveParams;
+from "ecc/edwardsScalarMult" import main as scalarMult;
+from "utils/pack/bool/nonStrictUnpack256.zok" import main as field_to_bool_256;
+from "hashes/poseidon/poseidon.zok" import main as poseidon;
+
+struct Keys {
+    field nullifierKey;
+    Point zkpPublicKey;
+}
+
+def main(field rootKey) -> Keys {
+    BabyJubJubParams context = curveParams();
+    Point g = [context.Gu, context.Gv];
+
+     // Calculation of zkpPrivateKey and nullifierKey from rootKey
+    field zkpPrivateKey = poseidon([rootKey, PRIVATE_KEY_DOMAIN]);
+    field nullifierKey = poseidon([rootKey, NULLIFIER_KEY_DOMAIN]);
+
+    // Calculate zkpPublicKey
+    Point zkpPublicKey = scalarMult(field_to_bool_256(zkpPrivateKey), g, context);
+    Keys keys = Keys { nullifierKey: nullifierKey, zkpPublicKey: zkpPublicKey};
+    return keys;
+}

--- a/nightfall-deployer/circuits/common/utils/structures.zok
+++ b/nightfall-deployer/circuits/common/utils/structures.zok
@@ -33,7 +33,6 @@ struct PublicTransaction {
 
 struct Nullifiers<N> {
 	CommitmentPreimage<N> oldCommitments;
-    field[N] rootKey;
     field[N][32] paths;
 	field[N] orders;
 }

--- a/nightfall-deployer/circuits/transfer.zok
+++ b/nightfall-deployer/circuits/transfer.zok
@@ -1,6 +1,7 @@
 
 from "./common/utils/structures.zok" import Point, PublicTransaction, Nullifiers, Commitments, Transfer, SHIFT;
 from "./common/utils/calculations.zok" import sum;
+from "./common/utils/calculateKeys.zok" import main as calculateKeys, Keys;
 from "./common/casts/u32_array_to_field.zok" import main as u32_array_to_field;
 from "./common/casts/u8_array_to_field.zok" import main as u8_array_to_field;
 from "./common/generic_circuit/Verifiers/verify_structure.zok" import main as verify_structure;
@@ -12,6 +13,7 @@ def main(\
     PublicTransaction tx,\
     field[4] roots,\
     field maticAddress,\
+    private field rootKey,\
     private Nullifiers<4> nullifiers,\
     private Commitments<3> commitments,\
     private Transfer transfer\
@@ -44,10 +46,13 @@ def main(\
     field idRemainder = u32_array_to_field(transfer.idTransfer[1..8]); 
     field packedErcAddress = transfer.ercAddressTransfer + u32_array_to_field([transfer.idTransfer[0]]) * SHIFT; 
 
+    //Calculate Keys
+    Keys keys = calculateKeys(rootKey);
+
     //Verify nullifiers
-    Point firstInputZkpPublicKeys = verify_nullifiers::<1,4>(packedErcAddress, idRemainder,\
+    assert(verify_nullifiers::<1,4>(packedErcAddress, idRemainder,\
         tx.nullifiers, roots, nullifiersValue, nullifiers.oldCommitments.salt,\
-        nullifiers.rootKey, nullifiers.paths, nullifiers.orders, maticAddress);
+        nullifiers.paths, nullifiers.orders, keys.nullifierKey, keys.zkpPublicKey, maticAddress));
 
     //Verify new Commmitments
     assert(verify_commitments::<1,3>(packedErcAddress, idRemainder, tx.commitments,\
@@ -55,10 +60,10 @@ def main(\
     maticAddress));
 
     //Verify Changes
-    assert(commitmentsValue[1] == 0 || firstInputZkpPublicKeys == commitments.recipientPublicKey[1]);
+    assert(commitmentsValue[1] == 0 || keys.zkpPublicKey == commitments.recipientPublicKey[1]);
     
      //Verify Fee change
-    assert(commitmentsValue[2] == 0 || firstInputZkpPublicKeys == commitments.recipientPublicKey[2]);
+    assert(commitmentsValue[2] == 0 || keys.zkpPublicKey == commitments.recipientPublicKey[2]);
 
     //Verify Kem Dem encryption
     assert(verify_encryption(tx.ercAddress,tx.tokenId, tx.compressedSecrets,\

--- a/nightfall-deployer/circuits/transfer_stub.zok
+++ b/nightfall-deployer/circuits/transfer_stub.zok
@@ -9,6 +9,7 @@ def main(\
     PublicTransaction tx,\
     field[4] roots,\
     field maticAddress,\
+    private field rootKey,\
     private Nullifiers<4> nullifiers,\
     private Commitments<3> commitments,\
     private Transfer transfer\
@@ -19,7 +20,7 @@ def main(\
 
     assert(nullifier_stub::<4>(\
         roots, nullifiersValue, nullifiers.oldCommitments.salt,\
-        nullifiers.rootKey, nullifiers.paths, nullifiers.orders));
+        nullifiers.paths, nullifiers.orders, rootKey));
 
     assert(commitment_stub::<3>(\
         commitmentsValue, commitments.newCommitments.salt, commitments.recipientPublicKey));

--- a/nightfall-deployer/circuits/withdraw.zok
+++ b/nightfall-deployer/circuits/withdraw.zok
@@ -1,5 +1,6 @@
 from "./common/utils/structures.zok" import Point, PublicTransaction, Nullifiers, Commitments, Transfer, SHIFT;
 from "./common/utils/calculations.zok" import sum;
+from "./common/utils/calculateKeys.zok" import main as calculateKeys, Keys;
 from "./common/casts/u32_array_to_field.zok" import main as u32_array_to_field;
 from "./common/casts/u8_array_to_field.zok" import main as u8_array_to_field;
 from "./common/generic_circuit/Verifiers/verify_structure.zok" import main as verify_structure;
@@ -11,6 +12,7 @@ def main(\
     PublicTransaction tx,\
     field[4] roots,\
     field maticAddress,\
+    private field rootKey,\
     private Nullifiers<4> nullifiers,\
     private Commitments<2> commitments\
 ) {
@@ -41,20 +43,23 @@ def main(\
     field idRemainder = u32_array_to_field(tx.tokenId[1..8]);
     field packedErcAddress = tx.ercAddress + u32_array_to_field([tx.tokenId[0]]) * SHIFT; 
 
+    //Calculate Keys
+    Keys keys = calculateKeys(rootKey);
+
     //Verify nullifiers
-    Point firstInputZkpPublicKeys = verify_nullifiers::<1,4>(packedErcAddress, idRemainder,\
+    assert(verify_nullifiers::<1,4>(packedErcAddress, idRemainder,\
         tx.nullifiers, roots, nullifiersValue, nullifiers.oldCommitments.salt,\
-        nullifiers.rootKey, nullifiers.paths, nullifiers.orders, maticAddress);
+        nullifiers.paths, nullifiers.orders, keys.nullifierKey, keys.zkpPublicKey, maticAddress));
 
     //Verify new Commmitments
     assert(verify_commitments::<0,2>(packedErcAddress, idRemainder, [tx.commitments[0], tx.commitments[1]],\
     commitmentsValue, commitments.newCommitments.salt, commitments.recipientPublicKey, maticAddress));
 
     //Verify Changes
-    assert(commitmentsValue[0] == 0 || firstInputZkpPublicKeys == commitments.recipientPublicKey[0]);
+    assert(commitmentsValue[0] == 0 || keys.zkpPublicKey == commitments.recipientPublicKey[0]);
     
      //Verify Fee change
-    assert(commitmentsValue[1] == 0 || firstInputZkpPublicKeys == commitments.recipientPublicKey[1]);
+    assert(commitmentsValue[1] == 0 || keys.zkpPublicKey == commitments.recipientPublicKey[1]);
 
     return;
 }

--- a/nightfall-deployer/circuits/withdraw_stub.zok
+++ b/nightfall-deployer/circuits/withdraw_stub.zok
@@ -8,6 +8,7 @@ def main(\
     PublicTransaction tx,\
     field[4] roots,\
     field maticAddress,\
+    private field rootKey,\
     private Nullifiers<4> nullifiers,\
     private Commitments<2> commitments\
 ) {
@@ -15,10 +16,9 @@ def main(\
     field[4] nullifiersValue = u8_array_to_field(nullifiers.oldCommitments.value);
     field[2] commitmentsValue = u8_array_to_field(commitments.newCommitments.value);
 
-
     assert(nullifier_stub::<4>(\
         roots, nullifiersValue, nullifiers.oldCommitments.salt,\
-        nullifiers.rootKey, nullifiers.paths, nullifiers.orders));
+        nullifiers.paths, nullifiers.orders, rootKey));
 
     assert(commitment_stub::<2>(\
         commitmentsValue, commitments.newCommitments.salt, commitments.recipientPublicKey));

--- a/wallet/src/nightfall-browser/services/transfer.js
+++ b/wallet/src/nightfall-browser/services/transfer.js
@@ -113,7 +113,7 @@ async function transfer(transferParams, shieldContractAddress) {
       });
 
       const privateData = {
-        rootKey: [rootKey, rootKey, rootKey, rootKey],
+        rootKey,
         oldCommitmentPreimage: commitmentsInfo.oldCommitments.map(o => {
           return { value: o.preimage.value, salt: o.preimage.salt };
         }),

--- a/wallet/src/nightfall-browser/services/withdraw.js
+++ b/wallet/src/nightfall-browser/services/withdraw.js
@@ -91,7 +91,7 @@ async function withdraw(withdrawParams, shieldContractAddress) {
     });
 
     const privateData = {
-      rootKey: [rootKey, rootKey, rootKey, rootKey],
+      rootKey,
       oldCommitmentPreimage: commitmentsInfo.oldCommitments.map(o => {
         return { value: o.preimage.value, salt: o.preimage.salt };
       }),

--- a/wallet/src/nightfall-browser/utils/compute-witness.ts
+++ b/wallet/src/nightfall-browser/utils/compute-witness.ts
@@ -38,8 +38,8 @@ type CommitmentPreimage = {
 };
 
 type Nullifier = {
+  rootKey: string;
   oldCommitments: CommitmentPreimage;
-  rootKey: string[];
   paths: string[][];
   orders: string[];
 };
@@ -102,7 +102,7 @@ const computePrivateInputsNullifiers = (
   oldCommitmentPreimage: Record<string, GeneralNumber>[],
   paths: GeneralNumber[][],
   orders: GeneralNumber[],
-  rootKey: GeneralNumber[],
+  rootKey: GeneralNumber,
 ): Nullifier => {
   const paddedOldCommitmentPreimage: Record<string, GeneralNumber>[] = padArray(
     oldCommitmentPreimage,
@@ -111,14 +111,13 @@ const computePrivateInputsNullifiers = (
   );
   const paddedPaths: GeneralNumber[][] = padArray(paths, new Array(32).fill(0), 4);
   const paddedOrders: GeneralNumber[] = padArray(orders, 0, 4);
-  const paddedRootKeys: GeneralNumber[] = padArray(rootKey, 0, 4);
 
   return {
+    rootKey: rootKey.field(BN128_GROUP_ORDER),
     oldCommitments: {
       value: paddedOldCommitmentPreimage.map(commitment => commitment.value.limbs(8, 31)),
       salt: paddedOldCommitmentPreimage.map(commitment => commitment.salt.field(BN128_GROUP_ORDER)),
     },
-    rootKey: paddedRootKeys.map(r => r.field(BN128_GROUP_ORDER)),
     paths: paddedPaths.map(ps => ps.map(p => p.field(BN128_GROUP_ORDER))),
     orders: paddedOrders.map(m => m.field(BN128_GROUP_ORDER)),
   };


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
This PR modifies the nullifier struct in the circuits so that rootKey is only sent once and therefore the nullifierKey and zkpPublicKey are calculated only once. With this change, the transfer and withdrawal circuits have a constraint reduction of around 12K, which is roughly a 20% reduction

## Does this close any currently open issues? 
Yes, it closes #978 

## Any relevant logs, error output, etc? 
No
## Any other comments? 
No

