### PR TITLE
filter commitments

### DIFF
--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -1286,7 +1286,7 @@ class Nf3 {
     const res = await axios.get(`${this.clientBaseUrl}/commitment/commitments`, {
       params: {
         compressedZkpPublicKey:
-          filterByCompressedZkpPublicKey === true ? this.zkpKeys.compressedZkpPublicKey : null,
+          filterByCompressedZkpPublicKey === true ? [this.zkpKeys.compressedZkpPublicKey] : [],
         ercList,
       },
     });

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -1276,12 +1276,20 @@ class Nf3 {
     Returns the commitments of tokens held in layer 2
     @method
     @async
+    @param {Array} ercList - list of erc contract addresses to filter.
+    @param {Boolean} filterByCompressedZkpPublicKey- flag to indicate if request is filtered
     @returns {Promise} This promise resolves into an object whose properties are the
     addresses of the ERC contracts of the tokens held by this account in Layer 2. The
     value of each propery is an array of commitments originating from that contract.
     */
-  async getLayer2Commitments() {
-    const res = await axios.get(`${this.clientBaseUrl}/commitment/commitments`);
+  async getLayer2Commitments(ercList, filterByCompressedZkpPublicKey) {
+    const res = await axios.get(`${this.clientBaseUrl}/commitment/commitments`, {
+      params: {
+        compressedZkpPublicKey:
+          filterByCompressedZkpPublicKey === true ? this.zkpKeys.compressedZkpPublicKey : null,
+        ercList,
+      },
+    });
     return res.data.commitments;
   }
 

--- a/common-files/utils/httputils.mjs
+++ b/common-files/utils/httputils.mjs
@@ -23,7 +23,7 @@ const { LOG_HTTP_PAYLOAD_ENABLED, LOG_HTTP_FULL_DATA } = config;
  * Default obfuscation's rules.
  */
 const OBFUSCATION_SETTINGS = {
-  '^(?!.*public).*key(s)?$|.*password.*|.*secret.*|.*mnemonic.*': 'ALL',
+  '^(?!.*public).*key(s)?$|.*password.*|.*secret.*|.*mnemonic.*|.*salt.*': 'ALL',
 };
 
 const doObfuscation = object => {

--- a/docker/docker-compose.apps.yml
+++ b/docker/docker-compose.apps.yml
@@ -22,6 +22,8 @@ services:
       OPTIMIST_WS_PORT: ${OPTIMIST_WS_PORT:-8080}
       CLIENT_HOST: ${CLIENT_HOST:-client}
       CLIENT_PORT: ${CLIENT_PORT:-8080}
+      PROPOSER_HOST: ${PROPOSER_HOST}
+      PROPOSER_PORT: ${PROPOSER_PORT}
     networks:
       - nightfall_network
     volumes:

--- a/nightfall-client/src/routes/commitment.mjs
+++ b/nightfall-client/src/routes/commitment.mjs
@@ -62,7 +62,8 @@ router.get('/pending-spent', async (req, res, next) => {
 
 router.get('/commitments', async (req, res, next) => {
   try {
-    const commitments = await getWalletCommitments();
+    const { compressedZkpPublicKey, ercList } = req.query;
+    const commitments = await getWalletCommitments(compressedZkpPublicKey, ercList);
     res.json({ commitments });
   } catch (err) {
     next(err);

--- a/test/e2e/tokens/erc721.test.mjs
+++ b/test/e2e/tokens/erc721.test.mjs
@@ -94,7 +94,10 @@ describe('ERC721 tests', () => {
 
       const myPublicKey = nf3Users[0].zkpKeys.compressedZkpPublicKey;
       const balanceBefore = (await nf3Users[0].getLayer2Balances())[erc721Address]?.length || 0;
-      const unspentCommitmentsBefore = await nf3Users[0].getLayer2Commitments([erc721Address], true);
+      const unspentCommitmentsBefore = await nf3Users[0].getLayer2Commitments(
+        [erc721Address],
+        true,
+      );
       let nUnspentCommitmentsBefore = 0;
       if (myPublicKey in unspentCommitmentsBefore && unspentCommitmentsBefore[myPublicKey]) {
         nUnspentCommitmentsBefore = unspentCommitmentsBefore[myPublicKey][erc721Address].length;

--- a/test/e2e/tokens/erc721.test.mjs
+++ b/test/e2e/tokens/erc721.test.mjs
@@ -92,7 +92,13 @@ describe('ERC721 tests', () => {
     it('should deposit some ERC721 crypto into a ZKP commitment', async function () {
       const tokenToDeposit = availableTokenIds.shift();
 
+      const myPublicKey = nf3Users[0].zkpKeys.compressedZkpPublicKey;
       const balanceBefore = (await nf3Users[0].getLayer2Balances())[erc721Address]?.length || 0;
+      const unspentCommitmentsBefore = await nf3Users[0].getLayer2Commitments([erc721Address], true);
+      let nUnspentCommitmentsBefore = 0;
+      if (myPublicKey in unspentCommitmentsBefore && unspentCommitmentsBefore[myPublicKey]) {
+        nUnspentCommitmentsBefore = unspentCommitmentsBefore[myPublicKey][erc721Address].length;
+      }
 
       // We create enough transactions to fill blocks full of deposits.
       const res = await nf3Users[0].deposit(erc721Address, tokenTypeERC721, 0, tokenToDeposit, fee);
@@ -101,8 +107,14 @@ describe('ERC721 tests', () => {
       await emptyL2();
 
       const balanceAfter = (await nf3Users[0].getLayer2Balances())[erc721Address]?.length || 0;
+      const unspentCommitmentsAfter = await nf3Users[0].getLayer2Commitments([erc721Address], true);
+      let nUnspentCommitmentsAfter = 0;
+      if (myPublicKey in unspentCommitmentsAfter && unspentCommitmentsAfter[myPublicKey]) {
+        nUnspentCommitmentsAfter = unspentCommitmentsAfter[myPublicKey][erc721Address].length;
+      }
 
       expect(balanceAfter - balanceBefore).to.be.equal(1);
+      expect(nUnspentCommitmentsAfter - nUnspentCommitmentsBefore).to.be.equal(1);
     });
   });
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Several adjustments to make nightfall work with the SDK with future `tokenization` branch:
- filter unspent commitments. Burning transaction requires to burn at most a commitment, so we need to check number of existing unspent commitments. Modified nf3 `getLayer2Commitments` to accept a list of compressedZkpKeys and a list of ercAddresses to filter commitments
- add `salt` to obfuscation
- add `PROPOSER_PORT` and `PROPOSER_HOST` to proposer container env variables to allow to communicate client and proposer containers. Without this, client attempts to connect to `localhost:8092`, and this route is not enabled between containers. With the env variables, the proposer can register at `nightfall_3-proposer-1:8092` and that works.

## Does this close any currently open issues?
No

## What commands can I run to test the change? 
erc721.test includes verification of commitments

## Any other comments?
No
