### PR TITLE
Test optimist resync with non empty dB

### DIFF
--- a/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
+++ b/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
@@ -68,7 +68,9 @@ async function transactionSubmittedEventHandler(eventParams) {
     transaction = await checkAlreadyInBlock(transaction);
     // save transaction if not in block
     if (fromBlockProposer) {
-      saveTransaction({ ...transaction });
+      saveTransaction({ ...transaction }).catch(function (err) {
+        logger.error(err);
+      });
     }
 
     await checkTransaction(transaction, true);
@@ -76,7 +78,9 @@ async function transactionSubmittedEventHandler(eventParams) {
 
     // save it
     if (!fromBlockProposer) {
-      saveTransaction({ ...transaction });
+      saveTransaction({ ...transaction }).catch(function (err) {
+        logger.error(err);
+      });
     }
   } catch (err) {
     if (err instanceof TransactionError) {

--- a/test/optimist-resync.test.mjs
+++ b/test/optimist-resync.test.mjs
@@ -125,6 +125,10 @@ describe('Optimist synchronisation tests', () => {
           logger.debug(`Retrying dropping MongoDB blocks colection`);
           await waitForTimeout(2000);
         }
+        while (!(await mongoConn.db('optimist_data').collection('timber').drop())) {
+          logger.debug(`Retrying dropping MongoDB timber colection`);
+          await waitForTimeout(2000);
+        }
 
         logger.debug(`Optimist's Mongo blocks dropped successfuly!`);
       } finally {
@@ -173,6 +177,7 @@ describe('Optimist synchronisation tests', () => {
 
       // we need to remind optimist which proposer it's connected to
       await nf3Proposer1.registerProposer('http://optimist', MINIMUM_STAKE);
+      await waitForTimeout(5000);
       // TODO - get optimist to do this automatically.
       // Now we'll add another block and check that it's blocknumber is correct, indicating
       // that a resync correctly occured

--- a/test/optimist-resync.test.mjs
+++ b/test/optimist-resync.test.mjs
@@ -115,12 +115,32 @@ describe('Optimist synchronisation tests', () => {
       }
     };
 
+    const dropOptimistMongoBlocksCollection = async () => {
+      logger.debug(`Dropping Optimist's Mongo collection`);
+      let mongoConn;
+      try {
+        mongoConn = await mongo.connection('mongodb://localhost:27017');
+
+        while (!(await mongoConn.db('optimist_data').collection('blocks').drop())) {
+          logger.debug(`Retrying dropping MongoDB blocks colection`);
+          await waitForTimeout(2000);
+        }
+
+        logger.debug(`Optimist's Mongo blocks dropped successfuly!`);
+      } finally {
+        mongo.disconnect();
+      }
+    };
+
     async function restartOptimist(dropDb = true) {
       await compose.stopOne('optimist', options);
       await compose.rm(options, 'optimist');
 
+      // dropDb vs dropCollection.
       if (dropDb) {
         await dropOptimistMongoDatabase();
+      } else {
+        await dropOptimistMongoBlocksCollection();
       }
 
       await compose.upOne('optimist', options);

--- a/test/optimist-resync.test.mjs
+++ b/test/optimist-resync.test.mjs
@@ -168,6 +168,7 @@ describe('Optimist synchronisation tests', () => {
       // we still need to clean the 'BlockProposed' event from the  test logs though.
       ({ eventLogs } = await web3Client.waitForEvent(eventLogs, ['blockProposed']));
       // Now we have a block, let's force Optimist to re-sync by turning it off and on again!
+      await waitForTimeout(5000);
       await restartOptimist(false);
 
       // we need to remind optimist which proposer it's connected to


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Added additional test case to optimist-sync test where we restart optimist without dropping the Db. This is testing what issue https://github.com/EYBlockchain/nightfall_3/issues/1077 reports.

## Does this close any currently open issues?
#1077 and #1051

## What commands can I run to test the change? 
GHA test (resync tests)

## Any other comments?

