### PR TITLE
transferring/withdrawing specific commitments

### DIFF
--- a/nightfall-client/src/routes/transfer.mjs
+++ b/nightfall-client/src/routes/transfer.mjs
@@ -27,6 +27,9 @@ router.post('/', async (req, res, next) => {
     if (err.message.includes('No suitable commitments')) {
       logger.info('Returning "No suitable commitments" error');
       res.json({ error: 'No suitable commitments' });
+    } else if (err.message.includes('invalid commitment hashes')) {
+      logger.info('Returning "invalid commitment hashes" error');
+      res.json({ error: err.message });
     } else {
       next(err);
     }

--- a/nightfall-client/src/routes/withdraw.mjs
+++ b/nightfall-client/src/routes/withdraw.mjs
@@ -23,6 +23,10 @@ router.post('/', async (req, res, next) => {
     logger.trace(` raw transaction is ${JSON.stringify(txDataToSign, null, 2)}`);
     res.json({ txDataToSign, transaction });
   } catch (err) {
+    if (err.message.includes('invalid commitment hashes')) {
+      logger.info('Returning "invalid commitment hashes" error');
+      res.json({ error: err.message });
+    }
     logger.error(err);
     next(err);
   }

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -119,7 +119,7 @@ export async function setSiblingInfo(commitment, siblingPath, leafIndex, root) {
 }
 
 // function to mark a commitment as pending nullication for a mongo db
-async function markPending(commitment) {
+export async function markPending(commitment) {
   const connection = await mongo.connection(MONGO_URL);
   const query = { _id: commitment.hash.hex(32) };
   const update = { $set: { isPendingNullification: true } };
@@ -613,8 +613,8 @@ async function verifyEnoughCommitments(
       })
       .toArray();
 
-    // If not commitments are found, the transfer/withdrawal cannot be paid, so return null
-    if (commitmentArray === []) return null;
+    // If not commitments are found, the transfer/withdrawal cannot be paid, so throw an error
+    if (commitmentArray === []) throw new Error('no commitment for the actual transfer found');
 
     // Turn the fee commitments into real commitment object and sort it
     commitments = commitmentArray
@@ -647,7 +647,7 @@ async function verifyEnoughCommitments(
 
     // If after the loop minC is still zero means that we didn't found any sum of commitments
     // higher or equal than the amount required. Therefore the user can not pay it
-    if (minC === 0) return null;
+    if (minC === 0) throw new Error('no commitments found to cover the value');
   }
 
   // If there is a fee and the ercAddress of the fee doesn't match the ercAddress, get
@@ -666,8 +666,8 @@ async function verifyEnoughCommitments(
       })
       .toArray();
 
-    // If not commitments are found, the fee cannot be paid, so return null
-    if (commitmentArrayFee === []) return null;
+    // If not commitments are found, the fee cannot be paid, so throw an error
+    if (commitmentArrayFee === []) throw new Error('no commitments found');
 
     // Turn the fee commitments into real commitment object and sort it
     commitmentsFee = commitmentArrayFee
@@ -694,7 +694,7 @@ async function verifyEnoughCommitments(
 
     // If after the loop minFc is still zero means that we didn't found any sum of commitments
     // higher or equal than the fee required. Therefore the user can not pay it
-    if (minFc === 0) return null;
+    if (minFc === 0) throw new Error('no commitments to cover the fee');
   }
 
   return { commitmentsFee, minFc, commitments, minC };
@@ -815,6 +815,38 @@ function findSubsetNCommitments(N, commitments, value) {
   return commitmentsToUse;
 }
 
+function selectCommitments(commitments, value, minC, maxC) {
+  const possibleSubsetsCommitments = [];
+
+  // Get the "best" subset of each possible size to then decide which one is better overall
+  // From the calculations performed in "verifyEnoughCommitments" we know that at least
+  // minC commitments are required. On the other hand, we can use a maximum of maxC commitments
+  // but we have to take into account that some spots needs to be used for the fee and that
+  // maybe the user does not have as much commitments
+  for (let i = minC; i <= Math.min(commitments.length, maxC); ++i) {
+    const subset = findSubsetNCommitments(i, commitments, value);
+    possibleSubsetsCommitments.unshift(subset);
+  }
+
+  // Rank the possible commitments subsets.
+  // We prioritize the subset that minimizes the change.
+  // If two subsets have the same change, we priority the subset that uses more commitments
+  const rankedSubsetCommitmentsArray = possibleSubsetsCommitments
+    .filter(subset => subset.length > 0)
+    .sort((a, b) => {
+      const changeA = a.reduce((acc, com) => acc + com.preimage.value.bigInt, 0n) - value.bigInt;
+      const changeB = b.reduce((acc, com) => acc + com.preimage.value.bigInt, 0n) - value.bigInt;
+      if (changeA - changeB === 0n) {
+        return b.length - a.length;
+      }
+
+      return changeA > changeB ? 0 : -1;
+    });
+
+  // Select the first ranked subset as the commitments the user will spend
+  return rankedSubsetCommitmentsArray.length > 0 ? rankedSubsetCommitmentsArray[0] : [];
+}
+
 async function findUsableCommitments(
   compressedZkpPublicKey,
   ercAddress,
@@ -839,8 +871,6 @@ async function findUsableCommitments(
     onlyFee,
   );
 
-  if (!commitmentsVerification) return null;
-
   const { commitments, minC, minFc, commitmentsFee } = commitmentsVerification;
 
   logger.debug(
@@ -853,73 +883,12 @@ async function findUsableCommitments(
     );
   }
 
-  const possibleSubsetsCommitments = [];
+  const maxC = maxNumberNullifiers - minFc;
+  const oldCommitments = !onlyFee ? selectCommitments(commitments, value, minC, maxC) : [];
 
-  // Get the "best" subset of each possible size to then decide which one is better overall
-  // From the calculations performed in "verifyEnoughCommitments" we know that at least
-  // minC commitments are required. On the other hand, we can use a maximum of maxNumberNullifiers commitments
-  // but we have to take into account that some spots needs to be used for the fee and that
-  // maybe the user does not have as much commitments
-  for (let i = minC; i <= Math.min(commitments.length, maxNumberNullifiers - minFc); ++i) {
-    const subset = findSubsetNCommitments(i, commitments, value);
-    possibleSubsetsCommitments.unshift(subset);
-  }
-
-  // Rank the possible commitments subsets.
-  // We prioritize the subset that minimizes the change.
-  // If two subsets have the same change, we priority the subset that uses more commitments
-  const rankedSubsetCommitmentsArray = possibleSubsetsCommitments
-    .filter(subset => subset.length > 0)
-    .sort((a, b) => {
-      const changeA = a.reduce((acc, com) => acc + com.preimage.value.bigInt, 0n) - value.bigInt;
-      const changeB = b.reduce((acc, com) => acc + com.preimage.value.bigInt, 0n) - value.bigInt;
-      if (changeA - changeB === 0n) {
-        return b.length - a.length;
-      }
-
-      return changeA > changeB ? 0 : -1;
-    });
-
-  // Select the first ranked subset as the commitments the user will spend
-  const oldCommitments =
-    rankedSubsetCommitmentsArray.length > 0 ? rankedSubsetCommitmentsArray[0] : [];
-
-  const possibleSubsetsCommitmentsFee = [];
-
-  if (fee.bigInt > 0n) {
-    // Get the "best" subset of each possible size for the fee to then decide which one
-    // is better overall. We know that at least we require minFc commitments.
-    // On the other hand, we can use a maximum of maxNumberNullifiers commitments minus the spots already used
-    // for the regular transfer. We also take into account that the user may not have as much commits
-    for (
-      let i = minFc;
-      i <= Math.min(commitmentsFee.length, maxNumberNullifiers - oldCommitments.length);
-      ++i
-    ) {
-      const subset = findSubsetNCommitments(i, commitmentsFee, fee);
-      possibleSubsetsCommitmentsFee.unshift(subset);
-    }
-  }
-
-  // Rank the possible commitments subsets.
-  // We prioritize the subset that minimizes the change.
-  // If two subsets have the same change, we priority the subset that uses more commitments
-  const rankedSubsetCommitmentsFeeArray = possibleSubsetsCommitmentsFee
-    .filter(subset => subset.length > 0)
-    .sort((a, b) => {
-      const changeA = a.reduce((acc, com) => acc + com.preimage.value.bigInt, 0n) - value.bigInt;
-      const changeB = b.reduce((acc, com) => acc + com.preimage.value.bigInt, 0n) - value.bigInt;
-      if (changeA - changeB === 0n) {
-        return b.length - a.length;
-      }
-
-      return Number(changeA - changeB);
-    });
-
-  // If fee was zero, ranked subset will be an empty array and therefore no commitments will be assigned
-  // Otherwise, set the best ranked as the commitments to spend
+  const maxFc = maxNumberNullifiers - oldCommitments.length;
   const oldCommitmentsFee =
-    rankedSubsetCommitmentsFeeArray.length > 0 ? rankedSubsetCommitmentsFeeArray[0] : [];
+    fee.bigInt > 0n ? selectCommitments(commitmentsFee, fee, minFc, maxFc) : [];
 
   // Mark all the commitments used as pending so that they can not be used twice
   await Promise.all(
@@ -1013,6 +982,31 @@ export async function getCommitmentsByCompressedZkpPublicKeyList(listOfCompresse
     })
     .toArray();
   return commitmentsByListOfCompressedZkpPublicKey;
+}
+
+export async function getCommitmentsByHash(hashes, compressedZkpPublicKey, ercAddress, tokenId) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(COMMITMENTS_DB);
+  logger.debug({
+    msg: 'DB lookup',
+    compressedZkpPublicKey: compressedZkpPublicKey.hex(32),
+    'preimage.ercAddress': generalise(ercAddress).hex(32),
+    'preimage.tokenId': generalise(tokenId).hex(32),
+    isNullified: false,
+    isPendingNullification: false,
+  });
+  const commitment = await db
+    .collection(COMMITMENTS_COLLECTION)
+    .find({
+      _id: { $in: hashes },
+      compressedZkpPublicKey: compressedZkpPublicKey.hex(32),
+      'preimage.ercAddress': generalise(ercAddress).hex(32),
+      'preimage.tokenId': generalise(tokenId).hex(32),
+      isNullified: false,
+      isPendingNullification: false,
+    })
+    .toArray();
+  return commitment;
 }
 
 /**

--- a/nightfall-client/src/services/transfer.mjs
+++ b/nightfall-client/src/services/transfer.mjs
@@ -29,7 +29,7 @@ const NEXT_N_PROPOSERS = 3;
 async function transfer(transferParams) {
   logger.info('Creating a transfer transaction');
   // let's extract the input items
-  const { offchain = false, ...items } = transferParams;
+  const { offchain = false, providedCommitments, ...items } = transferParams;
   const { tokenId, recipientData, rootKey, fee } = generalise(items);
   const ercAddress = generalise(items.ercAddress.toLowerCase());
   const { recipientCompressedZkpPublicKeys, values } = recipientData;
@@ -61,6 +61,7 @@ async function transfer(transferParams) {
     tokenId,
     rootKey,
     maxNumberNullifiers: VK_IDS.transfer.numberNullifiers,
+    providedCommitments,
   });
 
   try {

--- a/nightfall-client/src/services/withdraw.mjs
+++ b/nightfall-client/src/services/withdraw.mjs
@@ -28,7 +28,7 @@ const NEXT_N_PROPOSERS = 3;
 async function withdraw(withdrawParams) {
   logger.info('Creating a withdraw transaction');
   // let's extract the input items
-  const { offchain = false, ...items } = withdrawParams;
+  const { offchain = false, providedCommitments, ...items } = withdrawParams;
   const { tokenId, value, recipientAddress, rootKey, fee } = generalise(items);
   const ercAddress = generalise(items.ercAddress.toLowerCase());
   const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
@@ -53,6 +53,7 @@ async function withdraw(withdrawParams) {
     tokenId,
     rootKey,
     maxNumberNullifiers: VK_IDS.withdraw.numberNullifiers,
+    providedCommitments,
   });
 
   try {

--- a/nightfall-client/src/utils/getCommitmentInfo.mjs
+++ b/nightfall-client/src/utils/getCommitmentInfo.mjs
@@ -5,8 +5,10 @@ import constants from '@polygon-nightfall/common-files/constants/index.mjs';
 import Nullifier from '../classes/nullifier.mjs';
 import {
   clearPending,
+  markPending,
   findUsableCommitmentsMutex,
   getSiblingInfo,
+  getCommitmentsByHash,
 } from '../services/commitment-storage.mjs';
 import Commitment from '../classes/commitment.mjs';
 import { ZkpKeys } from '../services/keys.mjs';
@@ -25,9 +27,10 @@ export const getCommitmentInfo = async txInfo => {
     maticAddress,
     tokenId = generalise(0),
     rootKey,
-    maxNumberNullifiers,
-    onlyFee = false,
+    providedCommitments,
   } = txInfo;
+
+  let { maxNumberNullifiers, onlyFee = false } = txInfo;
 
   const { zkpPublicKey, compressedZkpPublicKey, nullifierKey } = new ZkpKeys(rootKey);
 
@@ -41,39 +44,94 @@ export const getCommitmentInfo = async txInfo => {
 
   logger.debug(`Fee will be added as part of the transaction commitments: ${addedFee > 0n}`);
 
-  const value = totalValueToSend + addedFee;
+  let value = totalValueToSend + addedFee;
   const feeValue = fee.bigInt - addedFee;
 
-  const commitments = await findUsableCommitmentsMutex(
-    compressedZkpPublicKey,
-    ercAddress,
-    tokenId,
-    maticAddress,
-    value,
-    feeValue,
-    maxNumberNullifiers,
-    onlyFee,
-  );
+  logger.debug(`using user provided commitments: ${providedCommitments !== undefined}`);
 
-  if (!commitments) throw new Error('Not available commitments has been found');
-
-  const { oldCommitments, oldCommitmentsFee } = commitments;
-
-  logger.debug(
-    `Found commitments ${addedFee > 0n ? 'including fee' : ''} ${JSON.stringify(
-      oldCommitments,
-      null,
-      2,
-    )}`,
-  );
-
-  if (feeValue > 0n) {
-    logger.debug(`Found commitments fee ${JSON.stringify(oldCommitmentsFee, null, 2)}`);
-  }
-
-  const spentCommitments = [...oldCommitments, ...oldCommitmentsFee];
-
+  const spentCommitments = [];
   try {
+    let validatedProvidedCommitments = [];
+    if (providedCommitments) {
+      const commitmentHashes = providedCommitments.map(c => c.toString());
+      logger.debug({ msg: 'looking up these commitment hashes:', commitmentHashes });
+      const rawCommitments = await getCommitmentsByHash(
+        commitmentHashes,
+        compressedZkpPublicKey,
+        ercAddress,
+        tokenId,
+      );
+
+      if (rawCommitments.length < commitmentHashes.length) {
+        const invalidHashes = commitmentHashes.filter(ch => {
+          for (const rc of rawCommitments) {
+            if (rc._id === ch) return false;
+          }
+          return true;
+        });
+        throw new Error(`invalid commitment hashes: ${invalidHashes}`);
+      }
+
+      const providedValue = rawCommitments
+        .map(c => generalise(c.preimage.value).bigInt)
+        .reduce((sum, c) => sum + c);
+
+      if (providedValue < totalValueToSend)
+        throw new Error('provided commitments do not cover the value');
+
+      // transform the hashes retrieved from the DB to well formed commitments
+      validatedProvidedCommitments = rawCommitments.map(ct => new Commitment(ct.preimage));
+      logger.debug({ providedValue });
+
+      if (maticAddress.hex(32) === ercAddress.hex(32)) {
+        // the user provieded enough commitments to cover the value but not the fee
+        // this can only happen when the token to send is the fee token
+        // we need to set the value here instead of the feeValue
+        value = providedValue >= value ? 0n : value - providedValue;
+        onlyFee = value === 0n;
+      } else {
+        onlyFee = true;
+      }
+
+      maxNumberNullifiers -= validatedProvidedCommitments.length;
+
+      await Promise.all(validatedProvidedCommitments.map(c => markPending(c)));
+      spentCommitments.push(...validatedProvidedCommitments);
+    }
+
+    logger.debug({
+      msg: 'find usable commitments inputs',
+      value,
+      feeValue,
+      onlyFee,
+    });
+    const commitments = await findUsableCommitmentsMutex(
+      compressedZkpPublicKey,
+      ercAddress,
+      tokenId,
+      maticAddress,
+      value,
+      feeValue,
+      maxNumberNullifiers,
+      onlyFee,
+    );
+    logger.debug({ commitments });
+    const { oldCommitments, oldCommitmentsFee } = commitments;
+
+    spentCommitments.push(...oldCommitments);
+    spentCommitments.push(...oldCommitmentsFee);
+    oldCommitments.push(...validatedProvidedCommitments);
+
+    logger.debug(
+      `Found commitments ${addedFee > 0n ? 'including fee' : ''} ${oldCommitments.map(c =>
+        JSON.stringify({ addr: c.preimage.ercAddress.hex(32), value: c.preimage.value.bigInt }),
+      )}`,
+    );
+
+    if (feeValue > 0n) {
+      logger.debug(`Found commitments fee ${JSON.stringify(oldCommitmentsFee, null, 2)}`);
+    }
+
     // Compute the nullifiers
     const nullifiers = spentCommitments.map(commitment => new Nullifier(commitment, nullifierKey));
 
@@ -84,7 +142,9 @@ export const getCommitmentInfo = async txInfo => {
     );
 
     // we may need to return change to the recipient
-    const change = totalInputCommitmentValue - value;
+    const change = totalInputCommitmentValue - (totalValueToSend + addedFee);
+
+    logger.debug({ totalInputCommitmentValue, change });
 
     // if so, add an output commitment to do that
     if (change !== 0n) {
@@ -102,6 +162,8 @@ export const getCommitmentInfo = async txInfo => {
 
     // we may need to return change to the recipient
     const changeFee = totalInputCommitmentFeeValue - feeValue;
+
+    logger.debug({ totalInputCommitmentFeeValue, changeFee });
 
     // if so, add an output commitment to do that
     if (changeFee !== 0n) {

--- a/test/client/commitments.test.mjs
+++ b/test/client/commitments.test.mjs
@@ -1,0 +1,319 @@
+import chai from 'chai';
+import ethers from 'ethers';
+import axios from 'axios';
+import chaiHttp from 'chai-http';
+import chaiAsPromised from 'chai-as-promised';
+import config from 'config';
+import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
+import mongo from '@polygon-nightfall/common-files/utils/mongo.mjs';
+import gen from 'general-number';
+
+import Nf3 from '../../cli/lib/nf3.mjs';
+import { getERCInfo } from '../../cli/lib/tokens.mjs';
+import { pendingCommitmentCount, Web3Client } from '../utils.mjs';
+
+const { expect } = chai;
+const { generalise } = gen;
+
+chai.use(chaiHttp);
+chai.use(chaiAsPromised);
+
+const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
+
+const { MONGO_URL, COMMITMENTS_DB, COMMITMENTS_COLLECTION } = config;
+const { fee, transferValue, MINIMUM_STAKE, mnemonics, signingKeys } = config.TEST_OPTIONS;
+
+const nf3Sender = new Nf3(signingKeys.user1, environment);
+const nf3Receiver = new Nf3(signingKeys.user2, environment);
+const nf3Proposer = new Nf3(signingKeys.proposer1, environment);
+const web3Client = new Web3Client();
+
+async function emptyL2(user) {
+  let count = await pendingCommitmentCount(user);
+  /* eslint-disable no-await-in-loop */
+  while (count !== 0) {
+    await nf3Sender.makeBlockNow();
+    try {
+      await web3Client.waitForEvent([], ['blockProposed']);
+      count = await pendingCommitmentCount(user);
+    } catch (err) {
+      break;
+    }
+  }
+}
+
+// tokenId is optional
+async function getCommitments(tokenAddress, minValue, user, tokenId) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(COMMITMENTS_DB);
+  const commitments = await db
+    .collection(COMMITMENTS_COLLECTION)
+    .find({
+      compressedZkpPublicKey: user.zkpKeys.compressedZkpPublicKey,
+      isNullified: false,
+      isPendingNullification: false,
+      'preimage.ercAddress': generalise(tokenAddress).hex(32),
+      'preimage.tokenId': generalise(tokenId).hex(32),
+    })
+    .toArray();
+
+  return commitments
+    .filter(c => Number(c.isOnChain) > -1)
+    .filter(c => c.preimage.value >= minValue);
+}
+
+// prepare a commitment, deposit it first if needed
+async function prepareCommitment(tokenAddress, tokenType, minValue, user, tokenId) {
+  let commitments = await getCommitments(tokenAddress, minValue, user, tokenId);
+  logger.debug({
+    msg: 'possible commitment values',
+    commitmentValues: commitments.map(c => parseInt(c.preimage.value, 16)),
+  });
+
+  if (commitments.length > 0) return commitments.pop();
+
+  await user.deposit(tokenAddress, tokenType, minValue, ethers.utils.hexZeroPad(tokenId, 32), fee);
+  await emptyL2(user);
+
+  commitments = await getCommitments(tokenAddress, minValue, user, tokenId);
+
+  if (commitments.length < 1) throw new Error('could not prepare commitment');
+  return commitments.pop();
+}
+
+async function getL2tokenBalance(nf3User, tokenAddress) {
+  const balances = await nf3User.getLayer2Balances();
+  if (!balances[tokenAddress]) return 0;
+
+  return balances[tokenAddress][0].balance;
+}
+
+describe('Custom Commitment Selection Test', () => {
+  before(async () => {
+    await nf3Proposer.init(mnemonics.proposer);
+    await nf3Proposer.registerProposer(environment.optimistApiUrl, MINIMUM_STAKE);
+    await nf3Proposer.startProposer();
+
+    await nf3Sender.init(mnemonics.user1);
+    await nf3Receiver.init(mnemonics.user2);
+
+    const stateAddress = await nf3Sender.stateContractAddress;
+    web3Client.subscribeTo('logs', [], { address: stateAddress });
+  });
+
+  describe('Transfers', () => {
+    it('should transfer a specified commitment', async () => {
+      const receiverKey = nf3Receiver.zkpKeys.compressedZkpPublicKey;
+      const tokenAddress = await nf3Sender.getContractAddress('ERC20Mock');
+
+      const commitment = await prepareCommitment(
+        tokenAddress,
+        'ERC20',
+        transferValue + fee,
+        nf3Sender,
+        '0x00',
+      );
+
+      const startBalances = {
+        msg: 'start balances',
+        senderBalance: await getL2tokenBalance(nf3Sender, tokenAddress),
+        recipientBalance: await getL2tokenBalance(nf3Receiver, tokenAddress),
+      };
+      logger.debug({
+        ...startBalances,
+        transferValue,
+        fee,
+        commitmentValue: parseInt(commitment.preimage.value, 16),
+      });
+
+      const res = await axios.post(`${environment.clientApiUrl}/transfer`, {
+        offchain: false,
+        ercAddress: ethers.utils.hexZeroPad(tokenAddress, 32),
+        tokenId: ethers.utils.hexZeroPad('0x00', 32),
+        recipientData: {
+          values: [transferValue],
+          recipientCompressedZkpPublicKeys: [receiverKey],
+        },
+        rootKey: nf3Sender.zkpKeys.rootKey,
+        fee,
+        providedCommitments: [commitment._id],
+      });
+
+      // since the transaction is on chain we still need to submit it
+      await nf3Sender.submitTransaction(res.data.txDataToSign, nf3Sender.shieldContractAddress, 0);
+
+      // assert commitment is spent
+      await emptyL2(nf3Sender);
+      const remainingCommitments = await getCommitments(
+        tokenAddress,
+        transferValue + fee,
+        nf3Sender,
+        '0x00',
+      );
+      logger.debug(remainingCommitments.map(c => parseInt(c.preimage.value, 16)));
+      expect(remainingCommitments).to.not.include(commitment);
+
+      await emptyL2(nf3Receiver);
+      const endBalances = {
+        msg: 'end balances',
+        senderBalance: await getL2tokenBalance(nf3Sender, tokenAddress),
+        recipientBalance: await getL2tokenBalance(nf3Receiver, tokenAddress),
+      };
+      logger.debug(endBalances);
+
+      expect(endBalances.senderBalance).to.equal(startBalances.senderBalance - transferValue - fee);
+      expect(endBalances.recipientBalance).to.equal(startBalances.recipientBalance + transferValue);
+    });
+
+    it('should look for missing fee when transferring fee token', async () => {
+      const receiverKey = nf3Receiver.zkpKeys.compressedZkpPublicKey;
+      const tokenAddress = await nf3Sender.getContractAddress('ERC20Mock');
+
+      // not enough to pay the fee
+      const commitment = await prepareCommitment(
+        tokenAddress,
+        'ERC20',
+        transferValue,
+        nf3Sender,
+        '0x00',
+      );
+
+      // a different commitment that covers the fee
+      await nf3Sender.deposit(tokenAddress, 'ERC20', fee, ethers.utils.hexZeroPad('0x00', 32), fee);
+
+      await emptyL2(nf3Sender);
+
+      const startBalances = {
+        msg: 'start balances',
+        senderBalance: await getL2tokenBalance(nf3Sender, tokenAddress),
+        recipientBalance: await getL2tokenBalance(nf3Receiver, tokenAddress),
+      };
+      logger.debug({
+        ...startBalances,
+        transferValue,
+        fee,
+        commitmentValue: parseInt(commitment.preimage.value, 16),
+      });
+
+      const res = await axios.post(`${environment.clientApiUrl}/transfer`, {
+        offchain: false,
+        ercAddress: ethers.utils.hexZeroPad(tokenAddress, 32),
+        tokenId: ethers.utils.hexZeroPad('0x00', 32),
+        recipientData: {
+          values: [transferValue],
+          recipientCompressedZkpPublicKeys: [receiverKey],
+        },
+        rootKey: nf3Sender.zkpKeys.rootKey,
+        fee,
+        providedCommitments: [commitment._id],
+      });
+
+      // since the transaction is on chain we still need to submit it
+      await nf3Sender.submitTransaction(res.data.txDataToSign, nf3Sender.shieldContractAddress, 0);
+
+      // assert commitment is spent
+      await emptyL2(nf3Sender);
+      const remainingCommitments = await getCommitments(tokenAddress, 0, nf3Sender, '0x00');
+      logger.debug(remainingCommitments.map(c => parseInt(c.preimage.value, 16)));
+      expect(remainingCommitments).to.not.include(commitment);
+
+      await emptyL2(nf3Receiver);
+      const endBalances = {
+        msg: 'end balances',
+        senderBalance: await getL2tokenBalance(nf3Sender, tokenAddress),
+        recipientBalance: await getL2tokenBalance(nf3Receiver, tokenAddress),
+      };
+      logger.debug(endBalances);
+
+      expect(endBalances.senderBalance).to.equal(startBalances.senderBalance - transferValue - fee);
+      expect(endBalances.recipientBalance).to.equal(startBalances.recipientBalance + transferValue);
+    });
+    it('should transfer a specified ERC721 commitment', async () => {
+      const recipientKey = nf3Receiver.zkpKeys.compressedZkpPublicKey;
+
+      const tokenAddress = await nf3Sender.getContractAddress('ERC721Mock');
+      const feeTokenAddress = await nf3Sender.getContractAddress('ERC20Mock');
+      const availableTokenIds = (
+        await getERCInfo(tokenAddress, nf3Sender.ethereumAddress, web3Client.getWeb3(), {
+          details: true,
+        })
+      ).details.map(t => t.tokenId);
+      const tokenId = generalise(availableTokenIds.shift()).hex(32);
+
+      const commitment = await prepareCommitment(tokenAddress, 'ERC721', 0, nf3Sender, tokenId);
+      await prepareCommitment(feeTokenAddress, 'ERC20', fee, nf3Sender, '0x00');
+
+      const res = await axios.post(`${environment.clientApiUrl}/transfer`, {
+        offchain: false,
+        ercAddress: tokenAddress,
+        tokenId,
+        recipientData: {
+          values: [0],
+          recipientCompressedZkpPublicKeys: [recipientKey],
+        },
+        rootKey: nf3Sender.zkpKeys.rootKey,
+        fee,
+        providedCommitments: [commitment._id],
+      });
+
+      // since the transaction is on chain we still need to submit it
+      await nf3Sender.submitTransaction(res.data.txDataToSign, nf3Sender.shieldContractAddress, 0);
+
+      // assert commitment is spent
+      await emptyL2(nf3Sender);
+      const remainingCommitments = await getCommitments(tokenAddress, 0, nf3Sender, tokenId);
+      expect(remainingCommitments).to.not.include(commitment);
+    });
+
+    describe('Withdrawals', () => {
+      it('should withdraw the specified commitment', async () => {
+        const tokenAddress = await nf3Sender.getContractAddress('ERC20Mock');
+
+        const commitment = await prepareCommitment(
+          tokenAddress,
+          'ERC20',
+          transferValue + fee,
+          nf3Sender,
+          '0x00',
+        );
+
+        const startBalance = await getL2tokenBalance(nf3Sender, tokenAddress);
+        const res = await axios
+          .post(`${environment.clientApiUrl}/withdraw`, {
+            offchain: false,
+            ercAddress: tokenAddress,
+            tokenId: '0x00',
+            tokenType: 'ERC20',
+            value: transferValue,
+            recipientAddress: nf3Sender.ethereumAddress,
+            rootKey: nf3Sender.zkpKeys.rootKey,
+            fee,
+            providedCommitments: [commitment._id],
+          })
+          .catch(console.log);
+
+        // since the transaction is on chain we still need to submit it
+        await nf3Sender.submitTransaction(
+          res.data.txDataToSign,
+          nf3Sender.shieldContractAddress,
+          0,
+        );
+
+        // assert commitment is spent
+        await emptyL2(nf3Sender);
+
+        const remainingCommitments = await getCommitments(tokenAddress, 0, nf3Sender, '0x00');
+        expect(remainingCommitments).to.not.include(commitment);
+
+        const endBalance = await getL2tokenBalance(nf3Sender, tokenAddress);
+        expect(endBalance).to.equal(startBalance - transferValue - fee);
+      });
+    });
+
+    after(() => {
+      nf3Sender.close();
+      nf3Receiver.close();
+      web3Client.closeWeb3();
+    });
+  });
+});

--- a/wallet/src/nightfall-browser/services/commitment-storage.js
+++ b/wallet/src/nightfall-browser/services/commitment-storage.js
@@ -155,7 +155,7 @@ export async function setSiblingInfo(commitment, siblingPath, leafIndex, root) {
 }
 
 // function to mark a commitment as pending nullication for a mongo db
-async function markPending(commitment) {
+export async function markPending(commitment) {
   const db = await connectDB();
   const { isPendingNullification, ...rest } = await db.get(
     COMMITMENTS_COLLECTION,
@@ -626,8 +626,8 @@ async function verifyEnoughCommitments(
       })
       .toArray();
 
-    // If not commitments are found, the transfer/withdrawal cannot be paid, so return null
-    if (commitmentArray === []) return null;
+    // If not commitments are found, the transfer/withdrawal cannot be paid, so throw an error
+    if (commitmentArray === []) throw new Error('no commitment for the actual transfer found');
 
     // Turn the fee commitments into real commitment object and sort it
     commitments = commitmentArray
@@ -660,7 +660,7 @@ async function verifyEnoughCommitments(
 
     // If after the loop minC is still zero means that we didn't found any sum of commitments
     // higher or equal than the amount required. Therefore the user can not pay it
-    if (minC === 0) return null;
+    if (minC === 0) throw new Error('no commitments found to cover the value');
   }
 
   // If there is a fee and the ercAddress of the fee doesn't match the ercAddress, get
@@ -679,8 +679,8 @@ async function verifyEnoughCommitments(
       })
       .toArray();
 
-    // If not commitments are found, the fee cannot be paid, so return null
-    if (commitmentArrayFee === []) return null;
+    // If not commitments are found, the fee cannot be paid, so throw an error
+    if (commitmentArrayFee === []) throw new Error('no commitments found');
 
     // Turn the fee commitments into real commitment object and sort it
     commitmentsFee = commitmentArrayFee
@@ -707,7 +707,7 @@ async function verifyEnoughCommitments(
 
     // If after the loop minFc is still zero means that we didn't found any sum of commitments
     // higher or equal than the fee required. Therefore the user can not pay it
-    if (minFc === 0) return null;
+    if (minFc === 0) throw new Error('no commitments to cover the fee');
   }
 
   return { commitmentsFee, minFc, commitments, minC };
@@ -828,6 +828,38 @@ function findSubsetNCommitments(N, commitments, value) {
   return commitmentsToUse;
 }
 
+function selectCommitments(commitments, value, minC, maxC) {
+  const possibleSubsetsCommitments = [];
+
+  // Get the "best" subset of each possible size to then decide which one is better overall
+  // From the calculations performed in "verifyEnoughCommitments" we know that at least
+  // minC commitments are required. On the other hand, we can use a maximum of maxC commitments
+  // but we have to take into account that some spots needs to be used for the fee and that
+  // maybe the user does not have as much commitments
+  for (let i = minC; i <= Math.min(commitments.length, maxC); ++i) {
+    const subset = findSubsetNCommitments(i, commitments, value);
+    possibleSubsetsCommitments.unshift(subset);
+  }
+
+  // Rank the possible commitments subsets.
+  // We prioritize the subset that minimizes the change.
+  // If two subsets have the same change, we priority the subset that uses more commitments
+  const rankedSubsetCommitmentsArray = possibleSubsetsCommitments
+    .filter(subset => subset.length > 0)
+    .sort((a, b) => {
+      const changeA = a.reduce((acc, com) => acc + com.preimage.value.bigInt, 0n) - value.bigInt;
+      const changeB = b.reduce((acc, com) => acc + com.preimage.value.bigInt, 0n) - value.bigInt;
+      if (changeA - changeB === 0n) {
+        return b.length - a.length;
+      }
+
+      return changeA > changeB ? 0 : -1;
+    });
+
+  // Select the first ranked subset as the commitments the user will spend
+  return rankedSubsetCommitmentsArray.length > 0 ? rankedSubsetCommitmentsArray[0] : [];
+}
+
 async function findUsableCommitments(
   compressedZkpPublicKey,
   ercAddress,
@@ -852,77 +884,14 @@ async function findUsableCommitments(
     onlyFee,
   );
 
-  if (!commitmentsVerification) return null;
-
   const { commitments, minC, minFc, commitmentsFee } = commitmentsVerification;
 
-  const possibleSubsetsCommitments = [];
+  const maxC = maxNumberNullifiers - minFc;
+  const oldCommitments = !onlyFee ? selectCommitments(commitments, value, minC, maxC) : [];
 
-  // Get the "best" subset of each possible size to then decide which one is better overall
-  // From the calculations performed in "verifyEnoughCommitments" we know that at least
-  // minC commitments are required. On the other hand, we can use a maximum of maxNumberNullifiers commitments
-  // but we have to take into account that some spots needs to be used for the fee and that
-  // maybe the user does not have as much commitments
-  for (let i = minC; i <= Math.min(commitments.length, maxNumberNullifiers - minFc); ++i) {
-    const subset = findSubsetNCommitments(i, commitments, value);
-    possibleSubsetsCommitments.unshift(subset);
-  }
-
-  // Rank the possible commitments subsets.
-  // We prioritize the subset that minimizes the change.
-  // If two subsets have the same change, we priority the subset that uses more commitments
-  const rankedSubsetCommitmentsArray = possibleSubsetsCommitments
-    .filter(subset => subset.length > 0)
-    .sort((a, b) => {
-      const changeA = a.reduce((acc, com) => acc + com.preimage.value.bigInt, 0n) - value.bigInt;
-      const changeB = b.reduce((acc, com) => acc + com.preimage.value.bigInt, 0n) - value.bigInt;
-      if (changeA - changeB === 0n) {
-        return b.length - a.length;
-      }
-
-      return changeA > changeB ? 0 : -1;
-    });
-
-  // Select the first ranked subset as the commitments the user will spend
-  const oldCommitments =
-    rankedSubsetCommitmentsArray.length > 0 ? rankedSubsetCommitmentsArray[0] : [];
-
-  const possibleSubsetsCommitmentsFee = [];
-
-  if (fee.bigInt > 0n) {
-    // Get the "best" subset of each possible size for the fee to then decide which one
-    // is better overall. We know that at least we require minFc commitments.
-    // On the other hand, we can use a maximum of maxNumberNullifiers commitments minus the spots already used
-    // for the regular transfer. We also take into account that the user may not have as much commits
-    for (
-      let i = minFc;
-      i <= Math.min(commitmentsFee.length, maxNumberNullifiers - oldCommitments.length);
-      ++i
-    ) {
-      const subset = findSubsetNCommitments(i, commitmentsFee, fee);
-      possibleSubsetsCommitmentsFee.unshift(subset);
-    }
-  }
-
-  // Rank the possible commitments subsets.
-  // We prioritize the subset that minimizes the change.
-  // If two subsets have the same change, we priority the subset that uses more commitments
-  const rankedSubsetCommitmentsFeeArray = possibleSubsetsCommitmentsFee
-    .filter(subset => subset.length > 0)
-    .sort((a, b) => {
-      const changeA = a.reduce((acc, com) => acc + com.preimage.value.bigInt, 0n) - value.bigInt;
-      const changeB = b.reduce((acc, com) => acc + com.preimage.value.bigInt, 0n) - value.bigInt;
-      if (changeA - changeB === 0n) {
-        return b.length - a.length;
-      }
-
-      return Number(changeA - changeB);
-    });
-
-  // If fee was zero, ranked subset will be an empty array and therefore no commitments will be assigned
-  // Otherwise, set the best ranked as the commitments to spend
+  const maxFc = maxNumberNullifiers - oldCommitments.length;
   const oldCommitmentsFee =
-    rankedSubsetCommitmentsFeeArray.length > 0 ? rankedSubsetCommitmentsFeeArray[0] : [];
+    fee.bigInt > 0n ? selectCommitments(commitmentsFee, fee, minFc, maxFc) : [];
 
   // Mark all the commitments used as pending so that they can not be used twice
   await Promise.all(
@@ -955,6 +924,23 @@ export async function findUsableCommitmentsMutex(
       onlyFee,
     ),
   );
+}
+
+export async function getCommitmentsByHash(hashes, compressedZkpPublicKey, ercAddress, tokenId) {
+  const connection = await connectDB();
+  const db = connection.db(COMMITMENTS_DB);
+  const commitment = await db
+    .collection(COMMITMENTS_COLLECTION)
+    .find({
+      _id: { $in: hashes },
+      compressedZkpPublicKey: compressedZkpPublicKey.hex(32),
+      'preimage.ercAddress': generalise(ercAddress).hex(32),
+      'preimage.tokenId': generalise(tokenId).hex(32),
+      isNullified: false,
+      isPendingNullification: false,
+    })
+    .toArray();
+  return commitment;
 }
 
 export async function getAllCommitments() {

--- a/wallet/src/nightfall-browser/services/transfer.js
+++ b/wallet/src/nightfall-browser/services/transfer.js
@@ -40,7 +40,7 @@ const circuitName = 'transfer';
 async function transfer(transferParams, shieldContractAddress) {
   logger.info('Creating a transfer transaction');
   // let's extract the input items
-  const { ...items } = transferParams;
+  const { providedCommitments, ...items } = transferParams;
   const { tokenId, recipientData, rootKey, fee = generalise(0) } = generalise(items);
 
   const ercAddress = generalise(items.ercAddress.toLowerCase());
@@ -83,6 +83,7 @@ async function transfer(transferParams, shieldContractAddress) {
       tokenId,
       rootKey,
       maxNumberNullifiers: VK_IDS.transfer.numberNullifiers,
+      providedCommitments,
     });
 
     try {

--- a/wallet/src/nightfall-browser/services/withdraw.js
+++ b/wallet/src/nightfall-browser/services/withdraw.js
@@ -36,6 +36,7 @@ async function withdraw(withdrawParams, shieldContractAddress) {
     recipientAddress,
     rootKey,
     fee = generalise(0),
+    providedCommitments,
   } = generalise(withdrawParams);
 
   const ercAddress = generalise(withdrawParams.ercAddress.toLowerCase());
@@ -76,6 +77,7 @@ async function withdraw(withdrawParams, shieldContractAddress) {
     tokenId,
     rootKey,
     maxNumberNullifiers: VK_IDS.withdraw.numberNullifiers,
+    providedCommitments,
   });
 
   try {

--- a/wallet/src/nightfall-browser/utils/getCommitmentInfo.ts
+++ b/wallet/src/nightfall-browser/utils/getCommitmentInfo.ts
@@ -5,7 +5,9 @@ import Nullifier from '../classes/nullifier';
 import {
   clearPending,
   findUsableCommitmentsMutex,
+  getCommitmentsByHash,
   getSiblingInfo,
+  markPending,
 } from '../services/commitment-storage';
 import { ZkpKeys } from '../services/keys';
 
@@ -35,6 +37,7 @@ type TxInfo = {
   rootKey: any;
   maxNumberNullifiers: number;
   onlyFee: boolean;
+  providedCommitments: string[];
 };
 
 const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
@@ -46,9 +49,11 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
     maticAddress,
     tokenId = generalise(0),
     rootKey,
-    maxNumberNullifiers,
-    onlyFee = false,
+    providedCommitments = [],
   } = txInfo;
+
+  let { maxNumberNullifiers, onlyFee = false } = txInfo;
+
   const { zkpPublicKey, compressedZkpPublicKey, nullifierKey } = new ZkpKeys(rootKey);
 
   const valuesArray = recipientZkpPublicKeysArray.map(() => totalValueToSend);
@@ -58,27 +63,74 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
   const tokenIdArray = recipientZkpPublicKeysArray.map(() => tokenId);
   const addedFee = maticAddress.hex(32) === ercAddress.hex(32) ? fee : 0n;
 
-  const value = totalValueToSend + addedFee;
-  const feeValue = fee - addedFee;
+  let value = totalValueToSend + addedFee;
+  let feeValue = fee - addedFee;
 
-  const commitments = await findUsableCommitmentsMutex(
-    compressedZkpPublicKey,
-    ercAddress,
-    tokenId,
-    maticAddress,
-    value,
-    feeValue,
-    maxNumberNullifiers,
-    onlyFee,
-  );
-
-  if (!commitments) throw new Error('Not available commitments has been found');
-
-  const { oldCommitments, oldCommitmentsFee } = commitments;
-
-  const spentCommitments = [...oldCommitments, ...oldCommitmentsFee];
-
+  const spentCommitments = [];
   try {
+    let validatedProvidedCommitments = [];
+    if (providedCommitments) {
+      const commitmentHashes = providedCommitments.map(c => c.toString());
+      const rawCommitments = await getCommitmentsByHash(
+        commitmentHashes,
+        compressedZkpPublicKey,
+        ercAddress,
+        tokenId,
+      );
+
+      if (rawCommitments.length < commitmentHashes.length) {
+        const invalidHashes = commitmentHashes.filter(ch => {
+          for (const rc of rawCommitments) {
+            if (rc._id === ch) return false;
+          }
+          return true;
+        });
+        throw new Error(`invalid commitment hashes: ${invalidHashes}`);
+      }
+
+      const providedValue = rawCommitments
+        .map((c: any) => generalise(c.preimage.value).bigInt)
+        .reduce((sum: bigint, c: bigint) => sum + c);
+
+      if (providedValue < totalValueToSend)
+        throw new Error('provided commitments do not cover the value');
+
+      // transform the hashes retrieved from the DB to well formed commitments
+      validatedProvidedCommitments = rawCommitments.map((ct: any) => new Commitment(ct.preimage));
+
+      // the user provieded enough commitments to cover the value but not the fee
+      // this can only happen when the token to send is the fee token
+      onlyFee = true;
+      value = 0n;
+      maxNumberNullifiers -= validatedProvidedCommitments.length;
+
+      if (maticAddress.hex(32) === ercAddress.hex(32)) {
+        feeValue = providedValue > value ? 0n : value - providedValue;
+      } else {
+        feeValue = fee;
+      }
+
+      await Promise.all(validatedProvidedCommitments.map((c: Commitment) => markPending(c)));
+      spentCommitments.push(...validatedProvidedCommitments);
+    }
+
+    const commitments = await findUsableCommitmentsMutex(
+      compressedZkpPublicKey,
+      ercAddress,
+      tokenId,
+      maticAddress,
+      value,
+      feeValue,
+      maxNumberNullifiers,
+      onlyFee,
+    );
+
+    const { oldCommitments, oldCommitmentsFee } = commitments;
+    spentCommitments.push(...oldCommitments);
+    spentCommitments.push(...oldCommitmentsFee);
+
+    oldCommitments.push(...validatedProvidedCommitments);
+
     // Compute the nullifiers
     const nullifiers = spentCommitments.map(commitment => new Nullifier(commitment, nullifierKey));
 
@@ -153,7 +205,7 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
       salts,
     };
   } catch (err) {
-    await Promise.all(oldCommitments.map((o: any) => clearPending(o)));
+    await Promise.all(spentCommitments.map((o: any) => clearPending(o)));
     throw new Error('Failed getting commitment info');
   }
 };


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
this allows users to specify the specific commitments they want to transfer/withdraw.

## Does this close any currently open issues?
#1012 

## What commands can I run to test the change? 
an e2e test can be run like this:
`LOG_LEVEL=warn npx hardhat test test/client/commitments.test.mjs --no-compile`
a unit test is WIP

## Any other comments?
This should be supported through the SDK, see #1071 

