### PR TITLE
fix: optimist local test bug

### DIFF
--- a/test/optimist-resync.test.mjs
+++ b/test/optimist-resync.test.mjs
@@ -51,7 +51,7 @@ describe('Optimist synchronisation tests', () => {
       'docker/docker-compose.ganache.yml',
     ],
     log: process.env.LOG_LEVEL || 'silent',
-    composeOptions: [['-p "nightfall_3"']],
+    composeOptions: [['-p', 'nightfall_3']],
   };
 
   before(async () => {


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

This fixes a bug in the optimist sync test whereby it would complain that `nightfall_3` was not a valid project name and throw, when testing locally.

## Does this close any currently open issues?

No

## What commands can I run to test the change? 

Run up nightfall as usual (`./start-nightfall -g -d`) and run `npm run test-optimist-sync`

## Any other comments?

It's unclear why this bug arose.  It may be that some characters were accidentally deleted because it's unlikely to have ever worked and yet we know that it used to. I changed double quotes to single quotes as well, but that is immaterial to the functioning, just a linter preference,
