### PR TITLE
Wallet: set withdraw type to 2

### DIFF
--- a/wallet/src/components/Modals/txInfoModal.tsx
+++ b/wallet/src/components/Modals/txInfoModal.tsx
@@ -75,7 +75,7 @@ export default function TxInfoModal(props: TxModalProps): JSX.Element {
         </div>
       </Modal.Body>
       <Modal.Footer>
-        {props.withdrawready && props.txtype === '3' ? (
+        {props.withdrawready && props.txtype === '2' ? (
           <Button
             style={{
               background: '#7B3FE4',

--- a/wallet/src/components/Transactions/index.jsx
+++ b/wallet/src/components/Transactions/index.jsx
@@ -109,12 +109,7 @@ const Transactions = () => {
       });
 
       let withdrawReady = false;
-      if (
-        safeTransactionType === '2' &&
-        tx.isOnChain > 0 &&
-        tx.withdrawState !== 'finalised' &&
-        Math.floor(Date.now() / 1000) - tx.createdTime > 3600 * 24 * 7
-      ) {
+      if (safeTransactionType === '2' && tx.isOnChain > 0 && tx.withdrawState !== 'finalised') {
         withdrawReady = await isValidWithdrawal(tx._id, shieldContractAddress);
       }
       if (tx.withdrawState === 'instant') {


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Simple fix for wallet withdraw type. Type was 3 and should be 2.

Also, remove 7 day `CHALLENGE_PERIOD` check, and call contract to verify if `CHALLENGE_PERIOD` has passed. This will allow to set different `CHALLENGE_PERIOD`

## Does this close any currently open issues?
No

## What commands can I run to test the change? 

## Any other comments?

