### PR TITLE
Get minimum and block stake from the blockchain

### DIFF
--- a/apps/proposer/config/default.js
+++ b/apps/proposer/config/default.js
@@ -11,5 +11,4 @@ module.exports = {
   BLOCKCHAIN_WS_HOST: process.env.BLOCKCHAIN_WS_HOST || 'localhost',
   BLOCKCHAIN_PORT: process.env.BLOCKCHAIN_PORT || 8546,
   BLOCKCHAIN_PATH: process.env.BLOCKCHAIN_PATH || '',
-  MINIMUM_STAKE: process.env.MINIMUM_STAKE || 100,
 };

--- a/apps/proposer/src/proposer.mjs
+++ b/apps/proposer/src/proposer.mjs
@@ -2,10 +2,8 @@
 /**
 Module that runs up as a proposer
 */
-import config from 'config';
 import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
 
-const { MINIMUM_STAKE } = config.TEST_OPTIONS;
 /**
 Does the preliminary setup and starts listening on the websocket
 */
@@ -19,7 +17,7 @@ export default async function startProposer(nf3, proposerBaseUrl) {
   else throw new Error('Healthcheck failed');
   logger.info('Attempting to register proposer');
 
-  await nf3.registerProposer(proposerBaseUrl, MINIMUM_STAKE);
+  await nf3.registerProposer(proposerBaseUrl, await nf3.getMinimumStake());
   logger.debug('Proposer healthcheck up');
 
   // TODO subscribe to layer 1 blocks and call change proposer

--- a/cli/lib/constants.mjs
+++ b/cli/lib/constants.mjs
@@ -16,8 +16,6 @@ export const APPROVE_AMOUNT =
 
 export const DEFAULT_FEE_ETH = 10;
 export const DEFAULT_FEE_MATIC = 10;
-export const DEFAULT_PROPOSER_BOND = 10;
-export const DEFAULT_BLOCK_STAKE = 1;
 
 export const WEBSOCKET_PING_TIME = 15000;
 

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -12,8 +12,6 @@ import erc721 from './abis/ERC721.mjs';
 import erc1155 from './abis/ERC1155.mjs';
 
 import {
-  DEFAULT_BLOCK_STAKE,
-  DEFAULT_PROPOSER_BOND,
   DEFAULT_FEE_ETH,
   DEFAULT_FEE_MATIC,
   WEBSOCKET_PING_TIME,
@@ -65,6 +63,8 @@ class Nf3 {
 
   stateContractAddress;
 
+  stateContract;
+
   ethereumSigningKey;
 
   ethereumAddress;
@@ -74,10 +74,6 @@ class Nf3 {
   defaultFeeEth = DEFAULT_FEE_ETH;
 
   defaultFeeMatic = DEFAULT_FEE_MATIC;
-
-  PROPOSER_BOND = DEFAULT_PROPOSER_BOND;
-
-  BLOCK_STAKE = DEFAULT_BLOCK_STAKE;
 
   latestWithdrawHash;
 
@@ -121,12 +117,15 @@ class Nf3 {
     switch (contractAddressProvider) {
       case undefined:
         this.contractGetter = this.getContractAddress;
+        this.contractAbiGetter = this.getContractAbi;
         break;
       case 'client':
         this.contractGetter = this.getContractAddress;
+        this.contractAbiGetter = this.getContractAbi;
         break;
       case 'optimist':
         this.contractGetter = this.getContractAddressOptimist;
+        this.contractAbiGetter = this.getContractAbiOptimist;
         break;
       default:
         throw new Error('Unknown contract address server');
@@ -136,6 +135,8 @@ class Nf3 {
     this.proposersContractAddress = await this.contractGetter('Proposers');
     this.challengesContractAddress = await this.contractGetter('Challenges');
     this.stateContractAddress = await this.contractGetter('State');
+    this.stateContract = await this.getContractInstance('State');
+
     // set the ethereumAddress iff we have a signing key
     if (typeof this.ethereumSigningKey === 'string') {
       this.ethereumAddress = await this.getAccounts();
@@ -144,6 +145,18 @@ class Nf3 {
     if (typeof mnemonic !== 'undefined') {
       await this.setZkpKeysFromMnemonic(mnemonic, 0);
     }
+  }
+
+  /**
+    Get contract instance.
+    @method
+    @param {string} contractName - name of the contract instance to get.
+    */
+  async getContractInstance(contractName) {
+    const abi = await this.contractAbiGetter(contractName);
+    const contractAddress = await this.contractGetter(contractName);
+    const contractInstance = new this.web3.eth.Contract(abi, contractAddress);
+    return contractInstance;
   }
 
   /**
@@ -389,6 +402,19 @@ class Nf3 {
     */
   async getContractAbi(contractName) {
     const res = await axios.get(`${this.clientBaseUrl}/contract-abi/${contractName}`);
+    return res.data.abi;
+  }
+
+  /**
+    Returns the abi of a Nightfall_3 contract calling the optimist.
+    @method
+    @async
+    @param {string} contractName - the name of the smart contract in question. Possible
+    values are 'Shield', 'State', 'Proposers', 'Challengers'.
+    @returns {Promise} Resolves into the Ethereum ABI of the contract
+  */
+  async getContractAbiOptimist(contractName) {
+    const res = await axios.get(`${this.optimistBaseUrl}/contract-abi/${contractName}`);
     return res.data.abi;
   }
 
@@ -954,6 +980,26 @@ class Nf3 {
   }
 
   /**
+    Get block stake
+    @method
+    @async
+    @returns {array} A promise that resolves to the Ethereum call.
+    */
+  async getBlockStake() {
+    return this.stateContract.methods.getBlockStake().call();
+  }
+
+  /**
+      Get minimum stake
+      @method
+      @async
+      @returns {array} A promise that resolves to the Ethereum call.
+      */
+  async getMinimumStake() {
+    return this.stateContract.methods.getMinimumStake().call();
+  }
+
+  /**
     Starts a Proposer that listens for blocks and submits block proposal
     transactions to the blockchain.
     @method
@@ -990,7 +1036,7 @@ class Nf3 {
         const tx = await this._signTransaction(
           txDataToSign,
           this.stateContractAddress,
-          this.BLOCK_STAKE,
+          await this.getBlockStake(), // the block stake could have changed, so we get it from the blockchain
         );
         proposerQueue.push(async () => {
           try {

--- a/config/default.js
+++ b/config/default.js
@@ -195,8 +195,6 @@ module.exports = {
     gas: 10000000,
     gasCosts: 80000000000000000,
     fee: 1,
-    BLOCK_STAKE: 1, // 1 wei
-    MINIMUM_STAKE: process.env.MINIMUM_STAKE || 1000000, // 1000000 wei
     ROTATE_PROPOSER_BLOCKS: 20,
     txPerBlock: process.env.TRANSACTIONS_PER_BLOCK || 2,
     signingKeys: {

--- a/doc/lib/nf3.mjs.html
+++ b/doc/lib/nf3.mjs.html
@@ -32,8 +32,6 @@ import erc721 from './abis/ERC721.mjs';
 import erc1155 from './abis/ERC1155.mjs';
 
 import {
-  DEFAULT_BLOCK_STAKE,
-  DEFAULT_PROPOSER_BOND,
   DEFAULT_FEE,
   WEBSOCKET_PING_TIME,
   GAS_MULTIPLIER,
@@ -93,11 +91,6 @@ class Nf3 {
   defaultFeeEth = DEFAULT_FEE_ETH;
 
   defaultFeeMatic = DEFAULT_FEE_MATIC;
-
-
-  PROPOSER_BOND = DEFAULT_PROPOSER_BOND;
-
-  BLOCK_STAKE = DEFAULT_BLOCK_STAKE;
 
   // nonce = 0;
 

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -24,7 +24,6 @@ chai.use(chaiHttp);
 chai.use(chaiAsPromised);
 
 const { TRANSACTIONS_PER_BLOCK } = config;
-const { MINIMUM_STAKE } = config.TEST_OPTIONS;
 const TX_WAIT = 12000;
 const TEST_LENGTH = 3;
 
@@ -101,7 +100,10 @@ describe('Testing with an adversary', () => {
     startBalance = await retrieveL2Balance(nf3User);
 
     // Proposer registration
-    await nf3AdversarialProposer.registerProposer('http://optimist', MINIMUM_STAKE);
+    await nf3AdversarialProposer.registerProposer(
+      'http://optimist',
+      await nf3AdversarialProposer.getMinimumStake(),
+    );
     // Proposer listening for incoming events
     const blockProposeEmitter = await nf3AdversarialProposer.startProposer();
     blockProposeEmitter

--- a/test/circuits.test.mjs
+++ b/test/circuits.test.mjs
@@ -19,7 +19,6 @@ const {
   tokenConfigs: { tokenType, tokenId },
   mnemonics,
   signingKeys,
-  MINIMUM_STAKE,
 } = config.TEST_OPTIONS;
 
 const nf3Users = [new Nf3(signingKeys.user1, environment), new Nf3(signingKeys.user2, environment)];
@@ -41,7 +40,7 @@ describe('General Circuit Test', () => {
   before(async () => {
     await nf3Proposer.init(mnemonics.proposer);
     // we must set the URL from the point of view of the client container
-    await nf3Proposer.registerProposer('http://optimist', MINIMUM_STAKE);
+    await nf3Proposer.registerProposer('http://optimist', await nf3Proposer.getMinimumStake());
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer.startProposer();

--- a/test/e2e/tokens/erc1155.test.mjs
+++ b/test/e2e/tokens/erc1155.test.mjs
@@ -24,7 +24,6 @@ const {
   tokenConfigs: { tokenTypeERC1155, tokenType, tokenId },
   mnemonics,
   signingKeys,
-  MINIMUM_STAKE,
 } = config.TEST_OPTIONS;
 
 const nf3Users = [new Nf3(signingKeys.user1, environment), new Nf3(signingKeys.user2, environment)];
@@ -56,7 +55,7 @@ const emptyL2 = async () => {
 describe('ERC1155 tests', () => {
   before(async () => {
     await nf3Proposer1.init(mnemonics.proposer);
-    await nf3Proposer1.registerProposer('http://optimist', MINIMUM_STAKE);
+    await nf3Proposer1.registerProposer('http://optimist', await nf3Proposer1.getMinimumStake());
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer1.startProposer();

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -28,7 +28,6 @@ const {
   mnemonics,
   signingKeys,
   restrictions: { erc20default },
-  MINIMUM_STAKE,
 } = config.TEST_OPTIONS;
 
 const {
@@ -73,7 +72,7 @@ describe('ERC20 tests', () => {
   before(async () => {
     await nf3Proposer.init(mnemonics.proposer);
     // we must set the URL from the point of view of the client container
-    await nf3Proposer.registerProposer('http://optimist', MINIMUM_STAKE);
+    await nf3Proposer.registerProposer('http://optimist', await nf3Proposer.getMinimumStake());
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer.startProposer();
@@ -133,8 +132,6 @@ describe('ERC20 tests', () => {
 
       await emptyL2();
 
-      // stateBalance += fee * txPerBlock + BLOCK_STAKE;
-
       const afterBalances = await getBalances();
 
       expect(afterBalances[0] - beforeBalances[0]).to.be.equal(-(transferValue + fee));
@@ -158,8 +155,6 @@ describe('ERC20 tests', () => {
       logger.debug(`Gas used was ${Number(res.gasUsed)}`);
 
       const after = (await nf3Users[0].getLayer2Balances())[erc20Address][0].balance;
-
-      // stateBalance += fee * txPerBlock + BLOCK_STAKE;
       expect(after - before).to.be.equal(-fee);
     });
   });

--- a/test/e2e/tokens/erc721.test.mjs
+++ b/test/e2e/tokens/erc721.test.mjs
@@ -22,7 +22,6 @@ const {
   tokenConfigs: { tokenTypeERC721, tokenType, tokenId },
   mnemonics,
   signingKeys,
-  MINIMUM_STAKE,
 } = config.TEST_OPTIONS;
 
 const nf3Users = [new Nf3(signingKeys.user1, environment), new Nf3(signingKeys.user2, environment)];
@@ -60,7 +59,7 @@ const emptyL2 = async () => {
 describe('ERC721 tests', () => {
   before(async () => {
     await nf3Proposer1.init(mnemonics.proposer);
-    await nf3Proposer1.registerProposer('http://optimist', MINIMUM_STAKE);
+    await nf3Proposer1.registerProposer('http://optimist', await nf3Proposer1.getMinimumStake());
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer1.startProposer();

--- a/test/gas.test.mjs
+++ b/test/gas.test.mjs
@@ -26,7 +26,6 @@ const {
   tokenConfigs: { tokenType, tokenId },
   mnemonics,
   signingKeys,
-  MINIMUM_STAKE,
 } = config.TEST_OPTIONS;
 
 const txPerBlock = process.env.TRANSACTIONS_PER_BLOCK || 32;
@@ -47,7 +46,7 @@ describe('Gas test', () => {
   let gasCost = 0;
   before(async () => {
     await nf3Proposer1.init(mnemonics.proposer);
-    await nf3Proposer1.registerProposer('http://optimist', MINIMUM_STAKE);
+    await nf3Proposer1.registerProposer('http://optimist', await nf3Proposer1.getMinimumStake());
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer1.startProposer();

--- a/test/kyc.test.mjs
+++ b/test/kyc.test.mjs
@@ -21,7 +21,6 @@ const {
   tokenConfigs: { tokenType, tokenId },
   mnemonics,
   signingKeys,
-  MINIMUM_STAKE,
 } = config.TEST_OPTIONS;
 
 const nf3Users = [new Nf3(signingKeys.user1, environment), new Nf3(signingKeys.user2, environment)];
@@ -37,7 +36,7 @@ describe('KYC tests', () => {
   before(async () => {
     await nf3Proposer.init(mnemonics.proposer);
     // we must set the URL from the point of view of the client container
-    await nf3Proposer.registerProposer('http://optimist', MINIMUM_STAKE);
+    await nf3Proposer.registerProposer('http://optimist', await nf3Proposer.getMinimumStake());
 
     // Proposer listening for incoming events
     const newGasBlockEmitter = await nf3Proposer.startProposer();

--- a/test/multisig/administrator.test.mjs
+++ b/test/multisig/administrator.test.mjs
@@ -17,7 +17,7 @@ chai.use(chaiAsPromised);
 
 const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
 
-const { mnemonics, signingKeys, addresses, MINIMUM_STAKE } = config.TEST_OPTIONS;
+const { mnemonics, signingKeys, addresses } = config.TEST_OPTIONS;
 const amount1 = 10;
 const amount2 = 100;
 const value1 = 1;
@@ -38,6 +38,8 @@ describe(`Testing Administrator`, () => {
   let challengesContract;
   let multisigContract;
   let nfMultiSig;
+  let minimumStakeDef;
+
   const proposers = [
     new Nf3(signingKeys.proposer1, environment),
     new Nf3(signingKeys.proposer2, environment),
@@ -51,6 +53,7 @@ describe(`Testing Administrator`, () => {
     await proposers[0].init(mnemonics.proposer);
     await proposers[1].init(mnemonics.proposer);
 
+    minimumStakeDef = await proposers[0].getMinimumStake();
     stateContract = await getContractInstance('State', nf3User);
     proposersContract = await getContractInstance('Proposers', nf3User);
     shieldContract = await getContractInstance('Shield', nf3User);
@@ -236,7 +239,7 @@ describe(`Testing Administrator`, () => {
 
     it('Allowing register first proposer', async () => {
       if (process.env.ENVIRONMENT !== 'aws') {
-        const res = await proposers[0].registerProposer('http://optimist', MINIMUM_STAKE);
+        const res = await proposers[0].registerProposer('http://optimist', minimumStakeDef);
         expectTransaction(res);
       }
     });
@@ -244,7 +247,7 @@ describe(`Testing Administrator`, () => {
     it('Not allowing register second proposer', async () => {
       let error = null;
       try {
-        const res = await proposers[1].registerProposer('http://optimist', MINIMUM_STAKE);
+        const res = await proposers[1].registerProposer('http://optimist', minimumStakeDef);
         expectTransaction(res);
       } catch (err) {
         error = err;
@@ -276,7 +279,7 @@ describe(`Testing Administrator`, () => {
     });
 
     it('Allowing register second proposer', async () => {
-      const res = await proposers[1].registerProposer('http://optimist', MINIMUM_STAKE);
+      const res = await proposers[1].registerProposer('http://optimist', minimumStakeDef);
       expectTransaction(res);
     });
 

--- a/test/optimist-resync.test.mjs
+++ b/test/optimist-resync.test.mjs
@@ -25,7 +25,6 @@ const {
   tokenConfigs: { tokenType, tokenId },
   mnemonics,
   signingKeys,
-  MINIMUM_STAKE,
 } = config.TEST_OPTIONS;
 
 const { PROPOSE_BLOCK } = config.SIGNATURES;
@@ -40,6 +39,7 @@ let erc20Address;
 let stateAddress;
 let eventLogs = [];
 let eventsSeen;
+let minimumStake;
 
 describe('Optimist synchronisation tests', () => {
   let blockProposeEmitter;
@@ -57,8 +57,9 @@ describe('Optimist synchronisation tests', () => {
   before(async () => {
     await nf3Proposer1.init(mnemonics.proposer);
     await nf3Challenger.init(mnemonics.challenger);
+    minimumStake = await nf3Proposer1.getMinimumStake();
     // we must set the URL from the point of view of the client container
-    await nf3Proposer1.registerProposer('http://optimist', MINIMUM_STAKE);
+    await nf3Proposer1.registerProposer('http://optimist', minimumStake);
 
     // Proposer listening for incoming events
     blockProposeEmitter = await nf3Proposer1.startProposer();
@@ -180,7 +181,7 @@ describe('Optimist synchronisation tests', () => {
       await restartOptimist(false);
 
       // we need to remind optimist which proposer it's connected to
-      await nf3Proposer1.registerProposer('http://optimist', MINIMUM_STAKE);
+      await nf3Proposer1.registerProposer('http://optimist', minimumStake);
       await waitForTimeout(5000);
       // TODO - get optimist to do this automatically.
       // Now we'll add another block and check that it's blocknumber is correct, indicating
@@ -227,7 +228,7 @@ describe('Optimist synchronisation tests', () => {
       await restartOptimist();
 
       // we need to remind optimist which proposer it's connected to
-      await nf3Proposer1.registerProposer('http://optimist', MINIMUM_STAKE);
+      await nf3Proposer1.registerProposer('http://optimist', minimumStake);
       // TODO - get optimist to do this automatically.
       // Now we'll add another block and check that it's blocknumber is correct, indicating
       // that a resync correctly occured
@@ -310,7 +311,7 @@ describe('Optimist synchronisation tests', () => {
       logger.debug('rollback complete event received');
       // the rollback will have removed us as proposer. We need to re-register because we
       // were the only proposer in town!
-      await nf3Proposer1.registerProposer('http://optimist', MINIMUM_STAKE);
+      await nf3Proposer1.registerProposer('http://optimist', minimumStake);
       // Now we'll add another block and check that it's blocknumber is correct, indicating
       // that a rollback correctly occured
       logger.debug(`      Sending ${txPerBlock} deposits...`);

--- a/test/ping-pong/ping-pong.test.mjs
+++ b/test/ping-pong/ping-pong.test.mjs
@@ -4,7 +4,7 @@ import Nf3 from '../../cli/lib/nf3.mjs';
 
 const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
 
-const { mnemonics, signingKeys, MINIMUM_STAKE } = config.TEST_OPTIONS;
+const { mnemonics, signingKeys } = config.TEST_OPTIONS;
 const nf3Proposer = new Nf3(signingKeys.proposer1, environment);
 
 describe('Ping-pong tests', () => {
@@ -12,7 +12,7 @@ describe('Ping-pong tests', () => {
     if (process.env.ENVIRONMENT !== 'aws') {
       await nf3Proposer.init(mnemonics.proposer);
       // we must set the URL from the point of view of the client container
-      await nf3Proposer.registerProposer('http://optimist', MINIMUM_STAKE);
+      await nf3Proposer.registerProposer('http://optimist', await nf3Proposer.getMinimumStake());
       await nf3Proposer.startProposer();
     }
   });

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -8,7 +8,6 @@ import { rand } from '@polygon-nightfall/common-files/utils/crypto/crypto-random
 
 const { expect } = chai;
 const { WEB3_PROVIDER_OPTIONS } = config;
-const { MINIMUM_STAKE } = config.TEST_OPTIONS;
 
 const ENVIRONMENT = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
 
@@ -447,7 +446,7 @@ export const retrieveL2Balance = async (client, ercAddress) => {
 */
 export const registerProposerOnNoProposer = async proposer => {
   if ((await proposer.getCurrentProposer()) === '0x0000000000000000000000000000000000000000') {
-    await proposer.registerProposer('http://optimist', MINIMUM_STAKE);
+    await proposer.registerProposer('http://optimist', await proposer.getMinimumStake());
   }
 };
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Fix #1172.
Change all constants for MINIMUM_STAKE and BLOCK_STAKE used in tests for the corresponding variable of the blockchain defined in `Config.sol` contract.

## Does this close any currently open issues?
Yes. #1172.

## What commands can I run to test the change? 
Any e2e test that use and register proposers.

## Any other comments?
No

