### PR TITLE
fix: fixing lower and upper case wrong comparison with ercAddress

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -81,7 +81,7 @@ module.exports = {
   CURVE: process.env.CURVE || 'bn128',
 
   TRANSACTIONS_PER_BLOCK: Number(process.env.TRANSACTIONS_PER_BLOCK) || 2,
-  RETRIES: Number(process.env.AUTOSTART_RETRIES) || 50,
+  RETRIES: Number(process.env.AUTOSTART_RETRIES) || 150,
   USE_STUBS: process.env.USE_STUBS === 'true',
   VK_IDS: { deposit: 0, transfer: 1, withdraw: 2 }, // used as an enum to mirror the Shield contracts enum for vk types. The keys of this object must correspond to a 'folderpath' (the .zok file without the '.zok' bit)
   MPC: {

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -30,10 +30,12 @@ export async function storeCommitment(commitment, nullifierKey) {
   // spotting if the commitment spend is ever rolled back, which would mean the
   // commitment is once again available to spend
   const nullifierHash = new Nullifier(commitment, nullifierKey).hash.hex(32);
+  const preimage = commitment.preimage.all.hex(32);
+  preimage.ercAddress = preimage.ercAddress.toLowerCase();
   const data = {
     _id: commitment.hash.hex(32),
     compressedZkpPublicKey: commitment.compressedZkpPublicKey.hex(32),
-    preimage: commitment.preimage.all.hex(32),
+    preimage,
     isDeposited: commitment.isDeposited || false,
     isOnChain: Number(commitment.isOnChain) || -1,
     isPendingNullification: false, // will not be pending when stored

--- a/nightfall-client/src/services/deposit.mjs
+++ b/nightfall-client/src/services/deposit.mjs
@@ -26,8 +26,8 @@ async function deposit(items) {
   logger.info('Creating a deposit transaction');
 
   // before we do anything else, long hex strings should be generalised to make subsequent manipulations easier
-  const { ercAddress, tokenId, value, compressedZkpPublicKey, nullifierKey, fee } =
-    generalise(items);
+  const { tokenId, value, compressedZkpPublicKey, nullifierKey, fee } = generalise(items);
+  const ercAddress = generalise(items.ercAddress.toLowerCase());
   const zkpPublicKey = ZkpKeys.decompressZkpPublicKey(compressedZkpPublicKey);
   const salt = await randValueLT(BN128_GROUP_ORDER);
   const commitment = new Commitment({ ercAddress, tokenId, value, zkpPublicKey, salt });

--- a/nightfall-client/src/services/transfer.mjs
+++ b/nightfall-client/src/services/transfer.mjs
@@ -30,7 +30,8 @@ async function transfer(transferParams) {
   logger.info('Creating a transfer transaction');
   // let's extract the input items
   const { offchain = false, ...items } = transferParams;
-  const { ercAddress, tokenId, recipientData, rootKey, fee } = generalise(items);
+  const { tokenId, recipientData, rootKey, fee } = generalise(items);
+  const ercAddress = generalise(items.ercAddress.toLowerCase());
   const { recipientCompressedZkpPublicKeys, values } = recipientData;
   const recipientZkpPublicKeys = recipientCompressedZkpPublicKeys.map(key =>
     ZkpKeys.decompressZkpPublicKey(key),
@@ -46,7 +47,7 @@ async function transfer(transferParams) {
 
   logger.debug({
     msg: 'Transfer ERC Token & Fee addresses',
-    ercAddress: ercAddress.hex(32).toLowerCase(),
+    ercAddress: ercAddress.hex(32),
     maticAddress: maticAddress.hex(32),
   });
 

--- a/nightfall-client/src/services/withdraw.mjs
+++ b/nightfall-client/src/services/withdraw.mjs
@@ -29,8 +29,8 @@ async function withdraw(withdrawParams) {
   logger.info('Creating a withdraw transaction');
   // let's extract the input items
   const { offchain = false, ...items } = withdrawParams;
-  const { ercAddress, tokenId, value, recipientAddress, rootKey, fee } = generalise(items);
-
+  const { tokenId, value, recipientAddress, rootKey, fee } = generalise(items);
+  const ercAddress = generalise(items.ercAddress.toLowerCase());
   const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
 
   const maticAddress = generalise(
@@ -39,7 +39,7 @@ async function withdraw(withdrawParams) {
 
   logger.debug({
     msg: 'Withdraw ERC Token and Fee addresses',
-    ercAddress: ercAddress.hex(32).toLowerCase(),
+    ercAddress: ercAddress.hex(32),
     maticAddress: maticAddress.hex(32),
   });
 

--- a/nightfall-client/src/utils/getCommitmentInfo.mjs
+++ b/nightfall-client/src/utils/getCommitmentInfo.mjs
@@ -35,8 +35,7 @@ export const getCommitmentInfo = async txInfo => {
 
   const tokenIdArray = recipientZkpPublicKeysArray.map(() => tokenId);
 
-  const addedFee =
-    maticAddress.hex(32).toLowerCase() === ercAddress.hex(32).toLowerCase() ? fee.bigInt : 0n;
+  const addedFee = maticAddress.hex(32) === ercAddress.hex(32) ? fee.bigInt : 0n;
 
   logger.debug(`Fee will be added as part of the transaction commitments: ${addedFee > 0n}`);
 

--- a/nightfall-deployer/migrations/2_deploy_upgradeable.js
+++ b/nightfall-deployer/migrations/2_deploy_upgradeable.js
@@ -76,5 +76,5 @@ module.exports = async function (deployer) {
   const maticAddress = RESTRICTIONS.tokens[process.env.ETH_NETWORK].find(
     token => token.name === 'MATIC',
   ).address;
-  await shield.setMaticAddress(maticAddress);
+  await shield.setMaticAddress(maticAddress.toLowerCase());
 };

--- a/nightfall-deployer/migrations/3_test_tokens_migration.js
+++ b/nightfall-deployer/migrations/3_test_tokens_migration.js
@@ -48,7 +48,7 @@ module.exports = function (deployer, _, accounts) {
 
     if (!config.ETH_ADDRESS) {
       //modify the matic address to be ERCMock for tests
-      await shield.setMaticAddress(ERC20deployed.address);
+      await shield.setMaticAddress(ERC20deployed.address.toLowerCase());
 
       // indicates we're running a wallet test that uses hardcoded addresses
       // For e2e tests

--- a/nightfall-deployer/migrations/4_upgrade_upgradeable.js
+++ b/nightfall-deployer/migrations/4_upgrade_upgradeable.js
@@ -89,5 +89,5 @@ module.exports = async function (deployer) {
   const maticAddress = RESTRICTIONS.tokens[process.env.ETH_NETWORK].find(
     token => token.name === 'MATIC',
   ).address;
-  await shield.setMaticAddress(maticAddress);
+  await shield.setMaticAddress(maticAddress.toLowerCase());
 };

--- a/nightfall-optimist/src/services/transaction-checker.mjs
+++ b/nightfall-optimist/src/services/transaction-checker.mjs
@@ -151,7 +151,9 @@ async function verifyProof(transaction) {
 
   const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
 
-  const maticAddress = await shieldContractInstance.methods.getMaticAddress().call();
+  const maticAddress = (
+    await shieldContractInstance.methods.getMaticAddress().call()
+  ).toLowerCase();
 
   const inputs = generalise(
     [
@@ -170,7 +172,7 @@ async function verifyProof(transaction) {
       historicRootSecond.root,
       historicRootThird.root,
       historicRootFourth.root,
-      maticAddress.toLowerCase(),
+      maticAddress,
     ].flat(Infinity),
   ).all.hex(32);
 

--- a/wallet/src/nightfall-browser/services/commitment-storage.js
+++ b/wallet/src/nightfall-browser/services/commitment-storage.js
@@ -42,10 +42,12 @@ const connectDB = async () => {
 
 // function to format a commitment for a mongo db and store it
 export async function storeCommitment(commitment, nullifierKey) {
+  const preimage = commitment.preimage.all.hex(32);
+  preimage.ercAddress = preimage.ercAddress.toLowerCase();
   const nullifierHash = new Nullifier(commitment, nullifierKey).hash.hex(32);
   const data = {
     _id: commitment.hash.hex(32),
-    preimage: commitment.preimage.all.hex(32),
+    preimage,
     compressedZkpPublicKey: commitment.compressedZkpPublicKey.hex(32),
     isDeposited: commitment.isDeposited || false,
     isOnChain: Number(commitment.isOnChain) || -1,

--- a/wallet/src/nightfall-browser/services/deposit.js
+++ b/wallet/src/nightfall-browser/services/deposit.js
@@ -31,8 +31,8 @@ async function deposit(items, shieldContractAddress) {
   logger.info('Creating a deposit transaction');
   // before we do anything else, long hex strings should be generalised to make
   // subsequent manipulations easier
-  const { ercAddress, tokenId, value, compressedZkpPublicKey, nullifierKey, fee } =
-    generalise(items);
+  const { tokenId, value, compressedZkpPublicKey, nullifierKey, fee } = generalise(items);
+  const ercAddress = generalise(items.ercAddress.toLowerCase());
   const zkpPublicKey = ZkpKeys.decompressZkpPublicKey(compressedZkpPublicKey);
 
   const shieldContractInstance = await getContractInstance(

--- a/wallet/src/nightfall-browser/services/transfer.js
+++ b/wallet/src/nightfall-browser/services/transfer.js
@@ -40,7 +40,8 @@ async function transfer(transferParams, shieldContractAddress) {
   logger.info('Creating a transfer transaction');
   // let's extract the input items
   const { ...items } = transferParams;
-  const { ercAddress, tokenId, recipientData, rootKey, fee = generalise(0) } = generalise(items);
+  const { tokenId, recipientData, rootKey, fee = generalise(0) } = generalise(items);
+  const ercAddress = generalise(items.ercAddress.toLowerCase());
   const { recipientCompressedZkpPublicKeys, values } = recipientData;
   const recipientZkpPublicKeys = recipientCompressedZkpPublicKeys.map(key =>
     ZkpKeys.decompressZkpPublicKey(key),

--- a/wallet/src/nightfall-browser/services/withdraw.js
+++ b/wallet/src/nightfall-browser/services/withdraw.js
@@ -30,13 +30,14 @@ async function withdraw(withdrawParams, shieldContractAddress) {
   logger.info('Creating a withdraw transaction');
   // let's extract the input items
   const {
-    ercAddress,
     tokenId,
     value,
     recipientAddress,
     rootKey,
     fee = generalise(0),
   } = generalise(withdrawParams);
+
+  const ercAddress = generalise(withdrawParams.ercAddress.toLowerCase());
 
   if (!(await checkIndexDBForCircuit(circuitName)))
     throw Error('Some circuit data are missing from IndexedDB');

--- a/wallet/src/nightfall-browser/utils/getCommitmentInfo.ts
+++ b/wallet/src/nightfall-browser/utils/getCommitmentInfo.ts
@@ -10,6 +10,8 @@ import {
 import { ZkpKeys } from '../services/keys';
 
 const { generalise } = gen;
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
 const { BN128_GROUP_ORDER } = global.nightfallConstants;
 
 type CommitmentsInfo = {
@@ -50,8 +52,7 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
   const ercAddressArray = recipientZkpPublicKeysArray.map(() => ercAddress);
 
   const tokenIdArray = recipientZkpPublicKeysArray.map(() => tokenId);
-  const addedFee =
-    maticAddress.hex(32).toLowerCase() === ercAddress.hex(32).toLowerCase() ? fee : 0n;
+  const addedFee = maticAddress.hex(32) === ercAddress.hex(32) ? fee : 0n;
 
   const value = totalValueToSend + addedFee;
   const feeValue = fee - addedFee;


### PR DESCRIPTION
## What does this implement/fix? 
Ethereum addresses uses capital and lower-case letters, and this was causing some issues in the SDK because commitments weren't fully consistent. All ercAddress are now converted to lower case

## Does this close any currently open issues?

## Any relevant logs, error output, etc?

## Any other comments?

