### PR TITLE
Add ALWAYS_DO_TRUSTED_SETUP to deployer container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       ZOKRATES_WORKER_HOST: ${ZOKRATES_WORKER_HOST:-worker}
       USE_STUBS: ${USE_STUBS:-false}
       WHITELISTING: ${WHITELISTING}
+      ALWAYS_DO_TRUSTED_SETUP: ${ALWAYS_DO_TRUSTED_SETUP}
 
   hosted-utils-api-server:
     build:


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
env variable `ALWAYS_DO_TRUSTED_SETUP` forces to do a trusted setup. This variable needs to be passed to the deployer container.

## Does this close any currently open issues?
No

## What commands can I run to test the change? 

## Any other comments?

