### PR TITLE
proposeBlock prevents to add a deposit that has not previously escrowed its funds using submitTransaction

### DIFF
--- a/nightfall-deployer/contracts/Config.sol
+++ b/nightfall-deployer/contracts/Config.sol
@@ -12,6 +12,8 @@ contract Config is Ownable, Structures {
     uint256 constant COOLING_OFF_PERIOD = 1 weeks;
     bytes32 constant ZERO = bytes32(0);
     uint256 constant TRANSACTIONS_PER_BLOCK = 32;
+    uint256 constant BLOCK_STRUCTURE_SLOTS = 7;
+    uint256 constant TRANSACTION_STRUCTURE_SLOTS = 24;
 
     address bootProposer;
     address bootChallenger;

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -38,6 +38,7 @@ contract Shield is Stateful, Config, Key_Registry, ReentrancyGuardUpgradeable, P
         emit TransactionSubmitted();
 
         if (t.transactionType == TransactionTypes.DEPOSIT) {
+            state.setTransactionEscrowed(uint256(Utils.hashTransaction(t)), true);
             require(uint256(t.fee) == msg.value);
             payIn(t);
         }

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -24,6 +24,7 @@ contract Shield is Stateful, Config, Key_Registry, ReentrancyGuardUpgradeable, P
     mapping(bytes32 => bool) public withdrawn;
     mapping(bytes32 => address) public advancedWithdrawals;
     mapping(bytes32 => uint256) public advancedFeeWithdrawals;
+    mapping(bytes32 => bool) public isEscrowed; // Check if transaction commitment values has been escrowed (only for deposit)
 
     function initialize() public override(Stateful, Key_Registry, Config, Pausable) initializer {
         Stateful.initialize();
@@ -33,12 +34,16 @@ contract Shield is Stateful, Config, Key_Registry, ReentrancyGuardUpgradeable, P
         Pausable.initialize();
     }
 
+    function getTransactionEscrowed(bytes32 transactionHash) public view returns (bool) {
+        return isEscrowed[transactionHash];
+    }
+
     function submitTransaction(Transaction calldata t) external payable nonReentrant whenNotPaused {
         // let everyone know what you did
         emit TransactionSubmitted();
 
         if (t.transactionType == TransactionTypes.DEPOSIT) {
-            state.setTransactionEscrowed(uint256(Utils.hashTransaction(t)), true);
+            isEscrowed[Utils.hashTransaction(t)] = true;
             require(uint256(t.fee) == msg.value);
             payIn(t);
         }
@@ -70,7 +75,7 @@ contract Shield is Stateful, Config, Key_Registry, ReentrancyGuardUpgradeable, P
             state.getFeeBookInfo(b.proposer, b.blockNumberL2);
         feePaymentsEth += BLOCK_STAKE;
 
-        state.setFeeBookInfo(b.proposer, b.blockNumberL2, uint256(0), 0);
+        state.resetFeeBookInfo(b.proposer, b.blockNumberL2);
 
         if (feePaymentsEth > 0) {
             (bool success, ) = payable(address(state)).call{value: feePaymentsEth}('');

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -343,7 +343,7 @@ contract State is Initializable, ReentrancyGuardUpgradeable, Pausable, Config {
         return proposerStartBlock;
     }
 
-    function removeProposer(address proposer) public onlyProposer {
+    function removeProposer(address proposer) public onlyRegistered {
         address previousAddress = proposers[proposer].previousAddress;
         address nextAddress = proposers[proposer].nextAddress;
         delete proposers[proposer];

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -65,12 +65,12 @@ contract State is Initializable, ReentrancyGuardUpgradeable, Pausable, Config {
     }
 
     modifier onlyProposer() {
-        require(msg.sender == proposersAddress, 'Only shield contract is authorized');
+        require(msg.sender == proposersAddress, 'Only proposer contract is authorized');
         _;
     }
 
     modifier onlyChallenger() {
-        require(msg.sender == challengesAddress, 'Only shield contract is authorized');
+        require(msg.sender == challengesAddress, 'Only challenger contract is authorized');
         _;
     }
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Currently, a user could potentially send a deposit off-chain to a proposer and this deposit could be added to a valid block without having escrowed the funds first. To solve this problem, a new mapping called `isEscrowed(uint256 => bool)` is added. This mapping checks if the funds for a transaction hash has been deposited. It is only set to true when submitting a deposit transaction using `submitTransaction`. Then, when a proposer calls `proposeBlock` it will check that all transactions with transaction type 0 (deposits) has been escrowed by checking the mapping.

This PR also contains a major refactor of the assembly code contained in `proposeBlock` to make it more understandable and organized. 

It also adds two new const variables in Config.sol that are the number of slots used in the transaction structure and the block structure respectively. If any of those structures are modified this constants will need to be updated. The reason of adding this constants is to not have to directly modify the assembly code every time that the structure is updated.

This PR also adds a couple of new modifiers inside State.sol
## Does this close any currently open issues? 
Yes, it closes #1001 

## What commands can I run to test the change? 
Tested locally - CI tests require adversary
In order to test that a deposit that has not previously escrowed will fail, one can simply comment the line in `submitTransaction` that updates the mapping `isEscrowed` and check that when trying to run the tests locally it fails because there's a revert in the Smart Contract call.
## Any other comments?
No

