### PR TITLE
Updates common-files to 0.0.8

### DIFF
--- a/common-files/package.json
+++ b/common-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polygon-nightfall/common-files",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "scripts": {
     "test": "NODE_CONFIG_DIR=../config mocha --timeout 0 --bail --exit test/*.mjs"
   },


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Some changes in the common-files weren't still published when the [PR](https://github.com/EYBlockchain/nightfall_3/pull/1183) merged which generated the version `0.0.8`.

## Does this close any currently open issues?
No

## What commands can I run to test the change? 
No

## Any other comments?
No
