### PR TITLE
#1082: Update setup-node step to v3

### DIFF
--- a/.github/workflows/check-PRs.yml
+++ b/.github/workflows/check-PRs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
       - name: eslint check
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
       - name: General Tests
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
       - name: Unit Tests
@@ -64,7 +64,7 @@ jobs:
       CONFIRMATIONS: 1
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
 
@@ -110,7 +110,7 @@ jobs:
       CONFIRMATIONS: 1
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
 
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
 
@@ -202,7 +202,7 @@ jobs:
       CONFIRMATIONS: 1
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
 
@@ -246,7 +246,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
 
@@ -293,7 +293,7 @@ jobs:
   #      CONFIRMATIONS: 1
   #    steps:
   #      - uses: actions/checkout@v3
-  #      - uses: actions/setup-node@v1
+  #      - uses: actions/setup-node@v3
   #        with:
   #          node-version: '16.17.0'
   #
@@ -344,7 +344,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
 
@@ -389,7 +389,7 @@ jobs:
       CONFIRMATIONS: 1
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
 
@@ -436,7 +436,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

This PR updates `setup-node` pipeline step to `v3`. This should speed things up a little and remove the warning messages about outdated versions of node from the pipeline results.

## Does this close any currently open issues?

Closes #1082 

## Any other comments?

Have a good day 👋

