### PR TITLE
Dependency review version update

### DIFF
--- a/.github/workflows/check-PRs.yml
+++ b/.github/workflows/check-PRs.yml
@@ -11,7 +11,7 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v2.1.0
+        uses: actions/dependency-review-action@v2
 
   eslint-check:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Updates the dependency review action to use the latest version. The current version is 2.4.1.

## Does this close any currently open issues?
No

## What commands can I run to test the change? 
It runs in the GA pipeline

## Any other comments?
No
