### PR TITLE
KYC admin functions

### DIFF
--- a/common-files/package-lock.json
+++ b/common-files/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "common-files",
-  "version": "1.0.0",
+  "name": "@polygon-nightfall/common-files",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "common-files",
-      "version": "1.0.0",
+      "name": "@polygon-nightfall/common-files",
+      "version": "0.0.1",
       "license": "CC0-1.0",
       "dependencies": {
         "axios": "^0.21.4",

--- a/doc/kyc.md
+++ b/doc/kyc.md
@@ -16,4 +16,4 @@ Whitelist managers are created/removed by the contract owner (multisig). They ca
 
 All whitelisting functionality is managed by the contract `KYC.sol`, the functions therein are self-explanatory.
 
-Note that all users are, by default members of the null group (group ID = 0). Members of this group are NOT whitelisted when whitelisting is enabled. Memebership of any other group confirs whitlisted status.
+Note that all users are, by default members of the null group (group ID = 0). Members of this group are NOT whitelisted when whitelisting is enabled. Membership of any other group confirs whitlisted status.

--- a/nightfall-administrator/src/index.mjs
+++ b/nightfall-administrator/src/index.mjs
@@ -5,7 +5,7 @@
  */
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import logger from 'common-files/utils/logger.mjs';
+import logger from '../../common-files/utils/logger.mjs';
 import { initUI } from './ui/menu.mjs';
 import start from './ui/get-info.mjs';
 import { initMultiSig } from './services/helpers.mjs';
@@ -20,8 +20,8 @@ async function main() {
   initUI();
   // start getting transaction information
   const signed = await start();
-  logger.info('******* Signed Transaction *******');
-  logger.info(signed);
+  console.log('******* Signed Transaction *******');
+  console.log(signed);
   process.kill(process.pid, 'SIGTERM');
 }
 

--- a/nightfall-administrator/src/index.mjs
+++ b/nightfall-administrator/src/index.mjs
@@ -5,7 +5,6 @@
  */
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import logger from '../../common-files/utils/logger.mjs';
 import { initUI } from './ui/menu.mjs';
 import start from './ui/get-info.mjs';
 import { initMultiSig } from './services/helpers.mjs';

--- a/nightfall-administrator/src/services/contract-calls.mjs
+++ b/nightfall-administrator/src/services/contract-calls.mjs
@@ -18,3 +18,10 @@ export async function getTokenRestrictions(tokenName) {
   }
   return Promise.all([depositRestrictions, withdrawRestrictions]);
 }
+/**
+ This function returns the group ID of the manager if the address given is a whitelist manager
+ */
+export async function isWhitelistManager(address) {
+  const shieldContractInstance = await waitForContract('Shield');
+  return shieldContractInstance.methods.isWhitelistManager(address).call();
+}

--- a/nightfall-administrator/src/services/contract-transactions.mjs
+++ b/nightfall-administrator/src/services/contract-transactions.mjs
@@ -12,7 +12,15 @@ const ownables = ['State', 'Shield', 'Proposers', 'Challenges'];
 /**
  This function adds a whitelist manager
  */
-export async function createWhitelistManager(groupId, address, signingKey, executorAddress, nonce) {
+export async function createWhitelistManager(
+  groupId,
+  address,
+  signingKey,
+  executorAddress,
+  _nonce,
+) {
+  let nonce = _nonce;
+  if (!Number.isInteger(nonce)) nonce = await getMultiSigNonce();
   const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
   const data = shieldContractInstance.methods.createWhitelistManager(groupId, address).encodeABI();
   return Promise.all([
@@ -29,7 +37,9 @@ export async function createWhitelistManager(groupId, address, signingKey, execu
 /**
  This function removes a whitelist manager
  */
-export async function removeWhitelistManager(address, signingKey, executorAddress, nonce) {
+export async function removeWhitelistManager(address, signingKey, executorAddress, _nonce) {
+  let nonce = _nonce;
+  if (!Number.isInteger(nonce)) nonce = await getMultiSigNonce();
   const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
   const data = shieldContractInstance.methods.removeWhitelistManager(address).encodeABI();
   return Promise.all([
@@ -46,7 +56,9 @@ export async function removeWhitelistManager(address, signingKey, executorAddres
 /**
  This function enables/disables whitelisting
  */
-export async function enableWhitelisting(enable, signingKey, executorAddress, nonce) {
+export async function enableWhitelisting(enable, signingKey, executorAddress, _nonce) {
+  let nonce = _nonce;
+  if (!Number.isInteger(nonce)) nonce = await getMultiSigNonce();
   const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
   const data = shieldContractInstance.methods.enableWhitelisting(enable).encodeABI();
   return Promise.all([
@@ -69,8 +81,10 @@ export async function setTokenRestrictions(
   withdrawRestriction,
   signingKey,
   executorAddress,
-  nonce,
+  _nonce,
 ) {
+  let nonce = _nonce;
+  if (!Number.isInteger(nonce)) nonce = await getMultiSigNonce();
   const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
   for (const token of RESTRICTIONS.tokens[process.env.ETH_NETWORK]) {
     if (token.name === tokenName) {
@@ -132,7 +146,6 @@ export async function pauseContracts(signingKey, executorAddress, _nonce) {
 }
 
 export async function unpauseContracts(signingKey, executorAddress, _nonce) {
-  logger.info('All pausable contracts being unpaused');
   let nonce = _nonce;
   if (!Number.isInteger(nonce)) nonce = await getMultiSigNonce();
   return Promise.all(
@@ -203,7 +216,6 @@ export async function setBootChallenger(
     msg: 'Boot challenger',
     newChallenger,
   });
-
   const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
   const data = shieldContractInstance.methods.setBootChallenger(newChallenger).encodeABI();
   return Promise.all([

--- a/nightfall-administrator/src/services/contract-transactions.mjs
+++ b/nightfall-administrator/src/services/contract-transactions.mjs
@@ -10,6 +10,57 @@ const pausables = ['State', 'Shield'];
 const ownables = ['State', 'Shield', 'Proposers', 'Challenges'];
 
 /**
+ This function adds a whitelist manager
+ */
+export async function createWhitelistManager(groupId, address, signingKey, executorAddress, nonce) {
+  const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
+  const data = shieldContractInstance.methods.createWhitelistManager(groupId, address).encodeABI();
+  return Promise.all([
+    addMultiSigSignature(
+      data,
+      signingKey,
+      shieldContractInstance.options.address,
+      executorAddress,
+      nonce,
+    ),
+  ]);
+}
+
+/**
+ This function removes a whitelist manager
+ */
+export async function removeWhitelistManager(address, signingKey, executorAddress, nonce) {
+  const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
+  const data = shieldContractInstance.methods.removeWhitelistManager(address).encodeABI();
+  return Promise.all([
+    addMultiSigSignature(
+      data,
+      signingKey,
+      shieldContractInstance.options.address,
+      executorAddress,
+      nonce,
+    ),
+  ]);
+}
+
+/**
+ This function enables/disables whitelisting
+ */
+export async function enableWhitelisting(enable, signingKey, executorAddress, nonce) {
+  const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
+  const data = shieldContractInstance.methods.enableWhitelisting(enable).encodeABI();
+  return Promise.all([
+    addMultiSigSignature(
+      data,
+      signingKey,
+      shieldContractInstance.options.address,
+      executorAddress,
+      nonce,
+    ),
+  ]);
+}
+
+/**
 This function sets the restriction data that the Shield contract is currently using
 */
 export async function setTokenRestrictions(

--- a/nightfall-administrator/src/services/helpers.mjs
+++ b/nightfall-administrator/src/services/helpers.mjs
@@ -1,6 +1,5 @@
 import config from 'config';
 import { ecsign } from 'ethereumjs-util';
-import logger from '../../../common-files/utils/logger.mjs';
 import { waitForContract, web3 } from '../../../common-files/utils/contract.mjs';
 import { checkThreshold, saveSigned, getSigned } from './database.mjs';
 

--- a/nightfall-administrator/src/services/helpers.mjs
+++ b/nightfall-administrator/src/services/helpers.mjs
@@ -52,7 +52,7 @@ export async function addSignedTransaction(signed) {
       await saveSigned(signed);
     } catch (err) {
       if (err.message.includes('duplicate key')) {
-        logger.info('You have already signed this message - no action taken');
+        console.log('You have already signed this message - no action taken');
       } else {
         throw err;
       }
@@ -60,12 +60,9 @@ export async function addSignedTransaction(signed) {
   }
   const numberOfSignatures = await checkThreshold(signed.messageHash);
 
-  logger.info({
-    msg: 'Number of signatures for this transaction',
-    total: numberOfSignatures,
-  });
+  console.log('Number of signatures for this transaction', numberOfSignatures);
 
-  if (numberOfSignatures === SIGNATURE_THRESHOLD) logger.info(`Signature threshold reached`);
+  if (numberOfSignatures === SIGNATURE_THRESHOLD) console.log(`Signature threshold reached`);
   const signedArray = (await getSigned(signed.messageHash)).sort((a, b) => {
     const x = BigInt(a.by);
     const y = BigInt(b.by);

--- a/nightfall-administrator/src/ui/get-info.mjs
+++ b/nightfall-administrator/src/ui/get-info.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable no-await-in-loop */
 import config from 'config';
 import { askQuestions } from './menu.mjs';
-import { getTokenRestrictions } from '../services/contract-calls.mjs';
+import { getTokenRestrictions, isWhitelistManager } from '../services/contract-calls.mjs';
 import {
   setTokenRestrictions,
   removeTokenRestrictions,
@@ -46,13 +46,7 @@ async function start() {
     switch (task) {
       case 'Get token restrictions': {
         const [deposit, withdraw] = await getTokenRestrictions(tokenName);
-
-        logger.info({
-          msg: 'Token restrictions are',
-          deposit,
-          withdraw,
-        });
-
+        console.log('Token restrictions are', deposit, withdraw);
         break;
       }
       case 'Set token restrictions': {
@@ -137,8 +131,14 @@ async function start() {
         approved = await enableWhitelisting(false, ethereumSigningKey, executorAddress, nonce);
         break;
       }
+      case 'Check if address is a whitelist manager': {
+        const groupId = await isWhitelistManager(managerAddress);
+        if (groupId) console.log('This address is a manager with group Id', groupId);
+        else console.log('This address is not a manager');
+        break;
+      }
       default: {
-        logger.info('This option has not been implemented');
+        logger.error('This option has not been implemented');
       }
     }
   }

--- a/nightfall-administrator/src/ui/get-info.mjs
+++ b/nightfall-administrator/src/ui/get-info.mjs
@@ -10,6 +10,9 @@ import {
   transferOwnership,
   setBootProposer,
   setBootChallenger,
+  createWhitelistManager,
+  removeWhitelistManager,
+  enableWhitelisting,
 } from '../services/contract-transactions.mjs';
 import {
   executeMultiSigTransaction,
@@ -36,6 +39,8 @@ async function start() {
     nonce,
     signedTx,
     workflow,
+    managerAddress,
+    managerGroupId,
   } = await askQuestions(false);
   if (workflow === 'create') {
     switch (task) {
@@ -103,6 +108,33 @@ async function start() {
           executorAddress,
           nonce,
         );
+        break;
+      }
+      case 'Add whitelist manager': {
+        approved = await createWhitelistManager(
+          managerGroupId,
+          managerAddress,
+          ethereumSigningKey,
+          executorAddress,
+          nonce,
+        );
+        break;
+      }
+      case 'Remove whitelist manager': {
+        approved = await removeWhitelistManager(
+          managerAddress,
+          ethereumSigningKey,
+          executorAddress,
+          nonce,
+        );
+        break;
+      }
+      case 'Enable whitelisting': {
+        approved = await enableWhitelisting(true, ethereumSigningKey, executorAddress, nonce);
+        break;
+      }
+      case 'Disable whitelisting': {
+        approved = await enableWhitelisting(false, ethereumSigningKey, executorAddress, nonce);
         break;
       }
       default: {

--- a/nightfall-administrator/src/ui/menu.mjs
+++ b/nightfall-administrator/src/ui/menu.mjs
@@ -78,11 +78,35 @@ export async function askQuestions(approved) {
         'Transfer ownership',
         'Set new boot proposer',
         'Set new boot challenger',
+        'Add whitelist manager',
+        'Remove whitelist manager',
+        'Enable whitelisting',
+        'Disable whitelisting',
+        'Check if address is a whitelist manager',
       ],
       get pageSize() {
         return this.choices.length;
       },
       when: answers => !approved && answers.workflow === 'create',
+    },
+    {
+      name: 'managerAddress',
+      type: 'input',
+      message: 'Please provide the address of the manager',
+      when: answers =>
+        [
+          'Add whitelist manager',
+          'Remove whitelist manager',
+          'Check if address is a whitelist manager',
+        ].includes(answers.task),
+      validate: input => web3.utils.isAddress(input),
+    },
+    {
+      name: 'managerGroupId',
+      type: 'input',
+      message: 'Please provide the group Id of the manager',
+      when: answers => answers.task === 'Add whitelist manager',
+      validate: input => Number.isInteger(Number(input)) && Number(input) > 0,
     },
     {
       name: 'tokenName',
@@ -92,12 +116,9 @@ export async function askQuestions(approved) {
       },
       message: 'Choose a token:',
       when: answers =>
-        [
-          'Get token restrictions',
-          'Set token restrictions',
-          'Transfer Shield contract balance',
-          'Remove token restrictions',
-        ].includes(answers.task),
+        ['Get token restrictions', 'Set token restrictions', 'Remove token restrictions'].includes(
+          answers.task,
+        ),
     },
     {
       name: 'depositRestriction',


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

This provides the `Administrator` container's `./admin` app with extra menu items that enable admin control of the whitelisting process, i.e.:
- Adding and removing whitelist managers
- Enabling/disabling whitelisting
- Checking if an address is a whitelist manager

Before this PR, these items could only be set at the point of contract deployment.
Note that these functions are the ones that must only be called by the contract multisig.  Whitelist managers do not have this level of access.  They access their whitelisting API via the client container (this is already merged).

## Does this close any currently open issues?

fixes #742 

## What commands can I run to test the change? 

Currently it is not possible to test the administrator container automatically.  This will be fixed by the upcoming issue #1037 and so is not addressed in this PR.
To test manually, read the instructions in the `nightfall-administrator` [README.md](https://github.com/EYBlockchain/nightfall_3/blob/westlad/kyc-admin/nightfall-administrator/README.md)

## Any other comments?

