### PR TITLE
do not register second proposer in ping pong test in AWS

### DIFF
--- a/common-files/utils/contract.mjs
+++ b/common-files/utils/contract.mjs
@@ -46,7 +46,7 @@ export async function getContractInstance(contractName, deployedAddress) {
   if (!options.from) {
     const accounts = await web3.eth.getAccounts();
 
-    logger.debug({
+    logger.trace({
       msg: 'blockchain accounts',
       accounts,
     });

--- a/test/ping-pong/ping-pong.test.mjs
+++ b/test/ping-pong/ping-pong.test.mjs
@@ -9,10 +9,12 @@ const nf3Proposer = new Nf3(signingKeys.proposer1, environment);
 
 describe('Ping-pong tests', () => {
   before(async () => {
-    await nf3Proposer.init(mnemonics.proposer);
-    // we must set the URL from the point of view of the client container
-    await nf3Proposer.registerProposer('http://optimist', MINIMUM_STAKE);
-    await nf3Proposer.startProposer();
+    if (process.env.ENVIRONMENT !== 'aws') {
+      await nf3Proposer.init(mnemonics.proposer);
+      // we must set the URL from the point of view of the client container
+      await nf3Proposer.registerProposer('http://optimist', MINIMUM_STAKE);
+      await nf3Proposer.startProposer();
+    }
   });
 
   it('Runs ping-pong tests', async () => {


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
This PR fixes bug in ping-pong-test, only visible in AWS where there is a proposer running. This test starts a second proposer with the same optimist, and the first one loses connection to optimist and its not able to receive blocks.

## Does this close any currently open issues?
No

## What commands can I run to test the change? 
run ping pong test

## Any other comments?

