### PR TITLE
Proposer fee endpoint and update

### DIFF
--- a/apps/proposer/src/routes/proposer.mjs
+++ b/apps/proposer/src/routes/proposer.mjs
@@ -32,4 +32,13 @@ router.get('/mempool', async (req, res) => {
   res.json({ mempoolTransactions });
 });
 
+router.get('/fee', async (req, res) => {
+  const nf3 = req.app.get('nf3');
+  logger.debug(`Proposer/fee endpoint received POST`);
+  logger.debug(`With content ${JSON.stringify(req.body, null, 2)}`);
+  const { proposers } = await nf3.getProposers();
+  const thisProposer = proposers.filter(p => p.thisAddress === nf3.ethereumAddress);
+  res.json({ fee: Number(thisProposer[0].fee) });
+});
+
 export default router;

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -707,12 +707,14 @@ class Nf3 {
     @async
     @param {string} url REST API URL with format https://xxxx.xxx.xx
     @param {number} stake - amount to stake
+    @param {number} fee - fee of the proposer
     @returns {Promise} A promise that resolves to the Ethereum transaction receipt.
     */
-  async registerProposer(url, stake) {
+  async registerProposer(url, stake, fee) {
     const res = await axios.post(`${this.optimistBaseUrl}/proposer/register`, {
       address: this.ethereumAddress,
       url,
+      fee,
     });
     if (res.data.txDataToSign === '') return false; // already registered
     return new Promise((resolve, reject) => {
@@ -871,12 +873,14 @@ class Nf3 {
     @async
     @param {string} Proposer REST API URL with format https://xxxx.xxx.xx
     @param {number} stake - amount to stake
+    @param {number} fee - fee of the proposer
     @returns {array} A promise that resolves to the Ethereum transaction receipt.
     */
-  async updateProposer(url, stake) {
+  async updateProposer(url, stake, fee) {
     const res = await axios.post(`${this.optimistBaseUrl}/proposer/update`, {
       address: this.ethereumAddress,
       url,
+      fee,
     });
     logger.debug(`Proposer with address ${this.ethereumAddress} updated to URL ${url}`);
     return new Promise((resolve, reject) => {

--- a/nightfall-deployer/contracts/Proposers.sol
+++ b/nightfall-deployer/contracts/Proposers.sol
@@ -19,7 +19,7 @@ contract Proposers is Stateful, Config, ReentrancyGuardUpgradeable {
     /**
      @dev register proposer with stake  
      */
-    function registerProposer(string calldata url) external payable nonReentrant {
+    function registerProposer(string calldata url, uint256 fee) external payable nonReentrant {
         require(
             state.getNumProposers() < maxProposers,
             'Proposers: Max number of registered proposers'
@@ -40,7 +40,7 @@ contract Proposers is Stateful, Config, ReentrancyGuardUpgradeable {
         LinkedAddress memory currentProposer = state.getCurrentProposer();
         // cope with this being the first proposer
         if (currentProposer.thisAddress == address(0)) {
-            currentProposer = LinkedAddress(msg.sender, msg.sender, msg.sender, url, false, 0);
+            currentProposer = LinkedAddress(msg.sender, msg.sender, msg.sender, url, fee, false, 0);
             state.setProposer(msg.sender, currentProposer);
             state.setProposerStartBlock(block.number);
             state.setNumProposers(1);
@@ -112,12 +112,12 @@ contract Proposers is Stateful, Config, ReentrancyGuardUpgradeable {
     }
 
     // Proposers can change REST API URL or increment stake
-    function updateProposer(string calldata url) external payable nonReentrant {
+    function updateProposer(string calldata url, uint256 fee) external payable nonReentrant {
         require(
             state.getProposer(msg.sender).thisAddress != address(0),
             'Proposers: This proposer is not registered or you are not that proposer'
         );
-        state.updateProposer(msg.sender, url);
+        state.updateProposer(msg.sender, url, fee);
         if (msg.value > 0) {
             TimeLockedStake memory stake = state.getStakeAccount(msg.sender);
             stake.amount += msg.value;

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -381,8 +381,13 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Config {
         }
     }
 
-    function updateProposer(address proposer, string calldata url) public onlyProposer {
+    function updateProposer(
+        address proposer,
+        string calldata url,
+        uint256 fee
+    ) public onlyProposer {
         proposers[proposer].url = url;
+        proposers[proposer].fee = fee;
     }
 
     // Checks if a block is actually referenced in the queue of blocks waiting

--- a/nightfall-deployer/contracts/Structures.sol
+++ b/nightfall-deployer/contracts/Structures.sol
@@ -81,6 +81,7 @@ contract Structures {
         address previousAddress;
         address nextAddress;
         string url;
+        uint256 fee;
         bool inProposerSet;
         uint256 indexProposerSet;
     }

--- a/nightfall-optimist/src/routes/proposer.mjs
+++ b/nightfall-optimist/src/routes/proposer.mjs
@@ -44,14 +44,14 @@ router.post('/register', async (req, res, next) => {
   logger.debug({ msg: '/register endpoint', payload: JSON.stringify(req.body, null, 2) });
 
   try {
-    const { address, url = '' } = req.body;
+    const { address, url = '', fee = 0 } = req.body;
     const proposersContractInstance = await waitForContract(PROPOSERS_CONTRACT_NAME);
     // the first thing to do is to check if the proposer is already registered on the blockchain
     const proposers = (await getProposers()).map(p => p.thisAddress);
     // if not, let's register it
     let txDataToSign = '';
     if (!proposers.includes(address)) {
-      txDataToSign = await proposersContractInstance.methods.registerProposer(url).encodeABI();
+      txDataToSign = await proposersContractInstance.methods.registerProposer(url, fee).encodeABI();
     } else {
       logger.warn(
         'Proposer was already registered on the blockchain - registration attempt ignored',
@@ -98,12 +98,14 @@ router.post('/update', async (req, res, next) => {
   logger.debug({ msg: '/update endpoint', payload: JSON.stringify(req.body, null, 2) });
 
   try {
-    const { address, url = '' } = req.body;
+    const { address, url = '', fee = 0 } = req.body;
     if (url === '') {
       throw new Error('Rest API URL not provided');
     }
     const proposersContractInstance = await getContractInstance(PROPOSERS_CONTRACT_NAME);
-    const txDataToSign = await proposersContractInstance.methods.updateProposer(url).encodeABI();
+    const txDataToSign = await proposersContractInstance.methods
+      .updateProposer(url, fee)
+      .encodeABI();
 
     logger.debug({
       msg: 'Returning raw transaction',

--- a/nightfall-optimist/src/routes/proposer.mjs
+++ b/nightfall-optimist/src/routes/proposer.mjs
@@ -45,6 +45,9 @@ router.post('/register', async (req, res, next) => {
 
   try {
     const { address, url = '', fee = 0 } = req.body;
+    if (url === '') {
+      throw new Error('Rest API URL not provided');
+    }
     const proposersContractInstance = await waitForContract(PROPOSERS_CONTRACT_NAME);
     // the first thing to do is to check if the proposer is already registered on the blockchain
     const proposers = (await getProposers()).map(p => p.thisAddress);

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -101,7 +101,7 @@ describe('Testing with an adversary', () => {
     startBalance = await retrieveL2Balance(nf3User);
 
     // Proposer registration
-    await nf3AdversarialProposer.registerProposer('', MINIMUM_STAKE);
+    await nf3AdversarialProposer.registerProposer('http://optimist', MINIMUM_STAKE);
     // Proposer listening for incoming events
     const blockProposeEmitter = await nf3AdversarialProposer.startProposer();
     blockProposeEmitter

--- a/test/circuits.test.mjs
+++ b/test/circuits.test.mjs
@@ -41,7 +41,7 @@ describe('General Circuit Test', () => {
   before(async () => {
     await nf3Proposer.init(mnemonics.proposer);
     // we must set the URL from the point of view of the client container
-    await nf3Proposer.registerProposer('http://optimist1', MINIMUM_STAKE);
+    await nf3Proposer.registerProposer('http://optimist', MINIMUM_STAKE);
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer.startProposer();

--- a/test/e2e/protocol/proposer.test.mjs
+++ b/test/e2e/protocol/proposer.test.mjs
@@ -170,7 +170,7 @@ describe('Basic Proposer tests', () => {
     let proposers;
     ({ proposers } = await bootProposer.getProposers());
     // we have to pay stake to be registered
-    const res = await bootProposer.updateProposer(testProposersUrl[3], 0);
+    const res = await bootProposer.updateProposer(testProposersUrl[3], 0, 0);
     expectTransaction(res);
     ({ proposers } = await bootProposer.getProposers());
     const thisProposer = proposers.filter(p => p.thisAddress === bootProposer.ethereumAddress);
@@ -180,12 +180,23 @@ describe('Basic Proposer tests', () => {
 
   it('should increment the stake of the proposer', async () => {
     const initialStake = await getStakeAccount(bootProposer.ethereumAddress);
-    const res = await bootProposer.updateProposer(testProposersUrl[0], MINIMUM_STAKE);
+    const res = await bootProposer.updateProposer(testProposersUrl[0], MINIMUM_STAKE, 0);
     expectTransaction(res);
     const finalStake = await getStakeAccount(bootProposer.ethereumAddress);
     expect(Number(finalStake.amount)).to.be.equal(
       Number(initialStake.amount) + Number(MINIMUM_STAKE),
     );
+  });
+
+  it('should update proposer fee', async () => {
+    let proposers;
+    ({ proposers } = await bootProposer.getProposers());
+    // we have to pay stake to be registered
+    const res = await bootProposer.updateProposer(testProposersUrl[3], 0, fee);
+    expectTransaction(res);
+    ({ proposers } = await bootProposer.getProposers());
+    const thisProposer = proposers.filter(p => p.thisAddress === bootProposer.ethereumAddress);
+    expect(Number(thisProposer[0].fee)).to.be.equal(fee);
   });
 
   it('should fail to register a proposer twice', async () => {

--- a/test/e2e/tokens/erc1155.test.mjs
+++ b/test/e2e/tokens/erc1155.test.mjs
@@ -56,7 +56,7 @@ const emptyL2 = async () => {
 describe('ERC1155 tests', () => {
   before(async () => {
     await nf3Proposer1.init(mnemonics.proposer);
-    await nf3Proposer1.registerProposer('', MINIMUM_STAKE);
+    await nf3Proposer1.registerProposer('http://optimist', MINIMUM_STAKE);
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer1.startProposer();

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -73,7 +73,7 @@ describe('ERC20 tests', () => {
   before(async () => {
     await nf3Proposer.init(mnemonics.proposer);
     // we must set the URL from the point of view of the client container
-    await nf3Proposer.registerProposer('http://optimist1', MINIMUM_STAKE);
+    await nf3Proposer.registerProposer('http://optimist', MINIMUM_STAKE);
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer.startProposer();

--- a/test/e2e/tokens/erc721.test.mjs
+++ b/test/e2e/tokens/erc721.test.mjs
@@ -60,7 +60,7 @@ const emptyL2 = async () => {
 describe('ERC721 tests', () => {
   before(async () => {
     await nf3Proposer1.init(mnemonics.proposer);
-    await nf3Proposer1.registerProposer('', MINIMUM_STAKE);
+    await nf3Proposer1.registerProposer('http://optimist', MINIMUM_STAKE);
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer1.startProposer();

--- a/test/gas.test.mjs
+++ b/test/gas.test.mjs
@@ -47,7 +47,7 @@ describe('Gas test', () => {
   let gasCost = 0;
   before(async () => {
     await nf3Proposer1.init(mnemonics.proposer);
-    await nf3Proposer1.registerProposer('', MINIMUM_STAKE);
+    await nf3Proposer1.registerProposer('http://optimist', MINIMUM_STAKE);
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer1.startProposer();

--- a/test/kyc.test.mjs
+++ b/test/kyc.test.mjs
@@ -37,7 +37,7 @@ describe('KYC tests', () => {
   before(async () => {
     await nf3Proposer.init(mnemonics.proposer);
     // we must set the URL from the point of view of the client container
-    await nf3Proposer.registerProposer('http://optimist1', MINIMUM_STAKE);
+    await nf3Proposer.registerProposer('http://optimist', MINIMUM_STAKE);
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer.startProposer();

--- a/test/multisig/administrator.test.mjs
+++ b/test/multisig/administrator.test.mjs
@@ -236,7 +236,7 @@ describe(`Testing Administrator`, () => {
 
     it('Allowing register first proposer', async () => {
       if (process.env.ENVIRONMENT !== 'aws') {
-        const res = await proposers[0].registerProposer('', MINIMUM_STAKE);
+        const res = await proposers[0].registerProposer('http://optimist', MINIMUM_STAKE);
         expectTransaction(res);
       }
     });
@@ -244,7 +244,7 @@ describe(`Testing Administrator`, () => {
     it('Not allowing register second proposer', async () => {
       let error = null;
       try {
-        const res = await proposers[1].registerProposer('', MINIMUM_STAKE);
+        const res = await proposers[1].registerProposer('http://optimist', MINIMUM_STAKE);
         expectTransaction(res);
       } catch (err) {
         error = err;
@@ -276,7 +276,7 @@ describe(`Testing Administrator`, () => {
     });
 
     it('Allowing register second proposer', async () => {
-      const res = await proposers[1].registerProposer('', MINIMUM_STAKE);
+      const res = await proposers[1].registerProposer('http://optimist', MINIMUM_STAKE);
       expectTransaction(res);
     });
 

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -445,7 +445,7 @@ export const retrieveL2Balance = async (client, ercAddress) => {
 */
 export const registerProposerOnNoProposer = async proposer => {
   if ((await proposer.getCurrentProposer()) === '0x0000000000000000000000000000000000000000') {
-    await proposer.registerProposer('', MINIMUM_STAKE);
+    await proposer.registerProposer('http://optimist', MINIMUM_STAKE);
   }
 };
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Fixes: #936 
- Add/update fee for the proposer
- Get fee for the proposer. Endpoint defined in the proposer app `/proposer/fee`.

## Does this close any currently open issues?
Yes. #936.

## What commands can I run to test the change? 
npm run test-e2e-protocol

## Any other comments?
No
