### PR TITLE
Fix HTTP header with an invalid value for correlationId

### DIFF
--- a/common-files/utils/httputils.mjs
+++ b/common-files/utils/httputils.mjs
@@ -93,7 +93,7 @@ const handleCorrelationId = (req, res, next) => {
 const applyAxiosDefaults = () => {
   // Creates a request interceptor that adds the correlationId as an HTTP header in every call
   axios.interceptors.request.use(function (config) {
-    if(correlator.getId()) {
+    if (correlator.getId()) {
       config.headers[HEADER_CORRELATION_ID] = correlator.getId();
     }
 

--- a/common-files/utils/httputils.mjs
+++ b/common-files/utils/httputils.mjs
@@ -93,7 +93,10 @@ const handleCorrelationId = (req, res, next) => {
 const applyAxiosDefaults = () => {
   // Creates a request interceptor that adds the correlationId as an HTTP header in every call
   axios.interceptors.request.use(function (config) {
-    config.headers[HEADER_CORRELATION_ID] = correlator.getId();
+    if(correlator.getId()) {
+      config.headers[HEADER_CORRELATION_ID] = correlator.getId();
+    }
+
     return config;
   });
 };


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
A quick fix to prevent an HTTP header of having an invalid value

## Does this close any currently open issues?
No

## What commands can I run to test the change? 
`npm run test-e2e-protocol && npm run test-e2e-tokens` 

## Any other comments?
No
