### PR TITLE
Move utils Dockerfile to appropriate location

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -81,7 +81,8 @@ services:
 
   hosted-utils-api-server:
     build:
-      context: ../hosted-utils-api-server
+      dockerfile: docker/hosted-utils-api-server.Dockerfile
+      context: ..
     depends_on:
       - worker
     ports:

--- a/docker/hosted-utils-api-server.Dockerfile
+++ b/docker/hosted-utils-api-server.Dockerfile
@@ -5,9 +5,9 @@ RUN apt-get install -y md5deep
 
 WORKDIR /app
 
-COPY src src
-COPY package.json package-lock.json ./
-COPY entrypoint.sh entrypoint.sh
+COPY hosted-utils-api-server/src src
+COPY hosted-utils-api-server/package.json package-lock.json ./
+COPY hosted-utils-api-server/entrypoint.sh entrypoint.sh
 
 RUN npm ci
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Move `hosted-utils-api-server` Docker file to `docker` folder, where all Docker config files are located.