### PR TITLE
PoS minor fixes

### DIFF
--- a/nightfall-deployer/contracts/Challenges.sol
+++ b/nightfall-deployer/contracts/Challenges.sol
@@ -283,18 +283,21 @@ contract Challenges is Stateful, Key_Registry, Config {
         // we need to remove the block that has been successfully
         // challenged from the linked list of blocks and all of the subsequent
         // blocks
-        uint256 numRemoved = removeBlockHashes(badBlock.blockNumberL2);
+        BlockData[] memory badBlocks = removeBlockHashes(badBlock.blockNumberL2);
         // remove the proposer and give the proposer's block stake to the challenger
-        state.rewardChallenger(msg.sender, badBlock.proposer, numRemoved);
+        state.rewardChallenger(msg.sender, badBlock.proposer, badBlocks);
     }
 
-    function removeBlockHashes(uint256 blockNumberL2) internal returns (uint256) {
+    function removeBlockHashes(uint256 blockNumberL2) internal returns (BlockData[] memory) {
         uint256 lastBlock = state.getNumberOfL2Blocks() - 1;
-        for (uint256 i = lastBlock; i >= blockNumberL2; i--) {
-            state.setBlockStakeWithdrawn(state.popBlockData().blockHash);
+        BlockData[] memory badBlocks = new BlockData[](lastBlock - blockNumberL2 + 1);
+        for (uint256 i = 0; i <= lastBlock - blockNumberL2 + 1; i++) {
+            BlockData memory blockData = state.popBlockData();
+            state.setBlockStakeWithdrawn(blockData.blockHash);
+            badBlocks[i] = blockData;
         }
         require(state.getNumberOfL2Blocks() == blockNumberL2, 'Number remaining not as expected.');
-        return (lastBlock + 1 - blockNumberL2);
+        return badBlocks;
     }
 
     //To prevent frontrunning, we need to commit to a challenge before we send it

--- a/nightfall-deployer/contracts/Challenges.sol
+++ b/nightfall-deployer/contracts/Challenges.sol
@@ -291,7 +291,7 @@ contract Challenges is Stateful, Key_Registry, Config {
     function removeBlockHashes(uint256 blockNumberL2) internal returns (BlockData[] memory) {
         uint256 lastBlock = state.getNumberOfL2Blocks() - 1;
         BlockData[] memory badBlocks = new BlockData[](lastBlock - blockNumberL2 + 1);
-        for (uint256 i = 0; i <= lastBlock - blockNumberL2 + 1; i++) {
+        for (uint256 i = 0; i <= lastBlock - blockNumberL2; i++) {
             BlockData memory blockData = state.popBlockData();
             state.setBlockStakeWithdrawn(blockData.blockHash);
             badBlocks[i] = blockData;

--- a/nightfall-deployer/contracts/Config.sol
+++ b/nightfall-deployer/contracts/Config.sol
@@ -12,8 +12,8 @@ contract Config is Ownable, Structures {
     uint256 constant BLOCK_STRUCTURE_SLOTS = 7;
     uint256 constant TRANSACTION_STRUCTURE_SLOTS = 24;
 
-    uint256 minimumStake;
-    uint256 blockStake;
+    uint96 minimumStake;
+    uint96 blockStake;
     uint256 rotateProposerBlocks;
     uint256 valuePerSlot; // amount of value of a slot
     uint256 proposerSetCount; // number of slots to pop after shuffling slots that will build the proposer set
@@ -157,7 +157,7 @@ contract Config is Ownable, Structures {
     /**
      * @dev Set minimum stake for a proposer
      */
-    function setMinimumStake(uint256 _minimumStake) external onlyOwner {
+    function setMinimumStake(uint96 _minimumStake) external onlyOwner {
         minimumStake = _minimumStake;
     }
 
@@ -171,14 +171,14 @@ contract Config is Ownable, Structures {
     /**
      * @dev Set block stake for a proposer
      */
-    function setBlockStake(uint256 _blockStake) external onlyOwner {
+    function setBlockStake(uint96 _blockStake) external onlyOwner {
         blockStake = _blockStake;
     }
 
     /**
      * @dev Get block stake for a proposer
      */
-    function getBlockStake() public view returns (uint256) {
+    function getBlockStake() public view returns (uint96) {
         return blockStake;
     }
 

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -90,8 +90,8 @@ contract Shield is Stateful, Config, ReentrancyGuardUpgradeable, Pausable, KYC {
 
         // recover the stake for that block
         TimeLockedStake memory stake = state.getStakeAccount(msg.sender);
-        stake.amount += blockStake;
-        stake.challengeLocked -= blockStake;
+        stake.amount += blockData.blockStake;
+        stake.challengeLocked -= blockData.blockStake;
         state.setStakeAccount(msg.sender, stake.amount, stake.challengeLocked);
 
         state.addPendingWithdrawal(msg.sender, feePaymentsEth, feePaymentsMatic);

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -115,6 +115,7 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Config {
         require(b.proposer == msg.sender, 'State: Proposer address is not the sender');
         // set the maximum tx/block to prevent unchallengably large blocks
         require(t.length <= TRANSACTIONS_PER_BLOCK, 'State: The block has too many transactions');
+        require(stake.amount >= blockStake, 'State: Proposer does not have enough funds staked');
         stake.amount -= blockStake;
         stake.challengeLocked += blockStake;
         stakeAccounts[msg.sender] = TimeLockedStake(stake.amount, stake.challengeLocked, 0);
@@ -253,7 +254,9 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Config {
         // All check pass so add the block to the list of blocks waiting to be permanently added to the state - we only save the hash of the block data plus the absolute minimum of metadata - it's up to the challenger, or person requesting inclusion of the block to the permanent contract state, to provide the block data.
 
         // blockHash is hash of all block data and hash of all the transactions data.
-        blockHashes.push(BlockData({blockHash: blockHash, time: block.timestamp}));
+        blockHashes.push(
+            BlockData({blockHash: blockHash, time: block.timestamp, blockStake: blockStake})
+        );
         // Timber will listen for the BlockProposed event as well as
         // nightfall-optimist.  The current, optimistic version of Timber does not
         // require the smart contract to craft NewLeaf/NewLeaves events.

--- a/nightfall-deployer/contracts/Structures.sol
+++ b/nightfall-deployer/contracts/Structures.sol
@@ -74,6 +74,7 @@ contract Structures {
     struct BlockData {
         bytes32 blockHash; // hash of the block
         uint256 time; // time the block was created
+        uint256 blockStake; //amount staked by the proposer for this block
     }
 
     struct LinkedAddress {

--- a/nightfall-deployer/contracts/Structures.sol
+++ b/nightfall-deployer/contracts/Structures.sol
@@ -74,7 +74,8 @@ contract Structures {
     struct BlockData {
         bytes32 blockHash; // hash of the block
         uint256 time; // time the block was created
-        uint256 blockStake; //amount staked by the proposer for this block
+        address proposer; //proposer of the block
+        uint96 blockStake; //amount staked by the proposer for this block
     }
 
     struct LinkedAddress {

--- a/test/unit/SmartContracts/shield.unit.test.mjs
+++ b/test/unit/SmartContracts/shield.unit.test.mjs
@@ -14,7 +14,7 @@ import {
   setWhitelist,
 } from '../utils/shieldStorage.mjs';
 import {
-  setBlockHash,
+  setBlockData,
   setBlockPaymentClaimed,
   setFeeBookInfo,
   setStakeAccount,
@@ -519,7 +519,7 @@ describe('Testing Shield Contract', function () {
   describe('requestBlockPayment', async function () {
     it('succeeds when requesting a block payment', async function () {
       await Erc20MockInstance.transfer(shieldAddress, 100);
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       await time.increase(86400 * 7 + 1);
       await setFeeBookInfo(stateAddress, block, 0, 20);
@@ -557,7 +557,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it("fails if block doesn't exist", async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       const blockFake = {
         leafCount: 1,
@@ -581,7 +581,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if block is still challengeable', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       await expect(ShieldInstance.requestBlockPayment(block)).to.be.revertedWith(
         'Shield: Too soon to get paid for this block',
@@ -589,7 +589,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if someone other than proposer is trying to request a payment', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       await time.increase(86400 * 7 + 1);
 
@@ -599,7 +599,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if block payment has been already claimed', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       await time.increase(86400 * 7 + 1);
 
@@ -613,7 +613,7 @@ describe('Testing Shield Contract', function () {
 
   describe('isBlockPaymentPending', async function () {
     it('succeeds if block payment is pending', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       await time.increase(86400 * 7 + 1);
 
@@ -627,7 +627,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if block is still challengeable', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       await expect(ShieldInstance.isBlockPaymentPending(0)).to.be.revertedWith(
         'Shield: Too soon to get paid for this block',
@@ -635,7 +635,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if block payment has been claimed', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       await setBlockPaymentClaimed(stateAddress, blockHash);
 
@@ -649,7 +649,7 @@ describe('Testing Shield Contract', function () {
 
   describe('isValidWithdrawal', async function () {
     it('returns true if withdrawal is valid', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       await time.increase(86400 * 7 + 1);
 
@@ -661,7 +661,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if block or transaction is not real (sibling path wrong)', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       await time.increase(86400 * 7 + 1);
 
@@ -673,7 +673,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if transaction is still challengeable', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       const siblingPath = [block.transactionHashesRoot, depositTransactionHash];
       const index = 0;
@@ -683,7 +683,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if transaction payment has been claimed', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       await time.increase(86400 * 7 + 1);
 
@@ -698,7 +698,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if transaction is not a withdraw', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       await time.increase(86400 * 7 + 1);
 
@@ -715,7 +715,7 @@ describe('Testing Shield Contract', function () {
     it('succeeds to finalise withdrawal for an ERC20 token if valid and has not been advanced', async function () {
       await ShieldInstance.setRestriction(erc20MockAddress, '10000', '10000');
       await Erc20MockInstance.transfer(shieldAddress, 10);
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       await time.increase(86400 * 7 + 1);
 
@@ -738,7 +738,7 @@ describe('Testing Shield Contract', function () {
     it('succeeds to finalise withdrawal for an ERC20 token if valid and has been advanced and fee pending', async function () {
       await ShieldInstance.setRestriction(erc20MockAddress, '10000', '10000');
       await Erc20MockInstance.transfer(shieldAddress, 110);
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       const siblingPath = [block.transactionHashesRoot, depositTransactionHash];
       const index = 0;
@@ -819,7 +819,7 @@ describe('Testing Shield Contract', function () {
         transactionHashesRoot,
       };
 
-      await setBlockHash(StateInstance, stateAddress, calculateBlockHash(blockERC721));
+      await setBlockData(StateInstance, stateAddress, calculateBlockHash(blockERC721));
 
       await time.increase(86400 * 7 + 1);
 
@@ -896,7 +896,7 @@ describe('Testing Shield Contract', function () {
         transactionHashesRoot,
       };
 
-      await setBlockHash(StateInstance, stateAddress, calculateBlockHash(blockERC1155));
+      await setBlockData(StateInstance, stateAddress, calculateBlockHash(blockERC1155));
 
       await time.increase(86400 * 7 + 1);
 
@@ -917,7 +917,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if block or transaction is not real', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
       const siblingPath = [block.transactionHashesRoot, withdrawTransactionHash];
       const wrongIndex = 0;
 
@@ -927,7 +927,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if block is still challengeable', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       const siblingPath = [block.transactionHashesRoot, depositTransactionHash];
       const index = 0;
@@ -937,7 +937,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if block payment has been claimed', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       await time.increase(86400 * 7 + 1);
 
@@ -952,7 +952,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if transaction is not a withdraw', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
       const siblingPath = [block.transactionHashesRoot, withdrawTransactionHash];
       const index = 1;
 
@@ -965,7 +965,7 @@ describe('Testing Shield Contract', function () {
 
     it('fails if user is not whitelisted and whitelisting is active', async function () {
       await setWhitelist(shieldAddress);
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       await time.increase(86400 * 7 + 1);
 
@@ -1030,7 +1030,7 @@ describe('Testing Shield Contract', function () {
         transactionHashesRoot,
       };
 
-      await setBlockHash(StateInstance, stateAddress, calculateBlockHash(blockWithdrawalInvalid));
+      await setBlockData(StateInstance, stateAddress, calculateBlockHash(blockWithdrawalInvalid));
 
       await time.increase(86400 * 7 + 1);
 
@@ -1100,7 +1100,7 @@ describe('Testing Shield Contract', function () {
         transactionHashesRoot,
       };
 
-      await setBlockHash(StateInstance, stateAddress, calculateBlockHash(blockWithdrawalInvalid));
+      await setBlockData(StateInstance, stateAddress, calculateBlockHash(blockWithdrawalInvalid));
 
       await time.increase(86400 * 7 + 1);
 
@@ -1169,7 +1169,7 @@ describe('Testing Shield Contract', function () {
         transactionHashesRoot,
       };
 
-      await setBlockHash(StateInstance, stateAddress, calculateBlockHash(blockWithdrawalInvalid));
+      await setBlockData(StateInstance, stateAddress, calculateBlockHash(blockWithdrawalInvalid));
       await time.increase(86400 * 7 + 1);
 
       const index = 0;
@@ -1237,7 +1237,7 @@ describe('Testing Shield Contract', function () {
         transactionHashesRoot,
       };
 
-      await setBlockHash(StateInstance, stateAddress, calculateBlockHash(blockWithdrawalInvalid));
+      await setBlockData(StateInstance, stateAddress, calculateBlockHash(blockWithdrawalInvalid));
 
       await time.increase(86400 * 7 + 1);
 
@@ -1259,7 +1259,7 @@ describe('Testing Shield Contract', function () {
       await Erc20MockInstance.transfer(await owner[1].address, 100);
       await Erc20MockInstance.connect(owner[1]).approve(shieldAddress, 10);
 
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       const siblingPath = [block.transactionHashesRoot, depositTransactionHash];
       const index = 0;
@@ -1288,7 +1288,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if block or transaction is not real', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
       const siblingPath = [block.transactionHashesRoot, withdrawTransactionHash];
       const wrongIndex = 0;
 
@@ -1298,7 +1298,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if no fee is set', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       const siblingPath = [block.transactionHashesRoot, depositTransactionHash];
       const index = 0;
@@ -1309,7 +1309,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if block is finalized', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       const siblingPath = [block.transactionHashesRoot, depositTransactionHash];
       const index = 0;
@@ -1324,7 +1324,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if block payment has been claimed', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       const siblingPath = [block.transactionHashesRoot, depositTransactionHash];
       const index = 0;
@@ -1341,7 +1341,7 @@ describe('Testing Shield Contract', function () {
 
   describe('setAdvanceWithdrawalFee', async function () {
     it('succeeds to set fee for advance withdrawal', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       const siblingPath = [block.transactionHashesRoot, depositTransactionHash];
       const index = 0;
@@ -1368,7 +1368,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if transaction is not a withdrawal', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
       const siblingPath = [block.transactionHashesRoot, withdrawTransactionHash];
       const index = 1;
 
@@ -1380,7 +1380,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if advance fee is zero', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
       const siblingPath = [block.transactionHashesRoot, depositTransactionHash];
       const index = 0;
 
@@ -1390,7 +1390,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if block or transaction is not real', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
       const siblingPath = [block.transactionHashesRoot, withdrawTransactionHash];
       const wrongIndex = 0;
 
@@ -1452,7 +1452,7 @@ describe('Testing Shield Contract', function () {
         transactionHashesRoot,
       };
 
-      await setBlockHash(StateInstance, stateAddress, calculateBlockHash(blockERC721));
+      await setBlockData(StateInstance, stateAddress, calculateBlockHash(blockERC721));
 
       const index = 0;
       const siblingPath = [blockERC721.transactionHashesRoot, ethers.utils.hexZeroPad(0, 32)];
@@ -1470,7 +1470,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if block is finalized', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       const siblingPath = [block.transactionHashesRoot, depositTransactionHash];
       const index = 0;
@@ -1485,7 +1485,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if block payment has been claimed', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       const siblingPath = [block.transactionHashesRoot, depositTransactionHash];
       const index = 0;
@@ -1500,7 +1500,7 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if trying to set a fee for a withdrawal that is not yours', async function () {
-      await setBlockHash(StateInstance, stateAddress, blockHash);
+      await setBlockData(StateInstance, stateAddress, blockHash);
 
       await setAdvancedWithdrawal(shieldAddress, withdrawTransactionHash, owner[1].address, 1);
 

--- a/test/unit/utils/shieldStorage.mjs
+++ b/test/unit/utils/shieldStorage.mjs
@@ -4,10 +4,10 @@ import { setStorageAt } from '@nomicfoundation/hardhat-network-helpers';
 
 const { ethers } = hardhat;
 
-const whitelistSlot = 164;
-const withdrawnSlot = 167;
-const advancedWithdrawalSlot = 168;
-const isEscrowedSlot = 169;
+const whitelistSlot = 163;
+const withdrawnSlot = 166;
+const advancedWithdrawalSlot = 167;
+const isEscrowedSlot = 168;
 
 export async function setTransactionWithdrawn(shieldAddress, withdrawTransactionHash) {
   const indexWithdrawn = ethers.utils.solidityKeccak256(

--- a/test/unit/utils/stateStorage.mjs
+++ b/test/unit/utils/stateStorage.mjs
@@ -54,7 +54,7 @@ export async function setStakeAccount(stateAddress, proposer, amount, challengeL
   );
 }
 
-export async function setBlockHash(StateInstance, stateAddress, blockHash) {
+export async function setBlockData(StateInstance, stateAddress, blockHash) {
   const indexTime = ethers.utils.solidityKeccak256(
     ['uint256'],
     [ethers.utils.hexlify(blockHashesSlot)],
@@ -71,5 +71,10 @@ export async function setBlockHash(StateInstance, stateAddress, blockHash) {
     stateAddress,
     ethers.utils.hexlify(BigNumber.from(indexTime).add(1)),
     ethers.utils.hexZeroPad(ethers.utils.hexlify(await time.latest()), 32),
+  );
+  await setStorageAt(
+    stateAddress,
+    ethers.utils.hexlify(BigNumber.from(indexTime).add(2)),
+    ethers.utils.hexZeroPad(ethers.utils.hexlify(1), 32),
   );
 }

--- a/test/unit/utils/stateStorage.mjs
+++ b/test/unit/utils/stateStorage.mjs
@@ -5,10 +5,10 @@ import { setStorageAt, time } from '@nomicfoundation/hardhat-network-helpers';
 
 const { ethers } = hardhat;
 
-const blockHashesSlot = 163;
-const stakeAccountsSlot = 166;
-const feeBookIndex = 167;
-const claimedBlockStakesSlot = 168;
+const blockHashesSlot = 162;
+const stakeAccountsSlot = 165;
+const feeBookIndex = 166;
+const claimedBlockStakesSlot = 167;
 
 export async function setBlockPaymentClaimed(stateAddress, blockHash) {
   const index = ethers.utils.solidityKeccak256(
@@ -54,7 +54,13 @@ export async function setStakeAccount(stateAddress, proposer, amount, challengeL
   );
 }
 
-export async function setBlockData(StateInstance, stateAddress, blockHash) {
+export async function setBlockData(
+  StateInstance,
+  stateAddress,
+  blockHash,
+  blockStake,
+  proposerAddress,
+) {
   const indexTime = ethers.utils.solidityKeccak256(
     ['uint256'],
     [ethers.utils.hexlify(blockHashesSlot)],
@@ -75,6 +81,11 @@ export async function setBlockData(StateInstance, stateAddress, blockHash) {
   await setStorageAt(
     stateAddress,
     ethers.utils.hexlify(BigNumber.from(indexTime).add(2)),
-    ethers.utils.hexZeroPad(ethers.utils.hexlify(1), 32),
+    ethers.utils.hexlify(
+      ethers.utils.concat([
+        ethers.utils.hexZeroPad(ethers.utils.hexlify(blockStake), 12),
+        proposerAddress,
+      ]),
+    ),
   );
 }


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
This PR adds a few fixes to PoS implementation. 
1. When calling `proposeBlock`, if the proposer's stake is less than the blockStake the transaction submitted will revert. To avoid this and provide more clarity, a require is added so that if the proposer doesn't have enough funds, a message will be thrown.
2. When calling `requestBlockPayment`, the proposer is getting back their locked funds for the challenge. However, during the challenge period the blockStake might have changed (or in a future a functionality will be enabled to do so). Therefore, we need to make sure that the proposer receives what he staked (not more, not less). To do so, we store for each block the amount staked. 
3. If a block is succesfully challenged, the challenger will get the stake for that block and all the subsequent ones. However, different blocks might have different stakes and different proposers. Therefore, `rewardChallenger`, `removeBlockHashes` and `challengeAccepted` functions are modified accordingly. 
## Does this close any currently open issues?
No

## What commands can I run to test the change? 
RequestBlockPayment unit test has been updated. There are still no tests for the State contract nor the Challenges contract.

## Any other comments?
No

