### PR TITLE
fix: updated filter conditions in client balances to return erc721 data

### DIFF
--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -367,7 +367,7 @@ export async function getWalletPendingDepositBalance(compressedZkpPublicKey, erc
     }))
     .filter(
       e =>
-        e.value > 0 &&
+        e.value >= 0 &&
         (compressedZkpPublicKey === null || e.compressedZkpPublicKey === compressedZkpPublicKey) &&
         (ercAddressList.length === 0 || ercAddressList.includes(e.ercAddress.toUpperCase())),
     )
@@ -428,7 +428,7 @@ export async function getWalletPendingSpentBalance(compressedZkpPublicKey, ercLi
     }))
     .filter(
       e =>
-        e.value > 0 &&
+        e.value >= 0 &&
         (compressedZkpPublicKey === null || e.compressedZkpPublicKey === compressedZkpPublicKey) &&
         (ercAddressList.length === 0 || ercAddressList.includes(e.ercAddress.toUpperCase())),
     )


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

When we store ERC721 tokens we set the value to `0` (since we care about `tokenId`). Filtering commitments above 0 value is preventing `/pending-deposit` and `/pending-spent` from returning info re ERC721.

## Does this close any currently open issues?

n/a

## Any relevant logs, error output, etc?

n/a

## Any other comments?

n/a