### PR TITLE
feat: Open debugger ports on client, optimist and hosted-utils-api-server

### DIFF
--- a/docker/client.Dockerfile
+++ b/docker/client.Dockerfile
@@ -3,7 +3,7 @@ FROM node:16.17
 RUN apt-get update -y
 RUN apt-get install -y netcat
 
-EXPOSE 80
+EXPOSE 80 9229
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -34,6 +34,9 @@ services:
       - type: bind
         source: ../config/default.js
         target: /config/default.js
+    ports:
+      - 9239:9229
+    command: ['npm', 'run', 'start:debug']
 
   deployer:
     build:
@@ -79,6 +82,9 @@ services:
       - type: bind
         source: ../config/default.js
         target: /app/config/default.js
+    ports:
+      - 9229:9229
+    command: ['npm', 'run', 'start:debug']
 
   worker:
     build:
@@ -100,4 +106,9 @@ services:
     ports:
       # to use with postman and etc
       - 8091:80
-    entrypoint: [ "npm", "run", "start" ]
+    entrypoint: ['npm', 'run', 'start']
+
+  hosted-utils-api-server:
+    ports:
+      - 9249:9229
+    command: ['npm', 'run', 'start:debug']

--- a/docker/optimist.Dockerfile
+++ b/docker/optimist.Dockerfile
@@ -13,9 +13,7 @@ RUN apt-get install -y libgmpxx4ldbl libgmp3-dev
 ENV ZOKRATES_HOME /app
 ENV ZOKRATES_STDLIB /app/stdlib
 
-EXPOSE 80
-# websocket port 8080
-EXPOSE 8080
+EXPOSE 80 8080 9229
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
 

--- a/hosted-utils-api-server/Dockerfile
+++ b/hosted-utils-api-server/Dockerfile
@@ -11,6 +11,8 @@ COPY entrypoint.sh entrypoint.sh
 
 RUN npm ci
 
+EXPOSE 80 9229
+
 ENTRYPOINT ["/app/entrypoint.sh"]
 
 CMD ["npm", "start"]

--- a/hosted-utils-api-server/package.json
+++ b/hosted-utils-api-server/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.mjs",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node src/index.mjs"
+    "start": "node src/index.mjs",
+    "start:debug": "node --inspect=0.0.0.0:9229 src/index.mjs"
   },
   "author": "“Liju <“liju.jose@gds.ey.com”>",
   "license": "CC0-1.0",

--- a/nightfall-client/package.json
+++ b/nightfall-client/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.mjs",
   "scripts": {
     "start": "node src/index.mjs",
+    "start:debug": "node --inspect=0.0.0.0:9229 src/index.mjs",
     "dev": "nodemon src/index.mjs"
   },
   "repository": {

--- a/nightfall-optimist/package.json
+++ b/nightfall-optimist/package.json
@@ -5,6 +5,7 @@
   "main": "index.mjs",
   "scripts": {
     "start": "node src/index.mjs",
+    "start:debug": "node --inspect=0.0.0.0:9229 src/index.mjs",
     "dev": "nodemon src/index.mjs"
   },
   "repository": {


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

This PR enables debugging on dev env. This is going to help a lot with local debugging. Chromium debugger, VSCode and probably plenty other tools can now hook into ports to enable local debugging. Ports to debug individual services listed below:

- `9229` - nightfall-optimist
- `9239` - nightfall-client
- `9249` - hosted-utils-api-server

Because we already have some VSCode specific configuration in our repo, I allowed myself to add debugger configurations for individual services (`./vscode/launch.json`).