### PR TITLE
Add contract-abi endpoints to client/optimist

### DIFF
--- a/common-files/utils/contract.mjs
+++ b/common-files/utils/contract.mjs
@@ -31,6 +31,15 @@ export async function getContractAddress(contractName) {
   return deployedAddress;
 }
 
+export async function getContractAbi(contractName) {
+  let abi;
+  const contractInterface = await getContractInterface(contractName);
+  if (contractInterface) {
+    abi = contractInterface.abi;
+  }
+  return abi;
+}
+
 // returns a web3 contract instance
 export async function getContractInstance(contractName, deployedAddress) {
   // grab a 'from' account if one isn't set

--- a/nightfall-client/src/app.mjs
+++ b/nightfall-client/src/app.mjs
@@ -4,6 +4,7 @@ import cors from 'cors';
 import {
   deposit,
   getContractAddress,
+  getContractAbi,
   transfer,
   withdraw,
   finaliseWithdrawal,
@@ -26,6 +27,7 @@ app.use(bodyParser.urlencoded({ limit: '2mb', extended: true }));
 
 app.use('/deposit', deposit);
 app.use('/contract-address', getContractAddress);
+app.use('/contract-abi', getContractAbi);
 app.use('/transfer', transfer);
 app.use('/withdraw', withdraw);
 app.use('/finalise-withdrawal', finaliseWithdrawal);

--- a/nightfall-client/src/routes/contract-abi.mjs
+++ b/nightfall-client/src/routes/contract-abi.mjs
@@ -1,0 +1,29 @@
+/**
+Route for depositing (minting) a crypto commitment.
+This code assumes that the Shield contract already has approval to spend
+funds on a zkp deposit
+*/
+import express from 'express';
+import logger from 'common-files/utils/logger.mjs';
+import { getContractAbi } from 'common-files/utils/contract.mjs';
+
+const router = express.Router();
+
+router.get('/:contract', async (req, res, next) => {
+  logger.debug('contract-abi endpoint received GET');
+  const { contract } = req.params;
+  try {
+    const abi = await getContractAbi(contract);
+    logger.debug(`returning abi ${abi}`);
+    if (abi) {
+      res.json({ abi });
+    } else {
+      res.sendStatus(404);
+    }
+  } catch (err) {
+    logger.error(err);
+    next(err);
+  }
+});
+
+export default router;

--- a/nightfall-client/src/routes/index.mjs
+++ b/nightfall-client/src/routes/index.mjs
@@ -1,5 +1,6 @@
 import deposit from './deposit.mjs';
 import getContractAddress from './contract-address.mjs';
+import getContractAbi from './contract-abi.mjs';
 import transfer from './transfer.mjs';
 import withdraw from './withdraw.mjs';
 import finaliseWithdrawal from './finalise-withdrawal.mjs';
@@ -14,6 +15,7 @@ export {
   deposit,
   withdraw,
   getContractAddress,
+  getContractAbi,
   finaliseWithdrawal,
   isValidWithdrawal,
   commitment,

--- a/nightfall-optimist/src/app.mjs
+++ b/nightfall-optimist/src/app.mjs
@@ -7,6 +7,7 @@ import {
   challenger,
   transaction,
   getContractAddress,
+  getContractAbi,
   debug,
 } from './routes/index.mjs';
 
@@ -26,6 +27,7 @@ app.use('/block', block);
 app.use('/challenger', challenger);
 app.use('/transaction', transaction);
 app.use('/contract-address', getContractAddress);
+app.use('/contract-abi', getContractAbi);
 app.use('/debug', debug);
 
 export default app;

--- a/nightfall-optimist/src/routes/contract-abi.mjs
+++ b/nightfall-optimist/src/routes/contract-abi.mjs
@@ -1,0 +1,29 @@
+/**
+Route for depositing (minting) a crypto commitment.
+This code assumes that the Shield contract already has approval to spend
+funds on a zkp deposit
+*/
+import express from 'express';
+import logger from 'common-files/utils/logger.mjs';
+import { getContractAbi } from 'common-files/utils/contract.mjs';
+
+const router = express.Router();
+
+router.get('/:contract', async (req, res, next) => {
+  logger.debug('contract-abi endpoint received GET');
+  const { contract } = req.params;
+  try {
+    const abi = await getContractAbi(contract);
+    logger.debug(`returning abi ${abi}`);
+    if (abi) {
+      res.json({ abi });
+    } else {
+      res.sendStatus(404);
+    }
+  } catch (err) {
+    logger.error(err);
+    next(err);
+  }
+});
+
+export default router;

--- a/nightfall-optimist/src/routes/index.mjs
+++ b/nightfall-optimist/src/routes/index.mjs
@@ -4,5 +4,6 @@ import challenger from './challenger.mjs';
 import transaction from './transaction.mjs';
 import debug from './debug.mjs';
 import getContractAddress from './contract-address.mjs';
+import getContractAbi from './contract-abi.mjs';
 
-export { proposer, block, challenger, transaction, getContractAddress, debug };
+export { proposer, block, challenger, transaction, getContractAddress, getContractAbi, debug };


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Fix: #990
We have some issues when trying to get the version of the ABI for the current deployment in the Block Explorer on in some tests.
We will add enpoints to get ABI of the contracts in the `nightfall-client` and `nightfall-optimist` the same we have now with `contract-address`.
The endpoint will be `contract-abi`.

Example:
```
curl http://localhost:8080/contract-abi/State 
```

## Does this close any currently open issues?
Issue #990 
## Any relevant logs, error output, etc?

## Any other comments?

