### PR TITLE
David/local env

### DIFF
--- a/common-files/utils/utils.mjs
+++ b/common-files/utils/utils.mjs
@@ -6,11 +6,7 @@ export const isDev = () => process.env.NODE_ENV !== 'production';
 
 export const isLocal = () => {
   return (
-    process.env.NODE_ENV !== 'internal' &&
-    process.env.NODE_ENV !== 'staging' &&
-    process.env.NODE_ENV !== 'preprod' &&
-    process.env.NODE_ENV !== 'testnet' &&
-    process.env.NODE_ENV !== 'production'
+    process.env.ENVIRONMENT !== 'aws'
   );
 };
 

--- a/common-files/utils/utils.mjs
+++ b/common-files/utils/utils.mjs
@@ -5,9 +5,7 @@
 export const isDev = () => process.env.NODE_ENV !== 'production';
 
 export const isLocal = () => {
-  return (
-    process.env.ENVIRONMENT !== 'aws'
-  );
+  return process.env.ENVIRONMENT !== 'aws';
 };
 
 /**


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
There is a function that checks if the deployment environment is local or not, but the way it is done is based on `NODE_ENV` variable that is not intended for that. The correct variable should be `ENVIRONMENT !== 'aws'`. This change has the additional benefit that we don't need to keep updating the set of non local environments when we create new ones.

## Does this close any currently open issues?
No

## What commands can I run to test the change? 
Run any test and check logs are still present

## Any other comments?
No
