### PR TITLE
fix: assembly code bug

### DIFF
--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -194,7 +194,7 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Config {
                         call(
                             // Call getTransactionEscrowed function to see if funds has been deposited
                             gas(),
-                            shieldAddress.slot, //To addr
+                            sload(shieldAddress.slot), //To addr
                             0, //No value
                             x, //Inputs are stored at location x
                             0x24, //Inputs are 36 bytes long


### PR DESCRIPTION
Currently, there is a bug in the proposeBlock function when checking that a deposit was escrowed. The function wasn't properly called, but the memory location it was checking also passed the checked and hence it wasn't detected.

