### PR TITLE
Adding onlyFee flag in the commitment selection

### DIFF
--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -590,13 +590,65 @@ async function verifyEnoughCommitments(
   ercAddressFee,
   fee,
   maxNumberNullifiers,
+  onlyFee = false,
 ) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(COMMITMENTS_DB);
 
-  let fc = 0; // Number of fee commitments
   let minFc = 0; // Minimum number of fee commitments required to pay the fee
   let commitmentsFee = []; // Array containing the fee commitments available sorted
+  let minC = 0;
+  let commitments = [];
+
+  if (!onlyFee) {
+    // Get the commitments from the database
+    const commitmentArray = await db
+      .collection(COMMITMENTS_COLLECTION)
+      .find({
+        compressedZkpPublicKey: compressedZkpPublicKey.hex(32),
+        'preimage.ercAddress': ercAddress.hex(32),
+        'preimage.tokenId': tokenId.hex(32),
+        isNullified: false,
+        isPendingNullification: false,
+      })
+      .toArray();
+
+    // If not commitments are found, the transfer/withdrawal cannot be paid, so return null
+    if (commitmentArray === []) return null;
+
+    // Turn the fee commitments into real commitment object and sort it
+    commitments = commitmentArray
+      .filter(commitment => Number(commitment.isOnChain) > Number(-1)) // filters for on chain commitments
+      .map(ct => new Commitment(ct.preimage))
+      .sort((a, b) => Number(a.preimage.value.bigInt - b.preimage.value.bigInt));
+
+    const c = commitments.length; // Store the number of commitments
+
+    // At most, we can use (maxNumberNullifiers - number of fee commitments needed) commitments to pay for the
+    // transfer or withdraw. However, it is possible that the user doesn't have enough commitments.
+    // Therefore, the maximum number of commitments the user will be able to use is the minimum between
+    // maxNumberNullifiers - minFc and the number of commitments (c)
+
+    const minimumFeeCommits = fee.bigInt > 0n ? 1 : 0;
+    const maxPossibleCommitments = Math.min(c, maxNumberNullifiers - minimumFeeCommits);
+
+    let j = 1;
+    let sumHighestCommitments = 0n;
+    // We try to find the minimum number of commitments whose sum is higher than the value sent.
+    // Since the array is sorted, we just need to try to sum the highest commitments.
+    while (j <= maxPossibleCommitments) {
+      sumHighestCommitments += commitments[c - j].preimage.value.bigInt;
+      if (sumHighestCommitments >= value.bigInt) {
+        minC = j;
+        break;
+      }
+      ++j;
+    }
+
+    // If after the loop minC is still zero means that we didn't found any sum of commitments
+    // higher or equal than the amount required. Therefore the user can not pay it
+    if (minC === 0) return null;
+  }
 
   // If there is a fee and the ercAddress of the fee doesn't match the ercAddress, get
   // the fee commitments available and check the minimum number of commitments the user
@@ -623,12 +675,9 @@ async function verifyEnoughCommitments(
       .map(ct => new Commitment(ct.preimage))
       .sort((a, b) => Number(a.preimage.value.bigInt - b.preimage.value.bigInt));
 
-    fc = commitmentsFee.length; // Store the number of fee commitments
+    const fc = commitmentsFee.length; // Store the number of fee commitments
 
-    // At most, we can use maxNumberNullifiers - 1 commitments to pay for the fee. However, it is possible that
-    // the user has less than maxNumberNullifiers - 1 matic commitments. Therefore, the maximum number of commitments
-    // the user will be able to use is the minimum between maxNumberNullifiers - 1 and the number of fee commitments (fc)
-    const maxPossibleCommitmentsFee = Math.min(fc, maxNumberNullifiers - 1);
+    const maxPossibleCommitmentsFee = Math.min(fc, maxNumberNullifiers - minC);
 
     let i = 1;
     let sumHighestCommitmentsFee = 0n;
@@ -647,53 +696,6 @@ async function verifyEnoughCommitments(
     // higher or equal than the fee required. Therefore the user can not pay it
     if (minFc === 0) return null;
   }
-
-  // Get the commitments from the database
-  const commitmentArray = await db
-    .collection(COMMITMENTS_COLLECTION)
-    .find({
-      compressedZkpPublicKey: compressedZkpPublicKey.hex(32),
-      'preimage.ercAddress': ercAddress.hex(32),
-      'preimage.tokenId': tokenId.hex(32),
-      isNullified: false,
-      isPendingNullification: false,
-    })
-    .toArray();
-
-  // If not commitments are found, the transfer/withdrawal cannot be paid, so return null
-  if (commitmentArray === []) return null;
-
-  // Turn the fee commitments into real commitment object and sort it
-  const commitments = commitmentArray
-    .filter(commitment => Number(commitment.isOnChain) > Number(-1)) // filters for on chain commitments
-    .map(ct => new Commitment(ct.preimage))
-    .sort((a, b) => Number(a.preimage.value.bigInt - b.preimage.value.bigInt));
-
-  const c = commitments.length; // Store the number of commitments
-  let minC = 0;
-
-  // At most, we can use (maxNumberNullifiers - number of fee commitments needed) commitments to pay for the
-  // transfer or withdraw. However, it is possible that the user doesn't have enough commitments.
-  // Therefore, the maximum number of commitments the user will be able to use is the minimum between
-  // maxNumberNullifiers - minFc and the number of commitments (c)
-  const maxPossibleCommitments = Math.min(c, maxNumberNullifiers - minFc);
-
-  let j = 1;
-  let sumHighestCommitments = 0n;
-  // We try to find the minimum number of commitments whose sum is higher than the value sent.
-  // Since the array is sorted, we just need to try to sum the highest commitments.
-  while (j <= maxPossibleCommitments) {
-    sumHighestCommitments += commitments[c - j].preimage.value.bigInt;
-    if (sumHighestCommitments >= value.bigInt) {
-      minC = j;
-      break;
-    }
-    ++j;
-  }
-
-  // If after the loop minC is still zero means that we didn't found any sum of commitments
-  // higher or equal than the amount required. Therefore the user can not pay it
-  if (minC === 0) return null;
 
   return { commitmentsFee, minFc, commitments, minC };
 }
@@ -821,6 +823,7 @@ async function findUsableCommitments(
   _value,
   _fee,
   maxNumberNullifiers,
+  onlyFee = false,
 ) {
   const value = generalise(_value); // sometimes this is sent as a BigInt.
   const fee = generalise(_fee); // sometimes this is sent as a BigInt.
@@ -833,6 +836,7 @@ async function findUsableCommitments(
     ercAddressFee,
     fee,
     maxNumberNullifiers,
+    onlyFee,
   );
 
   if (!commitmentsVerification) return null;
@@ -934,6 +938,7 @@ export async function findUsableCommitmentsMutex(
   _value,
   _fee,
   maxNumberNullifiers,
+  onlyFee = false,
 ) {
   return mutex.runExclusive(async () =>
     findUsableCommitments(
@@ -944,6 +949,7 @@ export async function findUsableCommitmentsMutex(
       _value,
       _fee,
       maxNumberNullifiers,
+      onlyFee,
     ),
   );
 }

--- a/nightfall-client/src/utils/getCommitmentInfo.mjs
+++ b/nightfall-client/src/utils/getCommitmentInfo.mjs
@@ -26,6 +26,7 @@ export const getCommitmentInfo = async txInfo => {
     tokenId = generalise(0),
     rootKey,
     maxNumberNullifiers,
+    onlyFee = false,
   } = txInfo;
 
   const { zkpPublicKey, compressedZkpPublicKey, nullifierKey } = new ZkpKeys(rootKey);
@@ -51,6 +52,7 @@ export const getCommitmentInfo = async txInfo => {
     value,
     feeValue,
     maxNumberNullifiers,
+    onlyFee,
   );
 
   if (!commitments) throw new Error('Not available commitments has been found');

--- a/wallet/src/nightfall-browser/utils/getCommitmentInfo.ts
+++ b/wallet/src/nightfall-browser/utils/getCommitmentInfo.ts
@@ -34,6 +34,7 @@ type TxInfo = {
   tokenId: GeneralNumber;
   rootKey: any;
   maxNumberNullifiers: number;
+  onlyFee: boolean;
 };
 
 const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
@@ -46,6 +47,7 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
     tokenId = generalise(0),
     rootKey,
     maxNumberNullifiers,
+    onlyFee = false,
   } = txInfo;
   const { zkpPublicKey, compressedZkpPublicKey, nullifierKey } = new ZkpKeys(rootKey);
 
@@ -67,6 +69,7 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
     value,
     feeValue,
     maxNumberNullifiers,
+    onlyFee,
   );
 
   if (!commitments) throw new Error('Not available commitments has been found');


### PR DESCRIPTION
This PR adds a flag to the commitment selection function called only fee. If set to true, the commitment selection algorithm will only be performed to get the commitments to use for the fee. This flag is needed because value = 0 doesn't mean that no commitments are needed (ERC721)
 
