### PR TITLE
Using non-JSON logging only for local envs

### DIFF
--- a/common-files/utils/logger.mjs
+++ b/common-files/utils/logger.mjs
@@ -3,7 +3,7 @@
 
 import config from 'config';
 import pino from 'pino';
-import { isDev } from './utils.mjs';
+import { isLocal } from './utils.mjs';
 import correlator from './correlation-id.mjs';
 
 const LOGGER_TIME_STRING = 'yyyy-mm-dd HH:MM:ss.l';
@@ -32,7 +32,7 @@ const getInstance = () => {
     },
   };
 
-  if (!isDev()) {
+  if (!isLocal()) {
     delete pinoOptions.transport;
   }
 

--- a/common-files/utils/utils.mjs
+++ b/common-files/utils/utils.mjs
@@ -4,6 +4,16 @@
 
 export const isDev = () => process.env.NODE_ENV !== 'production';
 
+export const isLocal = () => {
+  return (
+    process.env.NODE_ENV !== 'internal' &&
+    process.env.NODE_ENV !== 'staging' &&
+    process.env.NODE_ENV !== 'preprod' &&
+    process.env.NODE_ENV !== 'testnet' &&
+    process.env.NODE_ENV !== 'production'
+  );
+};
+
 /**
  * This method is intended to be used for obfuscating sensitive data, totally or partially. It uses the obfuscation
  * settings passed as parameter to perform the obfuscation.


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Basically, when in local environments the logger will issue logs in a non-JSON format and, when in other envs, will use JSON format.

## Does this close any currently open issues?
Nope

## Any relevant logs, error output, etc?
Nope

## Any other comments?
Nope
