### PR TITLE
Transaction Structure optimization

### DIFF
--- a/.github/workflows/on-pull-request-master.yml
+++ b/.github/workflows/on-pull-request-master.yml
@@ -2,7 +2,7 @@ name: Check PR
 
 on:
   pull_request:
-    branches: [master, tokenisation-l2]
+    branches: [master, tokenisation-l2, RogerTaule/circuitHash]
 
 jobs:
   dependency-review:

--- a/config/default.js
+++ b/config/default.js
@@ -495,12 +495,12 @@ module.exports = {
   SIGNATURES: {
     BLOCK: '(uint48,address,bytes32,uint256,bytes32,bytes32, bytes32)',
     TRANSACTION:
-      '(uint112,uint96,uint40,uint8,uint64[],bytes32,bytes32,bytes32,bytes32[],bytes32[],bytes32[2],uint256[4])',
+      '(uint256,uint64[],bytes32,bytes32,bytes32,bytes32[],bytes32[],bytes32[2],uint256[4])',
     PROPOSE_BLOCK: [
       '(uint48,address,bytes32,uint256,bytes32,bytes32,bytes32)',
-      '(uint112,uint96,uint40,uint8,uint64[],bytes32,bytes32,bytes32,bytes32[],bytes32[],bytes32[2],uint256[4])[]',
+      '(uint256,uint64[],bytes32,bytes32,bytes32,bytes32[],bytes32[],bytes32[2],uint256[4])[]',
     ],
     SUBMIT_TRANSACTION:
-      '(uint112,uint96,uint40,uint8,uint64[],bytes32,bytes32,bytes32,bytes32[],bytes32[],bytes32[2],uint256[4])',
+      '(uint256,uint64[],bytes32,bytes32,bytes32,bytes32[],bytes32[],bytes32[2],uint256[4])',
   },
 };

--- a/nightfall-client/src/services/process-calldata.mjs
+++ b/nightfall-client/src/services/process-calldata.mjs
@@ -40,10 +40,7 @@ async function getProposeBlockCalldata(eventData) {
   };
   const transactions = transactionsData.map(t => {
     const [
-      value,
-      fee,
-      circuitHash,
-      tokenType,
+      packedInfo,
       historicRootBlockNumberL2,
       tokenId,
       ercAddress,
@@ -53,6 +50,9 @@ async function getProposeBlockCalldata(eventData) {
       compressedSecrets,
       proof,
     ] = t;
+
+    const { value, fee, circuitHash, tokenType } = Transaction.unpackInfo(packedInfo);
+
     const transaction = {
       value,
       fee,

--- a/nightfall-deployer/contracts/Challenges.sol
+++ b/nightfall-deployer/contracts/Challenges.sol
@@ -242,7 +242,7 @@ contract Challenges is Stateful, Config {
             transaction.transaction,
             extraPublicInputs,
             uncompressedProof,
-            state.getVerificationKey(transaction.transaction.circuitHash)
+            state.getVerificationKey(uint40(transaction.transaction.packedInfo >> 216))
         );
         challengeAccepted(transaction.blockL2);
     }

--- a/nightfall-deployer/contracts/Structures.sol
+++ b/nightfall-deployer/contracts/Structures.sol
@@ -44,10 +44,7 @@ contract Structures {
     // will hold default values for any specific tranaction, e.g. there are no
     // nullifiers for a Deposit transaction.
     struct Transaction {
-        uint112 value;
-        uint96 fee;
-        uint40 circuitHash;
-        TokenType tokenType;
+        uint256 packedInfo;
         uint64[] historicRootBlockNumberL2;
         bytes32 tokenId;
         bytes32 ercAddress;

--- a/nightfall-deployer/contracts/Utils.sol
+++ b/nightfall-deployer/contracts/Utils.sol
@@ -112,10 +112,10 @@ library Utils {
             ts.commitments.length;
         uint256[] memory inputs = new uint256[](transactionSlots);
         uint256 count = 0;
-        inputs[count++] = uint256(ts.value);
-        inputs[count++] = uint256(ts.fee);
-        inputs[count++] = uint256(ts.circuitHash);
-        inputs[count++] = uint256(ts.tokenType);
+        inputs[count++] = uint256(uint112(ts.packedInfo >> 8));
+        inputs[count++] = uint256(uint96(ts.packedInfo >> 120));
+        inputs[count++] = uint256(uint40(ts.packedInfo >> 216));
+        inputs[count++] = uint256(uint8(ts.packedInfo));
         for (uint256 i = 0; i < ts.historicRootBlockNumberL2.length; ++i) {
             inputs[count++] = ts.historicRootBlockNumberL2[i];
         }

--- a/nightfall-optimist/src/services/process-calldata.mjs
+++ b/nightfall-optimist/src/services/process-calldata.mjs
@@ -42,10 +42,7 @@ export async function getProposeBlockCalldata(eventData) {
   };
   const transactions = transactionsData.map(t => {
     const [
-      value,
-      fee,
-      circuitHash,
-      tokenType,
+      packedInfo,
       historicRootBlockNumberL2,
       tokenId,
       ercAddress,
@@ -55,6 +52,9 @@ export async function getProposeBlockCalldata(eventData) {
       compressedSecrets,
       proof,
     ] = t;
+
+    const { value, fee, circuitHash, tokenType } = Transaction.unpackInfo(packedInfo);
+
     const transaction = {
       value,
       fee,
@@ -94,10 +94,7 @@ export async function getTransactionSubmittedCalldata(eventData) {
   const abiBytecode = `0x${tx.input.slice(10)}`;
   const transactionData = web3.eth.abi.decodeParameter(SIGNATURES.SUBMIT_TRANSACTION, abiBytecode);
   const [
-    value,
-    fee,
-    circuitHash,
-    tokenType,
+    packedInfo,
     historicRootBlockNumberL2,
     tokenId,
     ercAddress,
@@ -107,9 +104,12 @@ export async function getTransactionSubmittedCalldata(eventData) {
     compressedSecrets,
     proof,
   ] = transactionData;
+
+  const { value, fee, circuitHash, tokenType } = Transaction.unpackInfo(packedInfo);
+
   const transaction = {
-    fee,
     value,
+    fee,
     circuitHash,
     tokenType,
     historicRootBlockNumberL2,

--- a/test/unit/SmartContracts/shield.unit.test.mjs
+++ b/test/unit/SmartContracts/shield.unit.test.mjs
@@ -6,6 +6,7 @@ import {
   calculateBlockHash,
   calculateTransactionHash,
   createBlockAndTransactions,
+  packInfoTransaction,
 } from '../utils/utils.mjs';
 import { setAdvancedWithdrawal, setWhitelist } from '../utils/shieldStorage.mjs';
 import {
@@ -176,11 +177,11 @@ describe('Testing Shield Contract', function () {
         shieldAddress,
         '28948022309329048855892746252171976963317496166410141009864396001978282409986',
       );
+
+      const packedInfo = packInfoTransaction(0, 0, 0, 1);
+
       const depositTransactionERC721 = {
-        value: '0',
-        fee: '0',
-        circuitHash: '0',
-        tokenType: '1',
+        packedInfo,
         historicRootBlockNumberL2: [
           '0x0000000000000000000000000000000000000000000000000000000000000000',
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -226,11 +227,11 @@ describe('Testing Shield Contract', function () {
 
     it('succeeds and sets is Escrowed to true for a deposit transaction of an ERC1155 token', async function () {
       await Erc1155MockInstance.setApprovalForAll(shieldAddress, true);
+
+      const packedInfo = packInfoTransaction(5, 0, 0, 2);
+
       const depositTransactionERC1155 = {
-        value: '5',
-        fee: '0',
-        circuitHash: '0',
-        tokenType: '2',
+        packedInfo,
         historicRootBlockNumberL2: [
           '0x0000000000000000000000000000000000000000000000000000000000000000',
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -286,11 +287,10 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails to submit deposit transaction if fee > 0 and msg.value > 0 ', async function () {
+      const packedInfo = packInfoTransaction(10, 10, 0, 0);
+
       const depositTransactionInvalid = {
-        value: '10',
-        fee: '10',
-        circuitHash: '0',
-        tokenType: '0',
+        packedInfo,
         historicRootBlockNumberL2: [
           '0x0000000000000000000000000000000000000000000000000000000000000000',
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -329,11 +329,10 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails to submit deposit transaction if ercAddress is invalid', async function () {
+      const packedInfo = packInfoTransaction(10, 0, 0, 0);
+
       const depositTransactionInvalid = {
-        value: '10',
-        fee: '0',
-        circuitHash: '0',
-        tokenType: '0',
+        packedInfo,
         historicRootBlockNumberL2: [
           '0x0000000000000000000000000000000000000000000000000000000000000000',
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -375,11 +374,10 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails to submit deposit transaction if tokenType is ERC20 and tokenId not zero', async function () {
+      const packedInfo = packInfoTransaction(10, 0, 0, 0);
+
       const depositTransactionInvalid = {
-        value: '10',
-        fee: '0',
-        circuitHash: '0',
-        tokenType: '0',
+        packedInfo,
         historicRootBlockNumberL2: [
           '0x0000000000000000000000000000000000000000000000000000000000000000',
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -425,11 +423,9 @@ describe('Testing Shield Contract', function () {
 
     it('fails to submit deposit transaction if tokenType is ERC20 and trying to deposit more than allowed', async function () {
       await ShieldInstance.setRestriction(erc20MockAddress, '10000', '10000');
+      const packedInfo = packInfoTransaction(100000, 0, 0, 0);
       const depositTransactionInvalid = {
-        value: '100000',
-        fee: '0',
-        circuitHash: '0',
-        tokenType: '0',
+        packedInfo,
         historicRootBlockNumberL2: [
           '0x0000000000000000000000000000000000000000000000000000000000000000',
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -468,11 +464,10 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails to submit deposit transaction if tokenType is ERC721 and value is invalid', async function () {
+      const packedInfo = packInfoTransaction(1, 0, 0, 1);
+
       const depositTransactionInvalid = {
-        value: '1',
-        fee: '0',
-        circuitHash: '0',
-        tokenType: '1',
+        packedInfo,
         historicRootBlockNumberL2: [
           '0x0000000000000000000000000000000000000000000000000000000000000000',
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -511,11 +506,10 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if tokenType is unknown', async function () {
+      const packedInfo = packInfoTransaction(1, 0, 0, 5);
+
       const depositTransactionInvalid = {
-        value: '1',
-        fee: '0',
-        circuitHash: '0',
-        tokenType: '5',
+        packedInfo,
         historicRootBlockNumberL2: [
           '0x0000000000000000000000000000000000000000000000000000000000000000',
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -821,11 +815,10 @@ describe('Testing Shield Contract', function () {
 
     it('succeeds to finalise withdrawal for an ERC721 token', async function () {
       await Erc721MockInstance.awardItem(shieldAddress, `https://erc721mock/item-id.json`);
+      const packedInfo = packInfoTransaction(0, 0, 2, 1);
+
       const withdrawERC721 = {
-        value: '0',
-        fee: '0',
-        circuitHash: '2',
-        tokenType: '1',
+        packedInfo,
         historicRootBlockNumberL2: [
           '0x0000000000000000000000000000000000000000000000000000000000000009',
           '0x0000000000000000000000000000000000000000000000000000000000000002',
@@ -908,11 +901,10 @@ describe('Testing Shield Contract', function () {
 
     it('succeeds to finalise withdrawal for an ERC1155 token', async function () {
       await Erc1155MockInstance.safeTransferFrom(owner[0].address, shieldAddress, 1, 25, []);
+      const packedInfo = packInfoTransaction(25, 0, 2, 2);
+
       const withdrawERC1155 = {
-        value: '25',
-        fee: '0',
-        circuitHash: '2',
-        tokenType: '2',
+        packedInfo,
         historicRootBlockNumberL2: [
           '0x0000000000000000000000000000000000000000000000000000000000000009',
           '0x0000000000000000000000000000000000000000000000000000000000000002',
@@ -1031,11 +1023,10 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if ercAddress is invalid', async function () {
+      const packedInfo = packInfoTransaction(10, 0, 2, 0);
+
       const withdrawalTransactionInvalid = {
-        value: '10',
-        fee: '0',
-        circuitHash: '2',
-        tokenType: '0',
+        packedInfo,
         historicRootBlockNumberL2: [
           '0x0000000000000000000000000000000000000000000000000000000000000009',
           '0x0000000000000000000000000000000000000000000000000000000000000002',
@@ -1135,11 +1126,10 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails to finalise withdrawal if tokenType is ERC20 and tokenId not zero', async function () {
+      const packedInfo = packInfoTransaction(10, 0, 2, 0);
+
       const withdrawalTransactionInvalid = {
-        value: '10',
-        fee: '0',
-        circuitHash: '2',
-        tokenType: '0',
+        packedInfo,
         historicRootBlockNumberL2: [
           '0x0000000000000000000000000000000000000000000000000000000000000009',
           '0x0000000000000000000000000000000000000000000000000000000000000002',
@@ -1211,11 +1201,10 @@ describe('Testing Shield Contract', function () {
 
     it('fails to finalise withdrawal if tokenType is ERC20 and trying to withdraw more than allowed', async function () {
       await ShieldInstance.setRestriction(erc20MockAddress, '10000', '10000');
+      const packedInfo = packInfoTransaction(100000000, 0, 2, 0);
+
       const withdrawalTransactionInvalid = {
-        value: '100000000',
-        fee: '0',
-        circuitHash: '2',
-        tokenType: '0',
+        packedInfo,
         historicRootBlockNumberL2: [
           '0x0000000000000000000000000000000000000000000000000000000000000009',
           '0x0000000000000000000000000000000000000000000000000000000000000002',
@@ -1286,11 +1275,10 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails to finalise withdrawal if tokenType is ERC721 and value is invalid', async function () {
+      const packedInfo = packInfoTransaction(5, 0, 2, 1);
+
       const withdrawalTransactionInvalid = {
-        value: '5',
-        fee: '0',
-        circuitHash: '2',
-        tokenType: '1',
+        packedInfo,
         historicRootBlockNumberL2: [
           '0x0000000000000000000000000000000000000000000000000000000000000009',
           '0x0000000000000000000000000000000000000000000000000000000000000002',
@@ -1360,11 +1348,10 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails to finalise withdrawal if tokenType is unknown', async function () {
+      const packedInfo = packInfoTransaction(5, 0, 2, 5);
+
       const withdrawalTransactionInvalid = {
-        value: '5',
-        fee: '0',
-        circuitHash: '2',
-        tokenType: '5',
+        packedInfo,
         historicRootBlockNumberL2: [
           '0x0000000000000000000000000000000000000000000000000000000000000009',
           '0x0000000000000000000000000000000000000000000000000000000000000002',
@@ -1598,11 +1585,10 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if trying to advance withdraw for a non ERC 20 token', async function () {
+      const packedInfo = packInfoTransaction(10, 0, 2, 1);
+
       const withdrawTransactionERC721 = {
-        value: '10',
-        fee: '0',
-        circuitHash: '2',
-        tokenType: '1',
+        packedInfo,
         historicRootBlockNumberL2: [
           '0x0000000000000000000000000000000000000000000000000000000000000000',
           '0x0000000000000000000000000000000000000000000000000000000000000000',

--- a/test/unit/SmartContracts/state.unit.test.mjs
+++ b/test/unit/SmartContracts/state.unit.test.mjs
@@ -1,6 +1,10 @@
 import { expect } from 'chai';
 import hardhat from 'hardhat';
-import { calculateTransactionHash, createBlockAndTransactions } from '../utils/utils.mjs';
+import {
+  calculateTransactionHash,
+  createBlockAndTransactions,
+  packInfoTransaction,
+} from '../utils/utils.mjs';
 import { setTransactionInfo } from '../utils/stateStorage.mjs';
 
 const { ethers, upgrades } = hardhat;
@@ -972,12 +976,9 @@ describe('State contract State functions', function () {
       frontierHash: '0xa2f1ec04a89542d6f1e04449398052422c7b1057df8606db047f48047bb7ab72',
       transactionHashesRoot: '0x0487da81cb1d53536928de44fa55de0accf9a8bc9f42739a80f69584970d572f',
     };
-
+    const packedInfo = packInfoTransaction(100000000000000, 10, 0, 0);
     const transaction1 = {
-      value: '100000000000000',
-      fee: '10',
-      circuitHash: '0',
-      tokenType: '0',
+      packedInfo,
       historicRootBlockNumberL2: [
         '0x0000000000000000000000000000000000000000000000000000000000000000',
         '0x0000000000000000000000000000000000000000000000000000000000000000',

--- a/test/unit/utils/utils.mjs
+++ b/test/unit/utils/utils.mjs
@@ -20,13 +20,21 @@ export function calculateBlockHash(b) {
   return ethers.utils.keccak256(encodedBlock);
 }
 
+export function packInfoTransaction(value, fee, circuitHash, tokenType) {
+  return ethers.utils.hexValue(
+    ethers.utils.concat([
+      ethers.utils.hexZeroPad(ethers.utils.hexlify(circuitHash), 5),
+      ethers.utils.hexZeroPad(ethers.utils.hexlify(fee), 12),
+      ethers.utils.hexZeroPad(ethers.utils.hexlify(value), 14),
+      ethers.utils.hexZeroPad(ethers.utils.hexlify(tokenType), 1),
+    ]),
+  );
+}
+
 export function calculateTransactionHash(tx) {
   const encodedTx = ethers.utils.defaultAbiCoder.encode(
     [
-      'uint112',
-      'uint96',
-      'uint40',
-      'uint8',
+      'uint256',
       'uint64[]',
       'bytes32',
       'bytes32',
@@ -37,10 +45,7 @@ export function calculateTransactionHash(tx) {
       'uint256[4]',
     ],
     [
-      tx.value,
-      tx.fee,
-      tx.circuitHash,
-      tx.tokenType,
+      tx.packedInfo,
       tx.historicRootBlockNumberL2,
       tx.tokenId,
       tx.ercAddress,
@@ -57,11 +62,10 @@ export function calculateTransactionHash(tx) {
 }
 
 export function createBlockAndTransactions(erc20MockAddress, ownerAddress) {
+  const packedInfoWithdraw = packInfoTransaction(10, 1, 2, 0);
+
   const withdrawTransaction = {
-    value: '10',
-    fee: '1',
-    circuitHash: '2',
-    tokenType: '0',
+    packedInfo: packedInfoWithdraw,
     historicRootBlockNumberL2: [
       '0x0000000000000000000000000000000000000000000000000000000000000009',
       '0x0000000000000000000000000000000000000000000000000000000000000002',
@@ -93,11 +97,10 @@ export function createBlockAndTransactions(erc20MockAddress, ownerAddress) {
     ],
   };
 
+  const packedInfoDeposit = packInfoTransaction(10, 0, 0, 0);
+
   const depositTransaction = {
-    value: '10',
-    fee: '0',
-    circuitHash: '0',
-    tokenType: '0',
+    packedInfo: packedInfoDeposit,
     historicRootBlockNumberL2: [],
     tokenId: '0x0000000000000000000000000000000000000000000000000000000000000000',
     ercAddress: ethers.utils.hexZeroPad(erc20MockAddress, 32),

--- a/wallet/src/common-files/classes/transaction.js
+++ b/wallet/src/common-files/classes/transaction.js
@@ -22,6 +22,15 @@ const arrayEquality = (as, bs) => {
   return false;
 };
 
+const packInfo = (value, fee, circuitHash, tokenType) => {
+  const valuePacked = generalise(value).hex(14).slice(2);
+  const feePacked = generalise(fee).hex(12).slice(2);
+  const circuitHashPacked = generalise(circuitHash).hex(5).slice(2);
+  const tokenTypePacked = generalise(tokenType).hex(1).slice(2);
+
+  return '0x'.concat(circuitHashPacked, feePacked, valuePacked, tokenTypePacked);
+};
+
 // function to compute the keccak hash of a transaction
 function keccak(preimage) {
   const web3 = Web3.connection();
@@ -40,11 +49,11 @@ function keccak(preimage) {
   } = preimage;
   let { proof } = preimage;
   proof = arrayEquality(proof, [0, 0, 0, 0, 0, 0, 0, 0]) ? [0, 0, 0, 0] : compressProof(proof);
+
+  const packedInfo = packInfo(value, fee, circuitHash, tokenType);
+
   const transaction = [
-    value,
-    fee,
-    circuitHash,
-    tokenType,
+    packedInfo,
     historicRootBlockNumberL2,
     tokenId,
     ercAddress,
@@ -131,6 +140,17 @@ class Transaction {
     return transactionHash;
   }
 
+  static unpackInfo(packedInfo) {
+    const packedInfoHex = generalise(packedInfo).hex(32).slice(2);
+
+    const circuitHash = generalise(`0x${packedInfoHex.slice(0, 10)}`).hex(5);
+    const fee = generalise(`0x${packedInfoHex.slice(10, 34)}`).hex(12);
+    const value = generalise(`0x${packedInfoHex.slice(34, 62)}`).hex(14);
+    const tokenType = generalise(`0x${packedInfoHex.slice(62, 64)}`).hex(1);
+
+    return { value, fee, circuitHash, tokenType };
+  }
+
   static buildSolidityStruct(transaction) {
     // return a version without properties that are not sent to the blockchain
     const {
@@ -147,11 +167,11 @@ class Transaction {
       compressedSecrets,
       proof,
     } = transaction;
+
+    const packedInfo = packInfo(value, fee, circuitHash, tokenType);
+
     return {
-      value,
-      fee,
-      circuitHash,
-      tokenType,
+      packedInfo,
       historicRootBlockNumberL2,
       tokenId,
       ercAddress,

--- a/wallet/src/nightfall-browser/services/process-calldata.js
+++ b/wallet/src/nightfall-browser/services/process-calldata.js
@@ -32,10 +32,7 @@ async function getProposeBlockCalldata(eventData) {
   };
   const transactions = transactionsData.map(t => {
     const [
-      value,
-      fee,
-      circuitHash,
-      tokenType,
+      packedInfo,
       historicRootBlockNumberL2,
       tokenId,
       ercAddress,
@@ -45,6 +42,9 @@ async function getProposeBlockCalldata(eventData) {
       compressedSecrets,
       proof,
     ] = t;
+
+    const { value, fee, circuitHash, tokenType } = Transaction.unpackInfo(packedInfo);
+
     const transaction = {
       value,
       fee,


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
This PR optimizes the transaction struct by storing value (uint112), fee (uint96), circuitHash(uint40) and tokenType(uint8) in a single uint256 slot. This should reduce the gas used per transaction in proposeBlock by around 1500 gas. This also reduces the cost of the calldata by around a 10 - 15 % whenever the transaction struct is passed.
## Does this close any currently open issues?
Yes, it closes #1174 
## What commands can I run to test the change? 
It is enough if all the tests go through
## Any other comments?

