### PR TITLE
Applying manual change to common-files version 0.0.7

### DIFF
--- a/common-files/package.json
+++ b/common-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polygon-nightfall/common-files",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "scripts": {
     "test": "NODE_CONFIG_DIR=../config mocha --timeout 0 --bail --exit test/*.mjs"
   },


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Changes `common-files` current version to `0.0.7`. The trigger solution implemented recently is failing because of the `branch protection rules` in place.

## Does this close any currently open issues?
No

## What commands can I run to test the change? 
No

## Any other comments?
We need to figure out how to do this automatically. Github allows us to create a new `role` with a more relaxed permission that might be used in this case however, this is not the best way.
