### PR TITLE
KEM-DEM Audit fixes 

### DIFF
--- a/common-files/utils/crypto/crypto-random.mjs
+++ b/common-files/utils/crypto/crypto-random.mjs
@@ -24,7 +24,7 @@ async function randValueLT(bigIntValue) {
     // eslint-disable-next-line no-await-in-loop
     genVal = await rand(minimumBytes);
     counter++;
-  } while (genVal.bigInt >= bigIntValue || genVal.bigInt === 0 || counter === MAX_ATTEMPTS);
+  } while ((genVal.bigInt >= bigIntValue || genVal.bigInt === 0) && counter < MAX_ATTEMPTS);
   if (counter === MAX_ATTEMPTS) throw new Error("Couldn't make a number below target value");
   return genVal;
 }

--- a/common-files/utils/crypto/crypto-random.mjs
+++ b/common-files/utils/crypto/crypto-random.mjs
@@ -24,7 +24,7 @@ async function randValueLT(bigIntValue) {
     // eslint-disable-next-line no-await-in-loop
     genVal = await rand(minimumBytes);
     counter++;
-  } while (genVal.bigInt >= bigIntValue || counter === MAX_ATTEMPTS);
+  } while (genVal.bigInt >= bigIntValue || genVal.bigInt === 0 || counter === MAX_ATTEMPTS);
   if (counter === MAX_ATTEMPTS) throw new Error("Couldn't make a number below target value");
   return genVal;
 }

--- a/doc/in-band-secret-distribution.md
+++ b/doc/in-band-secret-distribution.md
@@ -17,7 +17,7 @@ prime and `G` is the generator.
 Alice generates a random ephemeral asymmetric key-pair $(x_e, Q_e)$:  
 $$ x_e \; \leftarrow\; \{0, 1\}^{256} \qquad Q_e \coloneqq x_eG $$
 
-These keys are only used once, and are unique to this transaction, giving us perfect forward secerecy.
+These keys are only used once, and are unique to this transaction.
 
 ### Encryption
 

--- a/nightfall-client/src/services/kem-dem.mjs
+++ b/nightfall-client/src/services/kem-dem.mjs
@@ -10,6 +10,7 @@ const DOMAIN_KEM = 2103336540571167522381317926858644704162216915553936573639297
 // DOMAIN_KEM = field(SHA256('nightfall-dem'))
 const DOMAIN_DEM = 1241463701002173366467794894814691939898321302682516549591039420117995599097n;
 
+const BABYJUBJUB_GROUP_ORDER = BABYJUBJUB.JUBJUBE / BABYJUBJUB.JUBJUBC;
 /**
 This function is like splice but replaces the element in index and returns a new array
 @function immutableSplice
@@ -39,10 +40,8 @@ const packSecrets = (from, to, topMostFromBytesIndex, topMostToBytesIndex) => {
     throw new Error('This function packs u32[8], indices must be < 8');
   const fromLimbs = from.limbs(32, 8);
   const toLimbs = to.limbs(32, 8);
-  if (toLimbs[0] !== '0') throw new Error('Cannot pack since top bits non-zero');
+  if (toLimbs[topMostToBytesIndex] !== '0') throw new Error('Cannot pack since top bits non-zero');
 
-  if (topMostToBytesIndex + 1 === toLimbs.length)
-    throw new Error('Pack To Array is zero, need to specify to address');
   const topMostBytes = fromLimbs[topMostFromBytesIndex];
 
   const unpackedFrom = immutableSplice(fromLimbs, topMostFromBytesIndex, '0');
@@ -56,7 +55,7 @@ This function generates the ephemeral key pair used in the kem-dem
 @returns {Promise<Array<GeneralNumber, Array<BigInt>>>} The private and public key pair
 */
 const genEphemeralKeys = async () => {
-  const privateKey = await randValueLT(BN128_GROUP_ORDER);
+  const privateKey = await randValueLT(BABYJUBJUB_GROUP_ORDER);
   const publicKey = scalarMult(privateKey.bigInt, BABYJUBJUB.GENERATOR);
   return [privateKey, publicKey];
 };

--- a/wallet/src/common-files/utils/crypto/crypto-random.js
+++ b/wallet/src/common-files/utils/crypto/crypto-random.js
@@ -25,7 +25,7 @@ export async function randValueLT(bigIntValue) {
     // eslint-disable-next-line no-await-in-loop
     genVal = await rand(minimumBytes);
     counter++;
-  } while (genVal.bigInt >= bigIntValue || counter === MAX_ATTEMPTS);
+  } while (genVal.bigInt >= bigIntValue || genVal.bigInt === 0 || counter === MAX_ATTEMPTS);
   if (counter === MAX_ATTEMPTS) throw new Error("Couldn't make a number below target value");
   return genVal;
 }

--- a/wallet/src/common-files/utils/crypto/crypto-random.js
+++ b/wallet/src/common-files/utils/crypto/crypto-random.js
@@ -25,7 +25,7 @@ export async function randValueLT(bigIntValue) {
     // eslint-disable-next-line no-await-in-loop
     genVal = await rand(minimumBytes);
     counter++;
-  } while (genVal.bigInt >= bigIntValue || genVal.bigInt === 0 || counter === MAX_ATTEMPTS);
+  } while ((genVal.bigInt >= bigIntValue || genVal.bigInt === 0) && counter < MAX_ATTEMPTS);
   if (counter === MAX_ATTEMPTS) throw new Error("Couldn't make a number below target value");
   return genVal;
 }

--- a/wallet/src/nightfall-browser/services/kem-dem.ts
+++ b/wallet/src/nightfall-browser/services/kem-dem.ts
@@ -10,6 +10,7 @@ const DOMAIN_KEM = 2103336540571167522381317926858644704162216915553936573639297
 // DOMAIN_KEM = field(SHA256('nightfall-dem'))
 const DOMAIN_DEM = 1241463701002173366467794894814691939898321302682516549591039420117995599097n;
 
+const BABYJUBJUB_GROUP_ORDER = BABYJUBJUB.JUBJUBE / BABYJUBJUB.JUBJUBC;
 /**
 This function is like splice but replaces the element in index and returns a new array
 @function immutableSplice
@@ -44,10 +45,8 @@ const packSecrets = (
     throw new Error('This function packs u32[8], indices must be < 8');
   const fromLimbs = from.limbs(32, 8);
   const toLimbs = to.limbs(32, 8);
-  if (toLimbs[0] !== '0') throw new Error('Cannot pack since top bits non-zero');
+  if (toLimbs[topMostToBytesIndex] !== '0') throw new Error('Cannot pack since top bits non-zero');
 
-  if (topMostToBytesIndex + 1 === toLimbs.length)
-    throw new Error('Pack To Array is zero, need to specify to address');
   const topMostBytes = fromLimbs[topMostFromBytesIndex];
 
   const unpackedFrom = immutableSplice(fromLimbs, topMostFromBytesIndex, '0');
@@ -61,7 +60,7 @@ This function generates the ephemeral key pair used in the kem-dem
 @returns {Promise<Array<GeneralNumber, Array<BigInt>>>} The private and public key pair
 */
 const genEphemeralKeys = async (): Promise<[GeneralNumber, BigInt[]]> => {
-  const privateKey: any = await randValueLT(BN128_GROUP_ORDER);
+  const privateKey: any = await randValueLT(BABYJUBJUB_GROUP_ORDER);
   const publicKey = scalarMult(privateKey.bigInt, BABYJUBJUB.GENERATOR);
   return [privateKey, publicKey];
 };


### PR DESCRIPTION
This fixes some issues brought up as part the audit review

1. `randValueLT` used in KEM-DEM selects an element from the `BABYJUBJUB Sub Group Order` (Group_Order / cofactor), the random value is also checked to be non-zero
2. Error thrown in `packSecrets` have been removed or updated. 
3. Comments about `forward secrecy` removed.

