### PR TITLE
Fees upgrade

### DIFF
--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -410,7 +410,7 @@ class Nf3 {
       value,
       compressedZkpPublicKey: this.zkpKeys.compressedZkpPublicKey,
       nullifierKey: this.zkpKeys.nullifierKey,
-      fee,
+      fee: 0,
     });
     return new Promise((resolve, reject) => {
       userQueue.push(async () => {

--- a/nightfall-client/src/services/deposit.mjs
+++ b/nightfall-client/src/services/deposit.mjs
@@ -26,7 +26,7 @@ async function deposit(items) {
   logger.info('Creating a deposit transaction');
 
   // before we do anything else, long hex strings should be generalised to make subsequent manipulations easier
-  const { tokenId, value, compressedZkpPublicKey, nullifierKey, fee } = generalise(items);
+  const { tokenId, value, compressedZkpPublicKey, nullifierKey } = generalise(items);
   const ercAddress = generalise(items.ercAddress.toLowerCase());
   const zkpPublicKey = ZkpKeys.decompressZkpPublicKey(compressedZkpPublicKey);
   const salt = await randValueLT(BN128_GROUP_ORDER);
@@ -45,7 +45,7 @@ async function deposit(items) {
   );
 
   const publicData = new Transaction({
-    fee,
+    fee: 0,
     transactionType: 0,
     tokenType: items.tokenType,
     tokenId,
@@ -91,7 +91,7 @@ async function deposit(items) {
 
   // next we need to compute the optimistic Transaction object
   const optimisticDepositTransaction = new Transaction({
-    fee,
+    fee: 0,
     transactionType: 0,
     tokenType: items.tokenType,
     tokenId,

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -77,7 +77,7 @@ contract Shield is Stateful, Config, ReentrancyGuardUpgradeable, Pausable, KYC {
 
         //Request fees
         FeeTokens memory feePayments = state.getFeeBookBlocksInfo(b.proposer, b.blockNumberL2);
-        feePayments.feesEth += BLOCK_STAKE;
+        feePayments.feesEth += blockStake;
 
         state.resetFeeBookBlocksInfo(b.proposer, b.blockNumberL2);
 

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -23,7 +23,7 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Config {
     mapping(address => FeeTokens) public pendingWithdrawalsFees;
     mapping(address => LinkedAddress) public proposers;
     mapping(address => TimeLockedStake) public stakeAccounts;
-    mapping(bytes32 => FeeTokens) public feeBook;
+    mapping(bytes32 => FeeTokens) public feeBookBlocks;
     mapping(bytes32 => bool) public claimedBlockStakes;
     LinkedAddress public currentProposer; // who can propose a new shield state
     uint256 public proposerStartBlock; // L1 block where currentProposer became current
@@ -120,22 +120,14 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Config {
         stake.challengeLocked += blockStake;
         stakeAccounts[msg.sender] = TimeLockedStake(stake.amount, stake.challengeLocked, 0);
 
-        bytes32 input = keccak256(abi.encodePacked(b.proposer, b.blockNumberL2));
-        feeBook[input].feesEth = 0;
-        feeBook[input].feesMatic = 0;
-        for (uint256 i = 0; i < t.length; i++) {
-            if (t[i].transactionType == TransactionTypes.DEPOSIT) {
-                feeBook[input].feesEth += uint256(t[i].fee);
-            } else {
-                feeBook[input].feesMatic += uint256(t[i].fee);
-            }
-        }
+        FeeTokens memory feePayments = FeeTokens(0, 0);
 
         bytes32 blockHash;
         uint256 blockSlots = BLOCK_STRUCTURE_SLOTS; //Number of slots that the block structure has
 
         //Get the signature for the function that checks if the transaction has been escrowed or not
         bytes4 checkTxEscrowedSignature = bytes4(keccak256('getTransactionEscrowed(bytes32)'));
+        bytes4 checkTxEthFeesSignature = bytes4(keccak256('getTransactionEthFee(bytes32)'));
 
         assembly {
             //Function that calculates the height of the Merkle Tree
@@ -223,6 +215,54 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Config {
                         revert(0, 0)
                     }
                 }
+
+                if iszero(
+                    calldataload(
+                        add(add(t.offset, calldataload(add(t.offset, mul(0x20, i)))), mul(0x20, 1))
+                    )
+                ) {
+                    mstore(x, checkTxEthFeesSignature) //Store the signature of the function in x
+                    mstore(add(x, 0x04), mload(add(transactionHashesPos, mul(0x20, i)))) //Store the transactionHash after the signature
+                    pop(
+                        call(
+                            // Call getTransactionFeesEth function to see if funds has been deposited
+                            gas(),
+                            shieldAddress.slot, //To addr
+                            0, //No value
+                            x, //Inputs are stored at location x
+                            add(0x04, 0x20), //Inputs are 36 bytes long
+                            x, //Store output over input (saves space)
+                            0x20 //Outputs are 32 bytes long
+                        )
+                    )
+
+                    mstore(feePayments, add(mload(x), mload(feePayments)))
+                }
+
+                if eq(
+                    iszero(
+                        calldataload(
+                            add(
+                                add(t.offset, calldataload(add(t.offset, mul(0x20, i)))),
+                                mul(0x20, 1)
+                            )
+                        )
+                    ),
+                    0
+                ) {
+                    mstore(
+                        add(feePayments, 0x20),
+                        add(
+                            calldataload(
+                                add(
+                                    add(t.offset, calldataload(add(t.offset, mul(0x20, i)))),
+                                    mul(0x20, 1)
+                                )
+                            ),
+                            mload(add(feePayments, 0x20))
+                        )
+                    )
+                }
             }
 
             //Calculate the root of the transactions merkle tree
@@ -270,6 +310,9 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Config {
         // contain all of the relevant data (2) it doesn't take much gas.
         // All check pass so add the block to the list of blocks waiting to be permanently added to the state - we only save the hash of the block data plus the absolute minimum of metadata - it's up to the challenger, or person requesting inclusion of the block to the permanent contract state, to provide the block data.
 
+        // Store block fees
+        feeBookBlocks[keccak256(abi.encodePacked(b.proposer, b.blockNumberL2))] = feePayments;
+
         // blockHash is hash of all block data and hash of all the transactions data.
         blockHashes.push(BlockData({blockHash: blockHash, time: block.timestamp}));
         // Timber will listen for the BlockProposed event as well as
@@ -302,18 +345,18 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Config {
         return currentProposer;
     }
 
-    function getFeeBookInfo(address proposer, uint256 blockNumberL2)
+    function getFeeBookBlocksInfo(address proposer, uint256 blockNumberL2)
         public
         view
         returns (FeeTokens memory)
     {
         bytes32 input = keccak256(abi.encodePacked(proposer, blockNumberL2));
-        return (feeBook[input]);
+        return (feeBookBlocks[input]);
     }
 
-    function resetFeeBookInfo(address proposer, uint256 blockNumberL2) public onlyShield {
+    function resetFeeBookBlocksInfo(address proposer, uint256 blockNumberL2) public onlyShield {
         bytes32 input = keccak256(abi.encodePacked(proposer, blockNumberL2));
-        delete feeBook[input];
+        delete feeBookBlocks[input];
     }
 
     function popBlockData() public onlyChallenger returns (BlockData memory) {

--- a/wallet/src/nightfall-browser/services/deposit.js
+++ b/wallet/src/nightfall-browser/services/deposit.js
@@ -32,7 +32,7 @@ async function deposit(items, shieldContractAddress) {
   logger.info('Creating a deposit transaction');
   // before we do anything else, long hex strings should be generalised to make
   // subsequent manipulations easier
-  const { tokenId, value, compressedZkpPublicKey, nullifierKey, fee } = generalise(items);
+  const { tokenId, value, compressedZkpPublicKey, nullifierKey } = generalise(items);
   const ercAddress = generalise(items.ercAddress.toLowerCase());
   const zkpPublicKey = ZkpKeys.decompressZkpPublicKey(compressedZkpPublicKey);
 
@@ -67,7 +67,7 @@ async function deposit(items, shieldContractAddress) {
   logger.debug(`Hash of new commitment is ${commitment.hash.hex()}`);
   // now we can compute a Witness so that we can generate the proof
   const publicData = new Transaction({
-    fee,
+    fee: 0,
     transactionType: 0,
     tokenType: items.tokenType,
     tokenId,
@@ -108,7 +108,7 @@ async function deposit(items, shieldContractAddress) {
 
     // next we need to compute the optimistic Transaction object
     const optimisticDepositTransaction = new Transaction({
-      fee,
+      fee: 0,
       transactionType: 0,
       tokenType: items.tokenType,
       tokenId,

--- a/wallet/src/nightfall-browser/utils/compute-witness.ts
+++ b/wallet/src/nightfall-browser/utils/compute-witness.ts
@@ -1,4 +1,3 @@
-import utils from 'common-files/utils/crypto/merkle-tree/utils';
 import gen, { GeneralNumber } from 'general-number';
 import utils from '../../common-files/utils/crypto/merkle-tree/utils';
 

--- a/wallet/src/nightfall-browser/utils/compute-witness.ts
+++ b/wallet/src/nightfall-browser/utils/compute-witness.ts
@@ -1,3 +1,4 @@
+import utils from 'common-files/utils/crypto/merkle-tree/utils';
 import gen, { GeneralNumber } from 'general-number';
 import utils from '../../common-files/utils/crypto/merkle-tree/utils';
 


### PR DESCRIPTION
This PR should be merged after #1033.
Transaction structure contains a fee field which right now can be either matic (L2 token) or ether value, which makes it confusing for users. This PR fixes this behaviour by only storing the fees paid in L2. If the fees are paid in L1 (aka when deposit) the fee in the transaction is set to 0 and fee is stored in a mapping in the Smart Contract.

