### PR TITLE
wallet withdraw tx type

### DIFF
--- a/wallet/src/components/Transactions/index.jsx
+++ b/wallet/src/components/Transactions/index.jsx
@@ -365,7 +365,7 @@ const Transactions = () => {
                     </a>
                   </div>
                 </Row>
-                {tx.txType === '3' && tx.isOnChain > 0 && !tx.withdrawState ? (
+                {tx.txType === '2' && tx.isOnChain > 0 && !tx.withdrawState ? (
                   <WithdrawTransaction
                     withdrawready={tx.withdrawReady}
                     transactionhash={tx.transactionHash}


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
additional location where wallet uses tx type 3 for withdrawal instead of 2

## Does this close any currently open issues?

## What commands can I run to test the change? 

## Any other comments?

