### PR TITLE
optimist as a challenger instead of adversary for adversary.test.mjs

### DIFF
--- a/docker/docker-compose.adversary.yml
+++ b/docker/docker-compose.adversary.yml
@@ -37,6 +37,9 @@ services:
       # right now it doesn't matter what is IS_CHALLENGER flag's value is because
       # optimist container state-sync code start challenges at time of startup
       # by calling startMakingChallenges() function
+      # Also we don't want adversary who create bad block to be challenger as well
+      # this bit of code logic is updated in test/adversary.test.mjs by making challenger
+      # wbsockeet client to connect to optimist container instead of adversary
       IS_CHALLENGER: 'false'
       NONSTOP_QUEUE_AFTER_INVALID_BLOCK: 'false'
       TRANSACTIONS_PER_BLOCK: ${TRANSACTIONS_PER_BLOCK:-2}

--- a/docker/docker-compose.adversary.yml
+++ b/docker/docker-compose.adversary.yml
@@ -34,7 +34,10 @@ services:
       BLOCKCHAIN_PORT: 8546
       HASH_TYPE: poseidon
       LOG_LEVEL: debug
-      IS_CHALLENGER: 'true'
+      # right now it doesn't matter what is IS_CHALLENGER flag's value is because
+      # optimist container state-sync code start challenges at time of startup
+      # by calling startMakingChallenges() function
+      IS_CHALLENGER: 'false'
       NONSTOP_QUEUE_AFTER_INVALID_BLOCK: 'false'
       TRANSACTIONS_PER_BLOCK: ${TRANSACTIONS_PER_BLOCK:-2}
       AUTOSTART_RETRIES: 100

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -98,6 +98,9 @@ services:
       BLOCKCHAIN_PORT: 8546
       HASH_TYPE: poseidon
       LOG_LEVEL: debug
+      # right now it doesn't matter what is IS_CHALLENGER flag's value is because
+      # optimist container state-sync code start challenges at time of startup
+      # by calling startMakingChallenges() function
       IS_CHALLENGER: 'false'
       TRANSACTIONS_PER_BLOCK: ${TRANSACTIONS_PER_BLOCK:-2}
     command: ['npm', 'run', 'dev']
@@ -126,9 +129,9 @@ services:
       MPC: ${MPC}
 
 volumes:
-  mongodb:  
-  proving_files: 
-  build: 
+  mongodb:
+  proving_files:
+  build:
 networks:
   nightfall_network:
     driver: bridge

--- a/nightfall-optimist/src/event-handlers/challenge-commit.mjs
+++ b/nightfall-optimist/src/event-handlers/challenge-commit.mjs
@@ -8,9 +8,9 @@ async function committedToChallengeEventHandler(data) {
     `Received commmitted to challenge event, with hash ${commitHash} and sender ${sender}`,
   );
   logger.info('A challenge commitment has been mined');
-  const { txDataToSign, retrieved } = await getCommit(commitHash);
+  const commitData = await getCommit(commitHash);
   // We may not find the commitment. In this case, it's probably not ours so we take no action
-  if (txDataToSign === null) {
+  if (commitData === null) {
     logger.debug('Commit hash not found in database');
     return;
   }
@@ -18,6 +18,7 @@ async function committedToChallengeEventHandler(data) {
   // we have already revealed it - thus we don't reveal it again because that would
   // just waste gas.  This could happen if a chain reorg were to re-emit the
   // CommittedToChallenge event.
+  const { txDataToSign, retrieved } = commitData;
   if (!retrieved) revealChallenge(txDataToSign, sender);
 }
 

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -46,15 +46,15 @@ export async function signalRollbackCompleted(data) {
   // check that the websocket exists (it should) and its readyState is OPEN
   // before sending. If not wait until the challenger reconnects
   let tryCount = 0;
-  while (ws && ws.readyState !== WebSocket.OPEN) {
+  while (!ws || ws.readyState !== WebSocket.OPEN) {
     await new Promise(resolve => setTimeout(resolve, 3000)); // eslint-disable-line no-await-in-loop
     logger.warn(
-      `Websocket to proposer is closed for rollback complete.  Waiting for challenger to reconnect`,
+      `Websocket to proposer is closed for rollback complete.  Waiting for proposer to reconnect`,
     );
     if (tryCount++ > 100) throw new Error(`Websocket to proposer has failed`);
   }
   logger.debug('Rollback completed');
-  if (ws) ws.send(JSON.stringify({ type: 'rollback', data }));
+  ws.send(JSON.stringify({ type: 'rollback', data }));
 }
 
 async function makeBlock(proposer, number = TRANSACTIONS_PER_BLOCK) {

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -46,7 +46,7 @@ export async function signalRollbackCompleted(data) {
   // check that the websocket exists (it should) and its readyState is OPEN
   // before sending. If not wait until the challenger reconnects
   let tryCount = 0;
-  while (!ws || ws.readyState !== WebSocket.OPEN) {
+  while (ws && ws.readyState !== WebSocket.OPEN) {
     await new Promise(resolve => setTimeout(resolve, 3000)); // eslint-disable-line no-await-in-loop
     logger.warn(
       `Websocket to proposer is closed for rollback complete.  Waiting for challenger to reconnect`,
@@ -54,7 +54,7 @@ export async function signalRollbackCompleted(data) {
     if (tryCount++ > 100) throw new Error(`Websocket to proposer has failed`);
   }
   logger.debug('Rollback completed');
-  ws.send(JSON.stringify({ type: 'rollback', data }));
+  if (ws) ws.send(JSON.stringify({ type: 'rollback', data }));
 }
 
 async function makeBlock(proposer, number = TRANSACTIONS_PER_BLOCK) {

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -99,6 +99,16 @@ describe('Testing with an adversary', () => {
     ercAddress = await nf3User.getContractAddress('ERC20Mock');
     startBalance = await retrieveL2Balance(nf3User);
 
+    // initiating proposed websocket connection for aptimist ran as challenger
+    // this bit of a code added as work-around to a bug in code
+    // Bug is, when a optimist only spinned as challenger
+    // after a rollback we queue a job called `signalRollbackCompleted`
+    // inside in which we look for ws(websocket) of a propser continuously via
+    // while loop since optimist container only has challenger this case never satisfies
+    // and 'Error(`Websocket to proposer has failed`)'is throw meanwhile blockProposeEventHandler
+    // job never get picked from queue.
+    await nf3Challenger.startProposer();
+
     // Proposer registration
     await nf3AdversarialProposer.registerProposer();
     // Proposer listening for incoming events

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -81,8 +81,8 @@ describe('Testing with an adversary', () => {
 
     nf3Challenger = new Nf3(ethereumSigningKeyChallenger, {
       ...others,
-      optimistApiUrl: adversarialOptimistApiUrl,
-      optimistWsUrl: adversarialOptimistWsUrl,
+      optimistApiUrl,
+      optimistWsUrl,
     });
 
     // Generate a random mnemonic (uses crypto.randomBytes under the hood), defaults to 128-bits of entropy
@@ -133,6 +133,11 @@ describe('Testing with an adversary', () => {
           `Challenge transaction to the blochain of type ${type} failed due to error: ${error} `,
         );
       });
+
+    // for now optimist containers at time for startup state-sync code logic
+    // starts challenger by calling startMakingChallenges() function
+    // that reason explicitly call stop challenge api for nf3AdversarialProposer
+    await nf3AdversarialProposer.challengeEnable(false);
 
     // Configure adversary bad block sequence
     if (process.env.CHALLENGE_TYPE !== '') {

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -99,14 +99,14 @@ describe('Testing with an adversary', () => {
     ercAddress = await nf3User.getContractAddress('ERC20Mock');
     startBalance = await retrieveL2Balance(nf3User);
 
-    // initiating proposed websocket connection for aptimist ran as challenger
+    // initiating proposed websocket connection for optimist ran as challenger
     // this bit of a code added as work-around to a bug in code
     // Bug is, when a optimist only spinned as challenger
     // after a rollback we queue a job called `signalRollbackCompleted`
     // inside in which we look for ws(websocket) of a propser continuously via
     // while loop since optimist container only has challenger this case never satisfies
-    // and 'Error(`Websocket to proposer has failed`)'is throw meanwhile blockProposeEventHandler
-    // job never get picked from queue.
+    // and 'Error(`Websocket to proposer has failed`)'is throw and optimist crash
+    // meanwhile blockProposeEventHandler job never get picked from queue.
     await nf3Challenger.startProposer();
 
     // Proposer registration


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
This PR make adversary.test.mjs to make websocket connection to optimist instead of adversary container which run a challenger

## Does this close any currently open issues?
https://github.com/EYBlockchain/nightfall_3/issues/885


## Any other comments?
evidence: temporary successful github workflow run created on this branch https://github.com/EYBlockchain/nightfall_3/actions/runs/3150503026/jobs/5123363365 
