### PR TITLE
fix: 'cannot find cls-hooked' bug in master

### DIFF
--- a/setup-nightfall
+++ b/setup-nightfall
@@ -14,6 +14,7 @@ fi
 
 docker build ${NO_CACHE_FLAG} -t ghcr.io/eyblockchain/local-zokrates:0.8.2 -f docker/zokrates.Dockerfile .
 # containers built separately. A parallel build fails.
+docker-compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml build ${NO_CACHE_FLAG} deployer
 docker-compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml build ${NO_CACHE_FLAG} administrator
 docker-compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml build ${NO_CACHE_FLAG} client
 docker-compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml build ${NO_CACHE_FLAG} optimist


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

This fixes the bug in master where, running locally, deployer cannot find the package`cls-hooked`.

## Does this close any currently open issues?
No

## What commands can I run to test the change? 
This can be tested in the normal way with `npm t`

## Any other comments?
The bug is actually that the build of the `deployer` container is missing from `./setup-nightfall` and so the new package is not included in the container.

