### PR TITLE
Transaction Structure optimization

### DIFF
--- a/.github/workflows/on-pull-request-master.yml
+++ b/.github/workflows/on-pull-request-master.yml
@@ -2,7 +2,7 @@ name: Check PR
 
 on:
   pull_request:
-    branches: [master, tokenisation-l2]
+    branches: [master, RogerTaule/circuitHash, tokenisation-l2]
 
 jobs:
   dependency-review:

--- a/common-files/classes/transaction.mjs
+++ b/common-files/classes/transaction.mjs
@@ -23,13 +23,28 @@ const arrayEquality = (as, bs) => {
   return false;
 };
 
-const packInfo = (value, fee, circuitHash, tokenType) => {
+export const packInfo = (value, fee, circuitHash, tokenType) => {
   const valuePacked = generalise(value).hex(14).slice(2);
   const feePacked = generalise(fee).hex(12).slice(2);
   const circuitHashPacked = generalise(circuitHash).hex(5).slice(2);
   const tokenTypePacked = generalise(tokenType).hex(1).slice(2);
 
   return '0x'.concat(circuitHashPacked, feePacked, valuePacked, tokenTypePacked);
+};
+
+export const packHistoricRoots = historicRootBlockNumberL2 => {
+  let historicRootsHex = historicRootBlockNumberL2.map(h => generalise(h).hex(8).slice(2)).join('');
+
+  while (historicRootsHex.length % 64 !== 0) {
+    historicRootsHex += '0';
+  }
+
+  const historicRootsPacked = [];
+  for (let i = 0; i < historicRootsHex.length; i += 64) {
+    historicRootsPacked.push(`0x${historicRootsHex.substring(i, i + 64)}`);
+  }
+
+  return historicRootsPacked;
 };
 
 // function to compute the keccak hash of a transaction
@@ -53,9 +68,11 @@ function keccak(preimage) {
 
   const packedInfo = packInfo(value, fee, circuitHash, tokenType);
 
+  const historicRootsPacked = packHistoricRoots(historicRootBlockNumberL2);
+
   const transaction = [
     packedInfo,
-    historicRootBlockNumberL2,
+    historicRootsPacked,
     tokenId,
     ercAddress,
     recipientAddress,
@@ -155,6 +172,21 @@ class Transaction {
     return { value, fee, circuitHash, tokenType };
   }
 
+  static unpackHistoricRoot(nRoots, historicRootsPacked) {
+    const historicRootPackedHex = historicRootsPacked
+      .map(h => generalise(h).hex(32).slice(2))
+      .join('');
+
+    const historicRootBlockNumberL2 = [];
+
+    for (let i = 0; i < historicRootPackedHex.length; i += 16) {
+      if (historicRootBlockNumberL2.length === nRoots) break;
+      historicRootBlockNumberL2.push(`0x${historicRootPackedHex.substring(i, i + 16)}`);
+    }
+
+    return historicRootBlockNumberL2;
+  }
+
   static buildSolidityStruct(transaction) {
     // return a version without properties that are not sent to the blockchain
     const {
@@ -174,9 +206,11 @@ class Transaction {
 
     const packedInfo = packInfo(value, fee, circuitHash, tokenType);
 
+    const historicRootsPacked = packHistoricRoots(historicRootBlockNumberL2);
+
     return {
       packedInfo,
-      historicRootBlockNumberL2,
+      historicRootBlockNumberL2: historicRootsPacked,
       tokenId,
       ercAddress,
       recipientAddress,

--- a/config/default.js
+++ b/config/default.js
@@ -495,12 +495,12 @@ module.exports = {
   SIGNATURES: {
     BLOCK: '(uint48,address,bytes32,uint256,bytes32,bytes32, bytes32)',
     TRANSACTION:
-      '(uint256,uint64[],bytes32,bytes32,bytes32,bytes32[],bytes32[],bytes32[2],uint256[4])',
+      '(uint256,uint256[],bytes32,bytes32,bytes32,bytes32[],bytes32[],bytes32[2],uint256[4])',
     PROPOSE_BLOCK: [
       '(uint48,address,bytes32,uint256,bytes32,bytes32,bytes32)',
-      '(uint256,uint64[],bytes32,bytes32,bytes32,bytes32[],bytes32[],bytes32[2],uint256[4])[]',
+      '(uint256,uint256[],bytes32,bytes32,bytes32,bytes32[],bytes32[],bytes32[2],uint256[4])[]',
     ],
     SUBMIT_TRANSACTION:
-      '(uint256,uint64[],bytes32,bytes32,bytes32,bytes32[],bytes32[],bytes32[2],uint256[4])',
+      '(uint256,uint256[],bytes32,bytes32,bytes32,bytes32[],bytes32[],bytes32[2],uint256[4])',
   },
 };

--- a/nightfall-client/src/services/process-calldata.mjs
+++ b/nightfall-client/src/services/process-calldata.mjs
@@ -41,7 +41,7 @@ async function getProposeBlockCalldata(eventData) {
   const transactions = transactionsData.map(t => {
     const [
       packedInfo,
-      historicRootBlockNumberL2,
+      historicRootBlockNumberL2Packed,
       tokenId,
       ercAddress,
       recipientAddress,
@@ -52,6 +52,11 @@ async function getProposeBlockCalldata(eventData) {
     ] = t;
 
     const { value, fee, circuitHash, tokenType } = Transaction.unpackInfo(packedInfo);
+
+    const historicRootBlockNumberL2 = Transaction.unpackHistoricRoot(
+      nullifiers.length,
+      historicRootBlockNumberL2Packed,
+    );
 
     const transaction = {
       value,

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -98,7 +98,7 @@ contract Shield is Stateful, Config, ReentrancyGuardUpgradeable, Pausable, KYC {
     /**
      * @dev Check if a block has been paid to the proposer
      */
-    function isBlockPaymentPending(uint256 blockNumberL2) external view returns (bool) {
+    function isBlockPaymentPending(uint64 blockNumberL2) external view returns (bool) {
         BlockData memory blockData = state.getBlockData(blockNumberL2);
         require(
             blockData.time + CHALLENGE_PERIOD < block.timestamp,

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -38,10 +38,10 @@ contract Shield is Stateful, Config, ReentrancyGuardUpgradeable, Pausable, KYC {
             'Shield: You are not authorised to transact using Nightfall'
         );
         require(
-            msg.value == 0 || uint96(t.packedInfo >> 120) == 0,
+            msg.value == 0 || Utils.getFee(t.packedInfo) == 0,
             'Shield: Fee cannot be paid in both tokens'
         );
-        (, bool isEscrowRequired) = state.circuitInfo(uint40(t.packedInfo >> 216));
+        (, bool isEscrowRequired) = state.circuitInfo(Utils.getCircuitHash(t.packedInfo));
         if (isEscrowRequired || msg.value > 0) {
             bytes32 transactionHash = Utils.hashTransaction(t);
             state.setTransactionInfo(transactionHash, isEscrowRequired, uint248(msg.value));
@@ -146,7 +146,7 @@ contract Shield is Stateful, Config, ReentrancyGuardUpgradeable, Pausable, KYC {
         // check this block is a real one, in the queue, not something made up.
         bytes32 transactionHash = state.areBlockAndTransactionReal(b, t, index, siblingPath);
         // check that the block has been finalised
-        (bool isWithdrawing, ) = state.circuitInfo(uint40(t.packedInfo >> 216));
+        (bool isWithdrawing, ) = state.circuitInfo(Utils.getCircuitHash(t.packedInfo));
         require(isWithdrawing, 'Shield: Transaction is not a valid withdraw');
         require(
             state.getBlockData(b.blockNumberL2).time + CHALLENGE_PERIOD < block.timestamp,
@@ -182,7 +182,7 @@ contract Shield is Stateful, Config, ReentrancyGuardUpgradeable, Pausable, KYC {
             state.getBlockData(b.blockNumberL2).time + CHALLENGE_PERIOD < block.timestamp,
             'Shield: Too soon to withdraw funds from this block'
         );
-        (bool isWithdrawing, ) = state.circuitInfo(uint40(t.packedInfo >> 216));
+        (bool isWithdrawing, ) = state.circuitInfo(Utils.getCircuitHash(t.packedInfo));
         require(isWithdrawing, 'Shield: Transaction is not a valid withdraw');
         require(
             !advancedWithdrawals[transactionHash].isWithdrawn,
@@ -258,7 +258,7 @@ contract Shield is Stateful, Config, ReentrancyGuardUpgradeable, Pausable, KYC {
         IERC20Upgradeable(tokenAddress).safeTransferFrom(
             address(msg.sender),
             currentOwner,
-            uint256(uint112(t.packedInfo >> 8))
+            uint256(Utils.getValue(t.packedInfo))
         );
     }
 
@@ -272,7 +272,7 @@ contract Shield is Stateful, Config, ReentrancyGuardUpgradeable, Pausable, KYC {
         bytes32 transactionHash = state.areBlockAndTransactionReal(b, t, index, siblingPath);
 
         // The transaction is a withdrawal transaction
-        (bool isWithdrawing, ) = state.circuitInfo(uint40(t.packedInfo >> 216));
+        (bool isWithdrawing, ) = state.circuitInfo(Utils.getCircuitHash(t.packedInfo));
         require(isWithdrawing, 'Shield: Can only advance withdrawals');
 
         require(msg.value > 0, 'Shield: Advance fee cannot be zero');
@@ -284,7 +284,7 @@ contract Shield is Stateful, Config, ReentrancyGuardUpgradeable, Pausable, KYC {
         );
 
         require(
-            TokenType(uint8(t.packedInfo)) == TokenType.ERC20 && t.tokenId == ZERO,
+            Utils.getTokenType(t.packedInfo) == TokenType.ERC20 && t.tokenId == ZERO,
             'Shield: Can only advance withdrawals for fungible tokens'
         );
 
@@ -322,9 +322,9 @@ contract Shield is Stateful, Config, ReentrancyGuardUpgradeable, Pausable, KYC {
         );
         address addr = address(uint160(uint256(t.ercAddress)));
 
-        uint112 value = uint112(t.packedInfo >> 8);
+        uint112 value = Utils.getValue(t.packedInfo);
 
-        TokenType tokenType = TokenType(uint8(t.packedInfo));
+        TokenType tokenType = Utils.getTokenType(t.packedInfo);
         if (tokenType == TokenType.ERC20) {
             if (t.tokenId != ZERO)
                 revert('Shield: ERC20 withdrawal should have tokenId equal to ZERO');
@@ -362,8 +362,8 @@ contract Shield is Stateful, Config, ReentrancyGuardUpgradeable, Pausable, KYC {
         );
         address addr = address(uint160(addrNum));
 
-        uint112 value = uint112(t.packedInfo >> 8);
-        TokenType tokenType = TokenType(uint8(t.packedInfo));
+        uint112 value = Utils.getValue(t.packedInfo);
+        TokenType tokenType = Utils.getTokenType(t.packedInfo);
 
         if (tokenType == TokenType.ERC20) {
             if (t.tokenId != ZERO)

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -342,7 +342,7 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Key_Registry, Config {
         return currentProposer;
     }
 
-    function getFeeBookBlocksInfo(address proposer, uint256 blockNumberL2)
+    function getFeeBookBlocksInfo(address proposer, uint64 blockNumberL2)
         public
         view
         returns (FeeTokens memory)
@@ -350,7 +350,7 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Key_Registry, Config {
         return (feeBookBlocks[keccak256(abi.encodePacked(proposer, blockNumberL2))]);
     }
 
-    function resetFeeBookBlocksInfo(address proposer, uint256 blockNumberL2) public onlyShield {
+    function resetFeeBookBlocksInfo(address proposer, uint64 blockNumberL2) public onlyShield {
         delete feeBookBlocks[keccak256(abi.encodePacked(proposer, blockNumberL2))];
     }
 
@@ -361,7 +361,7 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Key_Registry, Config {
         return popped;
     }
 
-    function getBlockData(uint256 blockNumberL2) public view returns (BlockData memory) {
+    function getBlockData(uint64 blockNumberL2) public view returns (BlockData memory) {
         require(blockNumberL2 < blockHashes.length, 'State: Invalid block number L2');
         return blockHashes[blockNumberL2];
     }

--- a/nightfall-deployer/contracts/Structures.sol
+++ b/nightfall-deployer/contracts/Structures.sol
@@ -15,7 +15,7 @@ contract Structures {
         ERC1155
     }
 
-    event Rollback(uint256 blockNumberL2);
+    event Rollback(uint64 blockNumberL2);
 
     event BlockProposed();
 
@@ -45,7 +45,7 @@ contract Structures {
     // nullifiers for a Deposit transaction.
     struct Transaction {
         uint256 packedInfo;
-        uint64[] historicRootBlockNumberL2;
+        uint256[] historicRootBlockNumberL2;
         bytes32 tokenId;
         bytes32 ercAddress;
         bytes32 recipientAddress;
@@ -59,7 +59,7 @@ contract Structures {
         uint48 leafCount; // note this is defined to be the number of leaves AFTER the commitments in this block are added
         address proposer;
         bytes32 root; // the 'output' commmitment root after adding all commitments
-        uint256 blockNumberL2;
+        uint64 blockNumberL2;
         bytes32 previousBlockHash;
         bytes32 frontierHash;
         bytes32 transactionHashesRoot; // This variable needs to be the last one in order proposeBlock to work
@@ -86,11 +86,6 @@ contract Structures {
         uint256 amount; // The amount held
         uint256 challengeLocked; // The amount locked by block proposed still in CHALLENGE_PERIOD and not claimed
         uint256 time; // The time the funds were locked from
-    }
-
-    struct Fee {
-        address proposer;
-        uint256 blockNumberL2;
     }
 
     struct FeeTokens {

--- a/nightfall-deployer/contracts/Utils.sol
+++ b/nightfall-deployer/contracts/Utils.sol
@@ -106,8 +106,7 @@ library Utils {
         address maticAddress
     ) internal pure returns (uint256[] memory) {
         uint256 transactionSlots = 24 +
-            ts.nullifiers.length +
-            ts.historicRootBlockNumberL2.length +
+            2*ts.nullifiers.length +
             roots.length +
             ts.commitments.length;
         uint256[] memory inputs = new uint256[](transactionSlots);
@@ -116,8 +115,10 @@ library Utils {
         inputs[count++] = uint256(uint96(ts.packedInfo >> 120));
         inputs[count++] = uint256(uint40(ts.packedInfo >> 216));
         inputs[count++] = uint256(uint8(ts.packedInfo));
-        for (uint256 i = 0; i < ts.historicRootBlockNumberL2.length; ++i) {
-            inputs[count++] = ts.historicRootBlockNumberL2[i];
+        for (uint256 i = 0; i < ts.nullifiers.length; ++i) {
+            uint256 slot = uint256(uint(i) / 4);
+            uint256 position = 64 * (3 - (i % 4));
+            inputs[count++] = uint256(uint64(ts.historicRootBlockNumberL2[slot] >> position));
         }
         inputs[count++] = uint32(uint256(ts.tokenId) >> 224);
         inputs[count++] = uint32(uint256(ts.tokenId) >> 192);

--- a/nightfall-deployer/contracts/Utils.sol
+++ b/nightfall-deployer/contracts/Utils.sol
@@ -20,6 +20,32 @@ library Utils {
         return keccak256(abi.encode(frontier));
     }
 
+    function getValue(uint256 packedInfo) internal pure returns (uint112) {
+        return uint112(packedInfo >> 8);
+    }
+
+    function getCircuitHash(uint256 packedInfo) internal pure returns (uint40) {
+        return uint40(packedInfo >> 216);
+    }
+
+    function getFee(uint256 packedInfo) internal pure returns (uint96) {
+        return uint96(packedInfo >> 120);
+    }
+
+    function getTokenType(uint256 packedInfo) internal pure returns (Structures.TokenType) {
+        return Structures.TokenType(uint8(packedInfo));
+    }
+
+    function getHistoricRoot(uint256[] calldata historicRootBlockNumberL2, uint256 position)
+        internal
+        pure
+        returns (uint64)
+    {
+        uint256 slot = position / 4;
+        uint256 pos = 64 * (3 - (position % 4));
+        return uint64(historicRootBlockNumberL2[slot] >> pos);
+    }
+
     function hashTransactionHashes(Structures.Transaction[] calldata ts)
         public
         pure
@@ -106,19 +132,18 @@ library Utils {
         address maticAddress
     ) internal pure returns (uint256[] memory) {
         uint256 transactionSlots = 24 +
-            2*ts.nullifiers.length +
+            2 *
+            ts.nullifiers.length +
             roots.length +
             ts.commitments.length;
         uint256[] memory inputs = new uint256[](transactionSlots);
         uint256 count = 0;
-        inputs[count++] = uint256(uint112(ts.packedInfo >> 8));
-        inputs[count++] = uint256(uint96(ts.packedInfo >> 120));
-        inputs[count++] = uint256(uint40(ts.packedInfo >> 216));
-        inputs[count++] = uint256(uint8(ts.packedInfo));
+        inputs[count++] = uint256(getValue(ts.packedInfo));
+        inputs[count++] = uint256(getFee(ts.packedInfo));
+        inputs[count++] = uint256(getCircuitHash(ts.packedInfo));
+        inputs[count++] = uint256(getTokenType(ts.packedInfo));
         for (uint256 i = 0; i < ts.nullifiers.length; ++i) {
-            uint256 slot = uint256(uint(i) / 4);
-            uint256 position = 64 * (3 - (i % 4));
-            inputs[count++] = uint256(uint64(ts.historicRootBlockNumberL2[slot] >> position));
+            inputs[count++] = uint256(getHistoricRoot(ts.historicRootBlockNumberL2, i));
         }
         inputs[count++] = uint32(uint256(ts.tokenId) >> 224);
         inputs[count++] = uint32(uint256(ts.tokenId) >> 192);

--- a/nightfall-optimist/src/services/process-calldata.mjs
+++ b/nightfall-optimist/src/services/process-calldata.mjs
@@ -43,7 +43,7 @@ export async function getProposeBlockCalldata(eventData) {
   const transactions = transactionsData.map(t => {
     const [
       packedInfo,
-      historicRootBlockNumberL2,
+      historicRootBlockNumberL2Packed,
       tokenId,
       ercAddress,
       recipientAddress,
@@ -54,6 +54,11 @@ export async function getProposeBlockCalldata(eventData) {
     ] = t;
 
     const { value, fee, circuitHash, tokenType } = Transaction.unpackInfo(packedInfo);
+
+    const historicRootBlockNumberL2 = Transaction.unpackHistoricRoot(
+      nullifiers.length,
+      historicRootBlockNumberL2Packed,
+    );
 
     const transaction = {
       value,
@@ -95,7 +100,7 @@ export async function getTransactionSubmittedCalldata(eventData) {
   const transactionData = web3.eth.abi.decodeParameter(SIGNATURES.SUBMIT_TRANSACTION, abiBytecode);
   const [
     packedInfo,
-    historicRootBlockNumberL2,
+    historicRootBlockNumberL2Packed,
     tokenId,
     ercAddress,
     recipientAddress,
@@ -106,6 +111,11 @@ export async function getTransactionSubmittedCalldata(eventData) {
   ] = transactionData;
 
   const { value, fee, circuitHash, tokenType } = Transaction.unpackInfo(packedInfo);
+
+  const historicRootBlockNumberL2 = Transaction.unpackHistoricRoot(
+    nullifiers.length,
+    historicRootBlockNumberL2Packed,
+  );
 
   const transaction = {
     value,

--- a/nightfall-optimist/src/services/transaction-checker.mjs
+++ b/nightfall-optimist/src/services/transaction-checker.mjs
@@ -112,7 +112,7 @@ async function checkHistoricRootBlockNumber(transaction) {
   transaction.historicRootBlockNumberL2.forEach(L2BlockNumber => {
     if (Number(L2BlockNumber) === 0 && LatestL2BlockNumber === -1) return;
     if (Number(L2BlockNumber) > LatestL2BlockNumber) {
-      throw new TransactionError('Historic root has L2BlockNumber greater than OnChain', 3, {
+      throw new TransactionError('Historic root has block number L2 greater than on chain', 3, {
         transactionHash: transaction.transactionHash,
       });
     }

--- a/test/unit/SmartContracts/shield.unit.test.mjs
+++ b/test/unit/SmartContracts/shield.unit.test.mjs
@@ -6,7 +6,6 @@ import {
   calculateBlockHash,
   calculateTransactionHash,
   createBlockAndTransactions,
-  packInfoTransaction,
 } from '../utils/utils.mjs';
 import { setAdvancedWithdrawal, setWhitelist } from '../utils/shieldStorage.mjs';
 import {
@@ -15,6 +14,7 @@ import {
   setFeeBookInfo,
   setStakeAccount,
 } from '../utils/stateStorage.mjs';
+import { packHistoricRoots, packInfo } from '../../../common-files/classes/transaction.mjs';
 
 const { ethers, upgrades } = hardhat;
 
@@ -162,7 +162,6 @@ describe('Testing Shield Contract', function () {
         value: 15,
       });
 
-      console.log(await StateInstance.txInfo(depositTransactionHash));
       expect((await StateInstance.txInfo(depositTransactionHash)).isEscrowed).to.equal(true);
       expect(await Erc20MockInstance.balanceOf(await owner[0].address)).to.equal(99999990);
       expect(await Erc20MockInstance.balanceOf(shieldAddress)).to.equal(10);
@@ -178,16 +177,20 @@ describe('Testing Shield Contract', function () {
         '28948022309329048855892746252171976963317496166410141009864396001978282409986',
       );
 
-      const packedInfo = packInfoTransaction(0, 0, 0, 1);
+      const packedInfo = packInfo(0, 0, 0, 1);
+
+      const historicRootBlockNumberL2 = [
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ];
+
+      const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
 
       const depositTransactionERC721 = {
         packedInfo,
-        historicRootBlockNumberL2: [
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
+        historicRootBlockNumberL2: packedHistoricRootBlockNumber,
         tokenId: '0x4000000000000000000000000000000000000000000000000000000000000002',
         ercAddress: ethers.utils.hexZeroPad(erc721MockAddress, 32),
         recipientAddress: '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -228,16 +231,20 @@ describe('Testing Shield Contract', function () {
     it('succeeds and sets is Escrowed to true for a deposit transaction of an ERC1155 token', async function () {
       await Erc1155MockInstance.setApprovalForAll(shieldAddress, true);
 
-      const packedInfo = packInfoTransaction(5, 0, 0, 2);
+      const packedInfo = packInfo(5, 0, 0, 2);
+
+      const historicRootBlockNumberL2 = [
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ];
+
+      const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
 
       const depositTransactionERC1155 = {
         packedInfo,
-        historicRootBlockNumberL2: [
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
+        historicRootBlockNumberL2: packedHistoricRootBlockNumber,
         tokenId: '0x0000000000000000000000000000000000000000000000000000000000000000',
         ercAddress: ethers.utils.hexZeroPad(erc1155MockAddress, 32),
         recipientAddress: '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -287,16 +294,20 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails to submit deposit transaction if fee > 0 and msg.value > 0 ', async function () {
-      const packedInfo = packInfoTransaction(10, 10, 0, 0);
+      const packedInfo = packInfo(10, 10, 0, 0);
+
+      const historicRootBlockNumberL2 = [
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ];
+
+      const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
 
       const depositTransactionInvalid = {
         packedInfo,
-        historicRootBlockNumberL2: [
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
+        historicRootBlockNumberL2: packedHistoricRootBlockNumber,
         tokenId: '0x0000000000000000000000000000000000000000000000000000000000000000',
         ercAddress: ethers.utils.hexZeroPad(erc20MockAddress, 32),
         recipientAddress: '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -329,16 +340,20 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails to submit deposit transaction if ercAddress is invalid', async function () {
-      const packedInfo = packInfoTransaction(10, 0, 0, 0);
+      const packedInfo = packInfo(10, 0, 0, 0);
+
+      const historicRootBlockNumberL2 = [
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ];
+
+      const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
 
       const depositTransactionInvalid = {
         packedInfo,
-        historicRootBlockNumberL2: [
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
+        historicRootBlockNumberL2: packedHistoricRootBlockNumber,
         tokenId: '0x0000000000000000000000000000000000000000000000000000000000000000',
         ercAddress: ethers.utils.hexZeroPad(
           ethers.utils.hexlify(1461501637330902918203684832716283019655932542976n),
@@ -374,16 +389,20 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails to submit deposit transaction if tokenType is ERC20 and tokenId not zero', async function () {
-      const packedInfo = packInfoTransaction(10, 0, 0, 0);
+      const packedInfo = packInfo(10, 0, 0, 0);
+
+      const historicRootBlockNumberL2 = [
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ];
+
+      const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
 
       const depositTransactionInvalid = {
         packedInfo,
-        historicRootBlockNumberL2: [
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
+        historicRootBlockNumberL2: packedHistoricRootBlockNumber,
         tokenId: '0x0000000000000000000000000000000000000000000000000000000000000001',
         ercAddress: ethers.utils.hexZeroPad(erc20MockAddress, 32),
         recipientAddress: '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -423,15 +442,20 @@ describe('Testing Shield Contract', function () {
 
     it('fails to submit deposit transaction if tokenType is ERC20 and trying to deposit more than allowed', async function () {
       await ShieldInstance.setRestriction(erc20MockAddress, '10000', '10000');
-      const packedInfo = packInfoTransaction(100000, 0, 0, 0);
+      const packedInfo = packInfo(100000, 0, 0, 0);
+
+      const historicRootBlockNumberL2 = [
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ];
+
+      const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
+
       const depositTransactionInvalid = {
         packedInfo,
-        historicRootBlockNumberL2: [
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
+        historicRootBlockNumberL2: packedHistoricRootBlockNumber,
         tokenId: '0x0000000000000000000000000000000000000000000000000000000000000000',
         ercAddress: ethers.utils.hexZeroPad(erc20MockAddress, 32),
         recipientAddress: '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -464,16 +488,20 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails to submit deposit transaction if tokenType is ERC721 and value is invalid', async function () {
-      const packedInfo = packInfoTransaction(1, 0, 0, 1);
+      const packedInfo = packInfo(1, 0, 0, 1);
+
+      const historicRootBlockNumberL2 = [
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ];
+
+      const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
 
       const depositTransactionInvalid = {
         packedInfo,
-        historicRootBlockNumberL2: [
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
+        historicRootBlockNumberL2: packedHistoricRootBlockNumber,
         tokenId: '0x0000000000000000000000000000000000000000000000000000000000000000',
         ercAddress: ethers.utils.hexZeroPad(erc20MockAddress, 32),
         recipientAddress: '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -506,16 +534,20 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if tokenType is unknown', async function () {
-      const packedInfo = packInfoTransaction(1, 0, 0, 5);
+      const packedInfo = packInfo(1, 0, 0, 5);
+
+      const historicRootBlockNumberL2 = [
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ];
+
+      const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
 
       const depositTransactionInvalid = {
         packedInfo,
-        historicRootBlockNumberL2: [
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
+        historicRootBlockNumberL2: packedHistoricRootBlockNumber,
         tokenId: '0x0000000000000000000000000000000000000000000000000000000000000000',
         ercAddress: ethers.utils.hexZeroPad(erc20MockAddress, 32),
         recipientAddress: '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -815,16 +847,20 @@ describe('Testing Shield Contract', function () {
 
     it('succeeds to finalise withdrawal for an ERC721 token', async function () {
       await Erc721MockInstance.awardItem(shieldAddress, `https://erc721mock/item-id.json`);
-      const packedInfo = packInfoTransaction(0, 0, 2, 1);
+      const packedInfo = packInfo(0, 0, 2, 1);
+
+      const historicRootBlockNumberL2 = [
+        '0x0000000000000000000000000000000000000000000000000000000000000009',
+        '0x0000000000000000000000000000000000000000000000000000000000000002',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ];
+
+      const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
 
       const withdrawERC721 = {
         packedInfo,
-        historicRootBlockNumberL2: [
-          '0x0000000000000000000000000000000000000000000000000000000000000009',
-          '0x0000000000000000000000000000000000000000000000000000000000000002',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
+        historicRootBlockNumberL2: packedHistoricRootBlockNumber,
         tokenId: '0x4000000000000000000000000000000000000000000000000000000000000002',
         ercAddress: ethers.utils.hexZeroPad(erc721MockAddress, 32),
         recipientAddress: ethers.utils.hexZeroPad(owner[0].address, 32),
@@ -901,16 +937,20 @@ describe('Testing Shield Contract', function () {
 
     it('succeeds to finalise withdrawal for an ERC1155 token', async function () {
       await Erc1155MockInstance.safeTransferFrom(owner[0].address, shieldAddress, 1, 25, []);
-      const packedInfo = packInfoTransaction(25, 0, 2, 2);
+      const packedInfo = packInfo(25, 0, 2, 2);
+
+      const historicRootBlockNumberL2 = [
+        '0x0000000000000000000000000000000000000000000000000000000000000009',
+        '0x0000000000000000000000000000000000000000000000000000000000000002',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ];
+
+      const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
 
       const withdrawERC1155 = {
         packedInfo,
-        historicRootBlockNumberL2: [
-          '0x0000000000000000000000000000000000000000000000000000000000000009',
-          '0x0000000000000000000000000000000000000000000000000000000000000002',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
+        historicRootBlockNumberL2: packedHistoricRootBlockNumber,
         tokenId: '0x0000000000000000000000000000000000000000000000000000000000000001',
         ercAddress: ethers.utils.hexZeroPad(erc1155MockAddress, 32),
         recipientAddress: ethers.utils.hexZeroPad(owner[0].address, 32),
@@ -1023,16 +1063,20 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if ercAddress is invalid', async function () {
-      const packedInfo = packInfoTransaction(10, 0, 2, 0);
+      const packedInfo = packInfo(10, 0, 2, 0);
+
+      const historicRootBlockNumberL2 = [
+        '0x0000000000000000000000000000000000000000000000000000000000000009',
+        '0x0000000000000000000000000000000000000000000000000000000000000002',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ];
+
+      const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
 
       const withdrawalTransactionInvalid = {
         packedInfo,
-        historicRootBlockNumberL2: [
-          '0x0000000000000000000000000000000000000000000000000000000000000009',
-          '0x0000000000000000000000000000000000000000000000000000000000000002',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
+        historicRootBlockNumberL2: packedHistoricRootBlockNumber,
         tokenId: '0x0000000000000000000000000000000000000000000000000000000000000000',
         ercAddress: ethers.utils.concat([
           ethers.utils.hexlify(1),
@@ -1126,16 +1170,20 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails to finalise withdrawal if tokenType is ERC20 and tokenId not zero', async function () {
-      const packedInfo = packInfoTransaction(10, 0, 2, 0);
+      const packedInfo = packInfo(10, 0, 2, 0);
+
+      const historicRootBlockNumberL2 = [
+        '0x0000000000000000000000000000000000000000000000000000000000000009',
+        '0x0000000000000000000000000000000000000000000000000000000000000002',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ];
+
+      const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
 
       const withdrawalTransactionInvalid = {
         packedInfo,
-        historicRootBlockNumberL2: [
-          '0x0000000000000000000000000000000000000000000000000000000000000009',
-          '0x0000000000000000000000000000000000000000000000000000000000000002',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
+        historicRootBlockNumberL2: packedHistoricRootBlockNumber,
         tokenId: '0x0000000000000000000000000000000000000000000000000000000000000001',
         ercAddress: ethers.utils.hexZeroPad(erc20MockAddress, 32),
         recipientAddress: '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -1201,16 +1249,20 @@ describe('Testing Shield Contract', function () {
 
     it('fails to finalise withdrawal if tokenType is ERC20 and trying to withdraw more than allowed', async function () {
       await ShieldInstance.setRestriction(erc20MockAddress, '10000', '10000');
-      const packedInfo = packInfoTransaction(100000000, 0, 2, 0);
+      const packedInfo = packInfo(100000000, 0, 2, 0);
+
+      const historicRootBlockNumberL2 = [
+        '0x0000000000000000000000000000000000000000000000000000000000000009',
+        '0x0000000000000000000000000000000000000000000000000000000000000002',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ];
+
+      const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
 
       const withdrawalTransactionInvalid = {
         packedInfo,
-        historicRootBlockNumberL2: [
-          '0x0000000000000000000000000000000000000000000000000000000000000009',
-          '0x0000000000000000000000000000000000000000000000000000000000000002',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
+        historicRootBlockNumberL2: packedHistoricRootBlockNumber,
         tokenId: '0x0000000000000000000000000000000000000000000000000000000000000000',
         ercAddress: ethers.utils.hexZeroPad(erc20MockAddress, 32),
         recipientAddress: '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -1275,16 +1327,20 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails to finalise withdrawal if tokenType is ERC721 and value is invalid', async function () {
-      const packedInfo = packInfoTransaction(5, 0, 2, 1);
+      const packedInfo = packInfo(5, 0, 2, 1);
+
+      const historicRootBlockNumberL2 = [
+        '0x0000000000000000000000000000000000000000000000000000000000000009',
+        '0x0000000000000000000000000000000000000000000000000000000000000002',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ];
+
+      const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
 
       const withdrawalTransactionInvalid = {
         packedInfo,
-        historicRootBlockNumberL2: [
-          '0x0000000000000000000000000000000000000000000000000000000000000009',
-          '0x0000000000000000000000000000000000000000000000000000000000000002',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
+        historicRootBlockNumberL2: packedHistoricRootBlockNumber,
         tokenId: '0x0000000000000000000000000000000000000000000000000000000000000001',
         ercAddress: ethers.utils.hexZeroPad(erc20MockAddress, 32),
         recipientAddress: '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -1348,16 +1404,20 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails to finalise withdrawal if tokenType is unknown', async function () {
-      const packedInfo = packInfoTransaction(5, 0, 2, 5);
+      const packedInfo = packInfo(5, 0, 2, 5);
+
+      const historicRootBlockNumberL2 = [
+        '0x0000000000000000000000000000000000000000000000000000000000000009',
+        '0x0000000000000000000000000000000000000000000000000000000000000002',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ];
+
+      const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
 
       const withdrawalTransactionInvalid = {
         packedInfo,
-        historicRootBlockNumberL2: [
-          '0x0000000000000000000000000000000000000000000000000000000000000009',
-          '0x0000000000000000000000000000000000000000000000000000000000000002',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
+        historicRootBlockNumberL2: packedHistoricRootBlockNumber,
         tokenId: '0x0000000000000000000000000000000000000000000000000000000000000001',
         ercAddress: ethers.utils.hexZeroPad(erc20MockAddress, 32),
         recipientAddress: '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -1585,16 +1645,20 @@ describe('Testing Shield Contract', function () {
     });
 
     it('fails if trying to advance withdraw for a non ERC 20 token', async function () {
-      const packedInfo = packInfoTransaction(10, 0, 2, 1);
+      const packedInfo = packInfo(10, 0, 2, 1);
+
+      const historicRootBlockNumberL2 = [
+        '0x0000000000000000000000000000000000000000000000000000000000000009',
+        '0x0000000000000000000000000000000000000000000000000000000000000002',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ];
+
+      const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
 
       const withdrawTransactionERC721 = {
         packedInfo,
-        historicRootBlockNumberL2: [
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
+        historicRootBlockNumberL2: packedHistoricRootBlockNumber,
         tokenId: '0x0000000000000000000000000000000000000000000000000000000000000000',
         ercAddress: ethers.utils.hexZeroPad(erc20MockAddress, 32),
         recipientAddress: '0x0000000000000000000000000000000000000000000000000000000000000000',

--- a/test/unit/SmartContracts/state.unit.test.mjs
+++ b/test/unit/SmartContracts/state.unit.test.mjs
@@ -1,11 +1,8 @@
 import { expect } from 'chai';
 import hardhat from 'hardhat';
-import {
-  calculateTransactionHash,
-  createBlockAndTransactions,
-  packInfoTransaction,
-} from '../utils/utils.mjs';
+import { calculateTransactionHash, createBlockAndTransactions } from '../utils/utils.mjs';
 import { setTransactionInfo } from '../utils/stateStorage.mjs';
+import { packHistoricRoots, packInfo } from '../../../common-files/classes/transaction.mjs';
 
 const { ethers, upgrades } = hardhat;
 
@@ -672,7 +669,7 @@ describe('State contract State functions', function () {
 
     const proposerBlockHash = ethers.utils.keccak256(
       ethers.utils.solidityPack(
-        ['address', 'uint256'],
+        ['address', 'uint64'],
         [transactionsCreated.block.proposer, transactionsCreated.block.blockNumberL2],
       ),
     );
@@ -854,7 +851,7 @@ describe('State contract State functions', function () {
 
     const proposerBlockHash = ethers.utils.keccak256(
       ethers.utils.solidityPack(
-        ['address', 'uint256'],
+        ['address', 'uint64'],
         [transactionsCreated.block.proposer, transactionsCreated.block.blockNumberL2],
       ),
     );
@@ -976,15 +973,20 @@ describe('State contract State functions', function () {
       frontierHash: '0xa2f1ec04a89542d6f1e04449398052422c7b1057df8606db047f48047bb7ab72',
       transactionHashesRoot: '0x0487da81cb1d53536928de44fa55de0accf9a8bc9f42739a80f69584970d572f',
     };
-    const packedInfo = packInfoTransaction(100000000000000, 10, 0, 0);
+    const packedInfo = packInfo(100000000000000, 10, 0, 0);
+
+    const historicRootBlockNumberL2 = [
+      '0x0000000000000000000000000000000000000000000000000000000000000009',
+      '0x0000000000000000000000000000000000000000000000000000000000000002',
+      '0x0000000000000000000000000000000000000000000000000000000000000000',
+      '0x0000000000000000000000000000000000000000000000000000000000000000',
+    ];
+
+    const packedHistoricRootBlockNumber = packHistoricRoots(historicRootBlockNumberL2);
+
     const transaction1 = {
       packedInfo,
-      historicRootBlockNumberL2: [
-        '0x0000000000000000000000000000000000000000000000000000000000000000',
-        '0x0000000000000000000000000000000000000000000000000000000000000000',
-        '0x0000000000000000000000000000000000000000000000000000000000000000',
-        '0x0000000000000000000000000000000000000000000000000000000000000000',
-      ],
+      historicRootBlockNumberL2: packedHistoricRootBlockNumber,
       tokenId: '0x0000000000000000000000000000000000000000000000000000000000000000',
       ercAddress: '0x000000000000000000000000499d11e0b6eac7c0593d8fb292dcbbf815fb29ae',
       recipientAddress: '0x0000000000000000000000000000000000000000000000000000000000000000',

--- a/test/unit/utils/stateStorage.mjs
+++ b/test/unit/utils/stateStorage.mjs
@@ -42,7 +42,7 @@ export async function setBlockPaymentClaimed(stateAddress, blockHash) {
 
 export async function setFeeBookInfo(stateAddress, block, feePaymentsEth, feePaymentsMatic) {
   const proposerBlockHash = ethers.utils.keccak256(
-    ethers.utils.solidityPack(['address', 'uint256'], [block.proposer, block.blockNumberL2]),
+    ethers.utils.solidityPack(['address', 'uint64'], [block.proposer, block.blockNumberL2]),
   );
 
   const index = ethers.utils.solidityKeccak256(

--- a/test/unit/utils/utils.mjs
+++ b/test/unit/utils/utils.mjs
@@ -1,5 +1,6 @@
 /* eslint-disable no-empty-function */
 import hardhat from 'hardhat';
+import { packInfo } from '../../../common-files/classes/transaction.mjs';
 
 const { ethers } = hardhat;
 
@@ -20,22 +21,11 @@ export function calculateBlockHash(b) {
   return ethers.utils.keccak256(encodedBlock);
 }
 
-export function packInfoTransaction(value, fee, circuitHash, tokenType) {
-  return ethers.utils.hexValue(
-    ethers.utils.concat([
-      ethers.utils.hexZeroPad(ethers.utils.hexlify(circuitHash), 5),
-      ethers.utils.hexZeroPad(ethers.utils.hexlify(fee), 12),
-      ethers.utils.hexZeroPad(ethers.utils.hexlify(value), 14),
-      ethers.utils.hexZeroPad(ethers.utils.hexlify(tokenType), 1),
-    ]),
-  );
-}
-
 export function calculateTransactionHash(tx) {
   const encodedTx = ethers.utils.defaultAbiCoder.encode(
     [
       'uint256',
-      'uint64[]',
+      'uint256[]',
       'bytes32',
       'bytes32',
       'bytes32',
@@ -62,7 +52,7 @@ export function calculateTransactionHash(tx) {
 }
 
 export function createBlockAndTransactions(erc20MockAddress, ownerAddress) {
-  const packedInfoWithdraw = packInfoTransaction(10, 1, 2, 0);
+  const packedInfoWithdraw = packInfo(10, 1, 2, 0);
 
   const withdrawTransaction = {
     packedInfo: packedInfoWithdraw,
@@ -97,7 +87,7 @@ export function createBlockAndTransactions(erc20MockAddress, ownerAddress) {
     ],
   };
 
-  const packedInfoDeposit = packInfoTransaction(10, 0, 0, 0);
+  const packedInfoDeposit = packInfo(10, 0, 0, 0);
 
   const depositTransaction = {
     packedInfo: packedInfoDeposit,

--- a/wallet/src/nightfall-browser/services/process-calldata.js
+++ b/wallet/src/nightfall-browser/services/process-calldata.js
@@ -33,7 +33,7 @@ async function getProposeBlockCalldata(eventData) {
   const transactions = transactionsData.map(t => {
     const [
       packedInfo,
-      historicRootBlockNumberL2,
+      historicRootBlockNumberL2Packed,
       tokenId,
       ercAddress,
       recipientAddress,
@@ -44,6 +44,11 @@ async function getProposeBlockCalldata(eventData) {
     ] = t;
 
     const { value, fee, circuitHash, tokenType } = Transaction.unpackInfo(packedInfo);
+
+    const historicRootBlockNumberL2 = Transaction.unpackHistoricRoot(
+      nullifiers.length,
+      historicRootBlockNumberL2Packed,
+    );
 
     const transaction = {
       value,


### PR DESCRIPTION
This PR continues with the work done in #1178.
The variable `historicRootBlockNumberL2` is currently stored as a `uint64[]`. Since calldata doesn't pack struct variables, each slot of 32 bytes is set with a different blockNumberL2 value. Therefore, by processing the root block numbers in an smart way we can modify the transaction structure so that `historicRootBlockNumberL2` is stored as a `uint256[]` and each slot contains 4 block numbers concatenated. 
With the current circuits, the 32 bytes slots used when sending a transaction as a calldata is reduced by 3 (since both circuits used 4 nullifiers and therefore 4 roots and all 4 roots can be packed into a single uint256 slot).
However, this change will be more significant with circuits that use a big number of nullifiers (for example, if a circuit used 20 nullifiers this change would get rid of 15 slots)

