### PR TITLE
Adding missing npm linking

### DIFF
--- a/.github/workflows/on-pull-request-master.yml
+++ b/.github/workflows/on-pull-request-master.yml
@@ -77,6 +77,7 @@ jobs:
           npm link @polygon-nightfall/common-files
           cd cli
           npm link @polygon-nightfall/common-files
+          npm ci
           cd ..
 
       - name: Start Containers
@@ -134,6 +135,7 @@ jobs:
           npm link @polygon-nightfall/common-files
           cd cli
           npm link @polygon-nightfall/common-files
+          npm ci
           cd ..
 
       - name: Start Containers
@@ -191,6 +193,7 @@ jobs:
           npm link @polygon-nightfall/common-files
           cd cli
           npm link @polygon-nightfall/common-files
+          npm ci
           cd ..
 
       - name: Start Containers
@@ -248,6 +251,7 @@ jobs:
           npm link @polygon-nightfall/common-files
           cd cli
           npm link @polygon-nightfall/common-files
+          npm ci
           cd ..
 
       - name: Start Containers
@@ -305,6 +309,7 @@ jobs:
           npm link @polygon-nightfall/common-files
           cd cli
           npm link @polygon-nightfall/common-files
+          npm ci
           cd ..
 
       - name: Start Containers
@@ -363,6 +368,7 @@ jobs:
           npm link @polygon-nightfall/common-files
           cd cli
           npm link @polygon-nightfall/common-files
+          npm ci
           cd ..
 
       - name: Start Containers
@@ -419,6 +425,7 @@ jobs:
           npm link @polygon-nightfall/common-files
           cd cli
           npm link @polygon-nightfall/common-files
+          npm ci
           cd ..
 
       - name: Start Containers
@@ -476,6 +483,7 @@ jobs:
           npm link @polygon-nightfall/common-files
           cd cli
           npm link @polygon-nightfall/common-files
+          npm ci
           cd ..
 
       - name: Start Containers
@@ -534,6 +542,7 @@ jobs:
   #          npm link @polygon-nightfall/common-files
   #          cd cli
   #          npm link @polygon-nightfall/common-files
+  #          npm ci
   #          cd ..
   #
   #      - name: Build adversary
@@ -598,6 +607,7 @@ jobs:
           npm link @polygon-nightfall/common-files
           cd cli
           npm link @polygon-nightfall/common-files
+          npm ci
           cd ..
 
       - name: Start Containers
@@ -656,6 +666,7 @@ jobs:
           npm link @polygon-nightfall/common-files
           cd cli
           npm link @polygon-nightfall/common-files
+          npm ci
           cd ..
 
       - name: Start Containers with ganache
@@ -717,6 +728,7 @@ jobs:
           npm link @polygon-nightfall/common-files
           cd cli
           npm link @polygon-nightfall/common-files
+          npm ci
           cd ..
 
       - name: Start Containers with ganache

--- a/.github/workflows/on-pull-request-master.yml
+++ b/.github/workflows/on-pull-request-master.yml
@@ -74,9 +74,9 @@ jobs:
           cd common-files
           npm link
           cd ..
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd cli
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd ..
 
       - name: Start Containers
@@ -131,9 +131,9 @@ jobs:
           cd common-files
           npm link
           cd ..
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd cli
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd ..
 
       - name: Start Containers
@@ -188,9 +188,9 @@ jobs:
           cd common-files
           npm link
           cd ..
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd cli
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd ..
 
       - name: Start Containers
@@ -245,9 +245,9 @@ jobs:
           cd common-files
           npm link
           cd ..
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd cli
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd ..
 
       - name: Start Containers
@@ -302,9 +302,9 @@ jobs:
           cd common-files
           npm link
           cd ..
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd cli
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd ..
 
       - name: Start Containers
@@ -360,9 +360,9 @@ jobs:
           cd common-files
           npm link
           cd ..
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd cli
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd ..
 
       - name: Start Containers
@@ -416,9 +416,9 @@ jobs:
           cd common-files
           npm link
           cd ..
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd cli
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd ..
 
       - name: Start Containers
@@ -473,9 +473,9 @@ jobs:
           cd common-files
           npm link
           cd ..
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd cli
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd ..
 
       - name: Start Containers
@@ -531,9 +531,9 @@ jobs:
   #          cd common-files
   #          npm link
   #          cd ..
-  #          RUN npm link @polygon-nightfall/common-files
+  #          npm link @polygon-nightfall/common-files
   #          cd cli
-  #          RUN npm link @polygon-nightfall/common-files
+  #          npm link @polygon-nightfall/common-files
   #          cd ..
   #
   #      - name: Build adversary
@@ -595,9 +595,9 @@ jobs:
           cd common-files
           npm link
           cd ..
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd cli
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd ..
 
       - name: Start Containers
@@ -653,9 +653,9 @@ jobs:
           cd common-files
           npm link
           cd ..
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd cli
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd ..
 
       - name: Start Containers with ganache
@@ -714,9 +714,9 @@ jobs:
           cd common-files
           npm link
           cd ..
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd cli
-          RUN npm link @polygon-nightfall/common-files
+          npm link @polygon-nightfall/common-files
           cd ..
 
       - name: Start Containers with ganache

--- a/.github/workflows/on-pull-request-master.yml
+++ b/.github/workflows/on-pull-request-master.yml
@@ -69,6 +69,16 @@ jobs:
         with:
           node-version: '16.17.0'
 
+      - name: Perform npm link
+        run: |
+          cd common-files
+          npm link
+          cd ..
+          RUN npm link @polygon-nightfall/common-files
+          cd cli
+          RUN npm link @polygon-nightfall/common-files
+          cd ..
+
       - name: Start Containers
         run: |
           ./bin/setup-nightfall
@@ -115,6 +125,16 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
+
+      - name: Perform npm link
+        run: |
+          cd common-files
+          npm link
+          cd ..
+          RUN npm link @polygon-nightfall/common-files
+          cd cli
+          RUN npm link @polygon-nightfall/common-files
+          cd ..
 
       - name: Start Containers
         run: |
@@ -163,6 +183,16 @@ jobs:
         with:
           node-version: '16.17.0'
 
+      - name: Perform npm link
+        run: |
+          cd common-files
+          npm link
+          cd ..
+          RUN npm link @polygon-nightfall/common-files
+          cd cli
+          RUN npm link @polygon-nightfall/common-files
+          cd ..
+
       - name: Start Containers
         run: |
           ./bin/setup-nightfall
@@ -210,6 +240,16 @@ jobs:
         with:
           node-version: '16.17.0'
 
+      - name: Perform npm link
+        run: |
+          cd common-files
+          npm link
+          cd ..
+          RUN npm link @polygon-nightfall/common-files
+          cd cli
+          RUN npm link @polygon-nightfall/common-files
+          cd ..
+
       - name: Start Containers
         run: |
           ./bin/setup-nightfall
@@ -256,6 +296,16 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '16.17.0'
+
+      - name: Perform npm link
+        run: |
+          cd common-files
+          npm link
+          cd ..
+          RUN npm link @polygon-nightfall/common-files
+          cd cli
+          RUN npm link @polygon-nightfall/common-files
+          cd ..
 
       - name: Start Containers
         run: |
@@ -305,6 +355,16 @@ jobs:
         with:
           node-version: '16.17.0'
 
+      - name: Perform npm link
+        run: |
+          cd common-files
+          npm link
+          cd ..
+          RUN npm link @polygon-nightfall/common-files
+          cd cli
+          RUN npm link @polygon-nightfall/common-files
+          cd ..
+
       - name: Start Containers
         run: |
           ./bin/setup-nightfall
@@ -350,6 +410,16 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
+
+      - name: Perform npm link
+        run: |
+          cd common-files
+          npm link
+          cd ..
+          RUN npm link @polygon-nightfall/common-files
+          cd cli
+          RUN npm link @polygon-nightfall/common-files
+          cd ..
 
       - name: Start Containers
         run: |
@@ -398,6 +468,16 @@ jobs:
         with:
           node-version: '16.17.0'
 
+      - name: Perform npm link
+        run: |
+          cd common-files
+          npm link
+          cd ..
+          RUN npm link @polygon-nightfall/common-files
+          cd cli
+          RUN npm link @polygon-nightfall/common-files
+          cd ..
+
       - name: Start Containers
         run: |
           ./bin/setup-nightfall
@@ -445,6 +525,16 @@ jobs:
   #      - uses: actions/setup-node@v3
   #        with:
   #          node-version: '16.17.0'
+  #
+  #      - name: Perform npm link
+  #        run: |
+  #          cd common-files
+  #          npm link
+  #          cd ..
+  #          RUN npm link @polygon-nightfall/common-files
+  #          cd cli
+  #          RUN npm link @polygon-nightfall/common-files
+  #          cd ..
   #
   #      - name: Build adversary
   #        run: npm run build-adversary
@@ -500,6 +590,16 @@ jobs:
         with:
           node-version: '16.17.0'
 
+      - name: Perform npm link
+        run: |
+          cd common-files
+          npm link
+          cd ..
+          RUN npm link @polygon-nightfall/common-files
+          cd cli
+          RUN npm link @polygon-nightfall/common-files
+          cd ..
+
       - name: Start Containers
         run: |
           ./bin/setup-nightfall
@@ -547,6 +647,16 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
+
+      - name: Perform npm link
+        run: |
+          cd common-files
+          npm link
+          cd ..
+          RUN npm link @polygon-nightfall/common-files
+          cd cli
+          RUN npm link @polygon-nightfall/common-files
+          cd ..
 
       - name: Start Containers with ganache
         run: |
@@ -598,6 +708,16 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
+
+      - name: Perform npm link
+        run: |
+          cd common-files
+          npm link
+          cd ..
+          RUN npm link @polygon-nightfall/common-files
+          cd cli
+          RUN npm link @polygon-nightfall/common-files
+          cd ..
 
       - name: Start Containers with ganache
         run: |

--- a/docker/admin.Dockerfile
+++ b/docker/admin.Dockerfile
@@ -15,6 +15,7 @@ RUN npm link
 
 
 WORKDIR /app/cli
+RUN npm link @polygon-nightfall/common-files
 RUN npm ci
 
 WORKDIR /app/admin
@@ -24,6 +25,7 @@ COPY nightfall-administrator/docker-entrypoint.sh nightfall-administrator/packag
 
 RUN npm link @polygon-nightfall/common-files
 RUN npm ci
+
 COPY common-files/classes node_modules/@polygon-nightfall/common-files/classes
 COPY common-files/utils node_modules/@polygon-nightfall/common-files/utils
 COPY common-files/constants node_modules/@polygon-nightfall/common-files/constants

--- a/docker/client.Dockerfile
+++ b/docker/client.Dockerfile
@@ -22,6 +22,7 @@ COPY nightfall-client/docker-entrypoint.sh nightfall-client/package.json nightfa
 
 RUN npm link @polygon-nightfall/common-files
 RUN npm ci
+
 COPY common-files/classes node_modules/@polygon-nightfall/common-files/classes
 COPY common-files/utils node_modules/@polygon-nightfall/common-files/utils
 COPY common-files/constants node_modules/@polygon-nightfall/common-files/constants

--- a/docker/deployer.Dockerfile
+++ b/docker/deployer.Dockerfile
@@ -24,6 +24,7 @@ COPY nightfall-deployer/entrypoint.sh entrypoint.sh
 
 RUN npm link @polygon-nightfall/common-files
 RUN npm ci
+
 COPY common-files/classes node_modules/@polygon-nightfall/common-files/classes
 COPY common-files/utils node_modules/@polygon-nightfall/common-files/utils
 COPY common-files/constants node_modules/@polygon-nightfall/common-files/constants

--- a/docker/optimist.Dockerfile
+++ b/docker/optimist.Dockerfile
@@ -35,6 +35,7 @@ COPY --from=builder /app/ZoKrates/target/release/zokrates /app/
 
 RUN npm link @polygon-nightfall/common-files
 RUN npm ci
+
 COPY common-files/classes node_modules/@polygon-nightfall/common-files/classes
 COPY common-files/utils node_modules/@polygon-nightfall/common-files/utils
 COPY common-files/constants node_modules/@polygon-nightfall/common-files/constants

--- a/docker/proposer.Dockerfile
+++ b/docker/proposer.Dockerfile
@@ -27,6 +27,7 @@ COPY config config
 
 RUN npm link @polygon-nightfall/common-files
 RUN npm ci
+
 COPY common-files/classes node_modules/@polygon-nightfall/common-files/classes
 COPY common-files/utils node_modules/@polygon-nightfall/common-files/utils
 COPY common-files/constants node_modules/@polygon-nightfall/common-files/constants

--- a/docker/proposer.Dockerfile
+++ b/docker/proposer.Dockerfile
@@ -16,6 +16,7 @@ RUN npm ci
 RUN npm link
 
 WORKDIR /app/cli
+RUN npm link @polygon-nightfall/common-files
 RUN npm ci
 
 WORKDIR /app

--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -32,6 +32,7 @@ COPY ./zokrates-worker/start-dev ./start-dev
 
 RUN npm link @polygon-nightfall/common-files
 RUN npm ci
+
 COPY common-files/classes node_modules/@polygon-nightfall/common-files/classes
 COPY common-files/utils node_modules/@polygon-nightfall/common-files/utils
 COPY common-files/constants node_modules/@polygon-nightfall/common-files/constants


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Adds missing `npm link` instructions to Github Actions pipeline.

## Does this close any currently open issues?
No

## What commands can I run to test the change? 
No, but GA pipeline should work as expected

## Any other comments?
No
