### PR TITLE
Add check against sanctions list

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -40,6 +40,8 @@ module.exports = {
   WEBSOCKET_PORT: process.env.WEBSOCKET_PORT || 8080,
   WEBSOCKET_PING_TIME: 15000,
   ZOKRATES_WORKER_HOST: process.env.ZOKRATES_WORKER_HOST || 'worker',
+  SANCTIONS_CONTRACT:
+    process.env.TEST_SANCTIONS_CONTRACT || '0x40C57923924B5c5c5455c48D93317139ADDaC8fb',
   MULTISIG: {
     SIGNATURE_THRESHOLD: process.env.MULTISIG_SIGNATURE_THRESHOLD || 2, // number of signatures needed to perform an admin task
     APPROVERS: process.env.MULTISIG_APPROVERS
@@ -227,6 +229,9 @@ module.exports = {
       liquidityProvider:
         process.env.LIQUIDITY_PROVIDER_KEY ||
         '0xfbc1ee1c7332e2e5a76a99956f50b3ba2639aff73d56477e877ef8390c41e0c6',
+      sanctionedUser:
+        process.env.SANCTIONED_USER ||
+        '0xfbc1ee1c7332e2e5a76a99956f50b3ba2639aff73d56477e877ef8390c41e0c6',
     },
     addresses: {
       walletTest: process.env.WALLET_TEST_ADDRESS || '0xfCb059A4dB5B961d3e48706fAC91a55Bad0035C9',
@@ -239,6 +244,7 @@ module.exports = {
         process.env.BOOT_CHALLENGER_ADDRESS || '0xFFF578cDdc48792522F4a7Fdc3973Ec0d41A831f',
       liquidityProvider:
         process.env.LIQUIDITY_PROVIDER_ADDRESS || '0x4789FD18D5d71982045d85d5218493fD69F55AC4',
+      sanctionedUser: process.env.SANCTIONED_USER || '0x4789FD18D5d71982045d85d5218493fD69F55AC4',
     },
     zkpPublicKeys: {
       user1:
@@ -263,6 +269,9 @@ module.exports = {
         'crush power outer gadget enter maze advance rather divert monster indoor axis',
       liquidityProvider:
         process.env.LIQUIDITY_PROVIDER_MNEMONIC ||
+        'smart base soup sister army address member poem point quick save penalty',
+      sanctionedUser:
+        process.env.SANCTIONED_USER_MNEMONIC ||
         'smart base soup sister army address member poem point quick save penalty',
     },
     restrictions: {

--- a/doc/sanctions_list.md
+++ b/doc/sanctions_list.md
@@ -2,7 +2,7 @@
 
 Nightfall automatically checks the Chainalysis sanctions screening oracle [contract](https://go.chainalysis.com/chainalysis-oracle-docs.html#:~:text=The%20Chainalysis%20oracle%20is%20a,included%20in%20a%20sanctions%20designation).
 
-Although this check arguably forms part of a KYC check, it is not done via the KYC interface. This is because the sanctiosn contract already exposes its own interface, and manages its own blacklisting, thus there is nothing for Nightfall to do, other than to check the mapping held by the Chainalysis contract via the `SanctionsListInterface.sol` interface.
+Although this check arguably forms part of a KYC check, it is not done via the KYC interface. This is because the sanctions contract already exposes its own interface, and manages its own blacklisting, thus there is nothing for Nightfall to do, other than to check the mapping held by the Chainalysis contract via the `SanctionsListInterface.sol` interface.
 
 When testing, Nightfall uses a stub contract to simulate the Chainalysis one.  This has one sanctions-listed user (set in the default config's `TEST_OPTIONS` section) for test purposes. Nightfall will autmatically deploy this stub if the default config `SANCTIONS_CONTRACT` constant is set to anything other than an Ethereum address, in which case it will not deploy a stub but will call the sanctions list interface at that address.
 

--- a/doc/sanctions_list.md
+++ b/doc/sanctions_list.md
@@ -1,0 +1,9 @@
+# Checking sanctions list
+
+Nightfall automatically checks the Chainalysis sanctions screening oracle [contract](https://go.chainalysis.com/chainalysis-oracle-docs.html#:~:text=The%20Chainalysis%20oracle%20is%20a,included%20in%20a%20sanctions%20designation).
+
+Although this check arguably forms part of a KYC check, it is not done via the KYC interface. This is because the sanctiosn contract already exposes its own interface, and manages its own blacklisting, thus there is nothing for Nightfall to do, other than to check the mapping held by the Chainalysis contract via the `SanctionsListInterface.sol` interface.
+
+When testing, Nightfall uses a stub contract to simulate the Chainalysis one.  This has one sanctions-listed user (set in the default config's `TEST_OPTIONS` section) for test purposes. Nightfall will autmatically deploy this stub if the default config `SANCTIONS_CONTRACT` constant is set to anything other than an Ethereum address, in which case it will not deploy a stub but will call the sanctions list interface at that address.
+
+

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -67,6 +67,8 @@ services:
       - type: bind
         source: ../nightfall-deployer/entrypoint.sh
         target: /app/entrypoint.sh
+    environment:
+      TEST_SANCTIONS_CONTRACT: 'mock'
 
   optimist:
     build:

--- a/nightfall-deployer/contracts/SanctionsListInterface.sol
+++ b/nightfall-deployer/contracts/SanctionsListInterface.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+
+pragma solidity ^0.8.9;
+
+interface SanctionsListInterface {
+    function isSanctioned(address addr) external view returns (bool);
+}

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -28,13 +28,13 @@ contract Shield is Stateful, Config, ReentrancyGuardUpgradeable, Pausable {
     X509Interface x509;
     SanctionsListInterface sanctionsList;
 
-    function initializeState(address x509Address) public initializer {
+    function initializeState(address sanctionsListAddress, address x509Address) public initializer {
         sanctionsList = SanctionsListInterface(sanctionsListAddress);
         x509 = X509Interface(x509Address);
         initialize();
     }
 
-    function initialize() public override(Stateful, Config, Pausable, KYC) onlyInitializing {
+    function initialize() public override(Stateful, Config, Pausable) onlyInitializing {
         Stateful.initialize();
         Config.initialize();
         ReentrancyGuardUpgradeable.__ReentrancyGuard_init();

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -48,10 +48,13 @@ contract Shield is Stateful, Config, ReentrancyGuardUpgradeable, Pausable {
     function submitTransaction(Transaction calldata t) external payable nonReentrant whenNotPaused {
         // let everyone know what you did
         emit TransactionSubmitted();
-        require(x509.x509Check(msg.sender), 'You are not authorised to transact using Nightfall');
+        require(
+            x509.x509Check(msg.sender),
+            'Shield: You are not authorised to transact using Nightfall'
+        );
         require(
             !sanctionsList.isSanctioned(msg.sender),
-            'You are on the Chainalysis sanctions list'
+            'Shield: You are on the Chainalysis sanctions list'
         );
         if (t.transactionType == TransactionTypes.DEPOSIT) {
             txInfo[Utils.hashTransaction(t)].isEscrowed = true;
@@ -224,10 +227,13 @@ contract Shield is Stateful, Config, ReentrancyGuardUpgradeable, Pausable {
 
             state.addPendingWithdrawal(recipientAddress, uint256(advancedWithdrawal.advanceFee), 0);
         }
-        require(x509.x509Check(msg.sender), 'You are not authorised to transact using Nightfall');
+        require(
+            x509.x509Check(msg.sender),
+            'Shield: You are not authorised to transact using Nightfall'
+        );
         require(
             !sanctionsList.isSanctioned(msg.sender),
-            'You are on the Chainalysis sanctions list'
+            'Shield: You are on the Chainalysis sanctions list'
         );
         payOut(t, recipientAddress);
     }

--- a/nightfall-deployer/contracts/mocks/SanctionsListMock.sol
+++ b/nightfall-deployer/contracts/mocks/SanctionsListMock.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: CC0-1.0
+
+pragma solidity ^0.8.9;
+
+import '../SanctionsListInterface.sol';
+
+contract SanctionsListMock is SanctionsListInterface {
+    address sanctionedUser;
+    constructor(address _sanctionedUser) {
+        sanctionedUser = _sanctionedUser;
+    }
+    function isSanctioned(address user) external view returns (bool) {
+        if (user == sanctionedUser) return true;
+        return false;
+    }
+}

--- a/nightfall-deployer/migrations/2_deploy_upgradeable.js
+++ b/nightfall-deployer/migrations/2_deploy_upgradeable.js
@@ -11,15 +11,11 @@ const Challenges = artifacts.require('Challenges.sol');
 const State = artifacts.require('State.sol');
 const SimpleMultiSig = artifacts.require('SimpleMultiSig.sol');
 const X509 = artifacts.require('X509.sol');
-
-const config = require('config');
-
-const KYC = artifacts.require('KYC.sol');
 const SanctionsListMock = artifacts.require('SanctionsListMock.sol');
 
 const config = require('config');
 
-const { RESTRICTIONS, MULTISIG, SANCTIONS_CONTRACT, TEST_OPTIONS:{ addresses: { sanctionedUser} } } = config;
+const { RESTRICTIONS, MULTISIG, RSA_TRUST_ROOTS, SANCTIONS_CONTRACT, TEST_OPTIONS:{ addresses: { sanctionedUser} } } = config;
 const { addresses } = RESTRICTIONS;
 const { SIGNATURE_THRESHOLD, APPROVERS } = MULTISIG;
 const { network_id } = networks[process.env.ETH_NETWORK];

--- a/nightfall-deployer/migrations/2_deploy_upgradeable.js
+++ b/nightfall-deployer/migrations/2_deploy_upgradeable.js
@@ -53,6 +53,7 @@ module.exports = async function (deployer) {
   if (!web3.utils.isAddress(SANCTIONS_CONTRACT)) { 
     await deployer.deploy(SanctionsListMock, sanctionedUser);
     sanctionsContractAddress = SanctionsListMock.address;
+    console.log('SANTIONED', sanctionsContractAddress, sanctionedUser);
   }
   await deployProxy(X509, [], { deployer });
   await deployProxy(Proposers, [], { deployer, unsafeAllowLinkedLibraries: true });

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -36,7 +36,11 @@ const {
   },
 } = config;
 
-const nf3Users = [new Nf3(signingKeys.user1, environment), new Nf3(signingKeys.user2, environment)];
+const nf3Users = [
+  new Nf3(signingKeys.user1, environment),
+  new Nf3(signingKeys.user2, environment),
+  new Nf3(signingKeys.sanctionedUser, environment),
+];
 const nf3Proposer = new Nf3(signingKeys.proposer1, environment);
 
 const web3Client = new Web3Client();
@@ -95,6 +99,7 @@ describe('ERC20 tests', () => {
 
     await nf3Users[0].init(mnemonics.user1);
     await nf3Users[1].init(mnemonics.user2);
+    await nf3Users[2].init(mnemonics.santionedUser);
     erc20Address = await nf3Users[0].getContractAddress('ERC20Mock');
 
     stateAddress = await nf3Users[0].stateContractAddress;

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -99,7 +99,7 @@ describe('ERC20 tests', () => {
 
     await nf3Users[0].init(mnemonics.user1);
     await nf3Users[1].init(mnemonics.user2);
-    await nf3Users[2].init(mnemonics.santionedUser);
+    await nf3Users[2].init(mnemonics.sanctionedUser);
     erc20Address = await nf3Users[0].getContractAddress('ERC20Mock');
 
     stateAddress = await nf3Users[0].stateContractAddress;
@@ -122,6 +122,18 @@ describe('ERC20 tests', () => {
       const afterZkpPublicKeyBalance =
         (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
       expect(afterZkpPublicKeyBalance - currentZkpPublicKeyBalance).to.be.equal(transferValue);
+    });
+    it('should fail to deposit if the user is sanctioned', async function () {
+      try {
+        // user 2 is sanctioned
+        await nf3Users[2].deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+        expect.fail('Transaction has not been reverted by the EVM');
+      } catch (err) {
+        console.log(err);
+        expect(err.message).to.satisfy(message =>
+          message.includes('Transaction has been reverted by the EVM'),
+        );
+      }
     });
   });
 

--- a/test/unit/SmartContracts/challenges.unit.test.mjs
+++ b/test/unit/SmartContracts/challenges.unit.test.mjs
@@ -19,6 +19,12 @@ describe('Challenges contract Challenges functions', function () {
   let shield;
   let merkleTree;
   let challengesUtil;
+  let sanctionedSigner;
+
+  before(async () => {
+    const owner = await ethers.getSigners();
+    [, , , , sanctionedSigner] = owner;
+  });
 
   beforeEach(async () => {
     [addr1] = await ethers.getSigners();
@@ -75,8 +81,14 @@ describe('Challenges contract Challenges functions', function () {
     const x509 = await upgrades.deployProxy(X509, []);
     await x509.deployed();
 
+    const SanctionsListMockDeployer = await ethers.getContractFactory('SanctionsListMock');
+    const sanctionsListMockInstance = await SanctionsListMockDeployer.deploy(
+      sanctionedSigner.address,
+    );
+    const sanctionsListAddress = sanctionsListMockInstance.address;
+
     const Shield = await ethers.getContractFactory('Shield');
-    shield = await upgrades.deployProxy(Shield, [x509.address], {
+    shield = await upgrades.deployProxy(Shield, [sanctionsListAddress, X509.address], {
       initializer: 'initializeState',
     });
     await shield.deployed();

--- a/test/unit/SmartContracts/challenges.unit.test.mjs
+++ b/test/unit/SmartContracts/challenges.unit.test.mjs
@@ -79,7 +79,6 @@ describe('Challenges contract Challenges functions', function () {
 
     const X509 = await ethers.getContractFactory('X509');
     const x509 = await upgrades.deployProxy(X509, []);
-    await x509.deployed();
 
     const SanctionsListMockDeployer = await ethers.getContractFactory('SanctionsListMock');
     const sanctionsListMockInstance = await SanctionsListMockDeployer.deploy(
@@ -88,7 +87,7 @@ describe('Challenges contract Challenges functions', function () {
     const sanctionsListAddress = sanctionsListMockInstance.address;
 
     const Shield = await ethers.getContractFactory('Shield');
-    shield = await upgrades.deployProxy(Shield, [sanctionsListAddress, X509.address], {
+    shield = await upgrades.deployProxy(Shield, [sanctionsListAddress, x509.address], {
       initializer: 'initializeState',
     });
     await shield.deployed();

--- a/test/unit/SmartContracts/proposers.unit.test.mjs
+++ b/test/unit/SmartContracts/proposers.unit.test.mjs
@@ -59,7 +59,6 @@ describe('Proposers contract Proposers functions', function () {
 
     const X509 = await ethers.getContractFactory('X509');
     const x509 = await upgrades.deployProxy(X509, []);
-    await x509.deployed();
 
     const SanctionsListMockDeployer = await ethers.getContractFactory('SanctionsListMock');
     const sanctionsListMockInstance = await SanctionsListMockDeployer.deploy(
@@ -68,7 +67,7 @@ describe('Proposers contract Proposers functions', function () {
     const sanctionsListAddress = sanctionsListMockInstance.address;
 
     const Shield = await ethers.getContractFactory('Shield');
-    const shield = await upgrades.deployProxy(Shield, [sanctionsListAddress, X509.adress], {
+    const shield = await upgrades.deployProxy(Shield, [sanctionsListAddress, x509.address], {
       initializer: 'initializeState',
     });
     await shield.deployed();

--- a/test/unit/SmartContracts/proposers.unit.test.mjs
+++ b/test/unit/SmartContracts/proposers.unit.test.mjs
@@ -8,6 +8,12 @@ describe('Proposers contract Proposers functions', function () {
   let addr1;
   let addr2;
   let state;
+  let sanctionedSigner;
+
+  before(async () => {
+    const owner = await ethers.getSigners();
+    [, , , , sanctionedSigner] = owner;
+  });
 
   beforeEach(async () => {
     [addr1, addr2] = await ethers.getSigners();
@@ -55,8 +61,14 @@ describe('Proposers contract Proposers functions', function () {
     const x509 = await upgrades.deployProxy(X509, []);
     await x509.deployed();
 
+    const SanctionsListMockDeployer = await ethers.getContractFactory('SanctionsListMock');
+    const sanctionsListMockInstance = await SanctionsListMockDeployer.deploy(
+      sanctionedSigner.address,
+    );
+    const sanctionsListAddress = sanctionsListMockInstance.address;
+
     const Shield = await ethers.getContractFactory('Shield');
-    const shield = await upgrades.deployProxy(Shield, [x509.address], {
+    const shield = await upgrades.deployProxy(Shield, [sanctionsListAddress, X509.adress], {
       initializer: 'initializeState',
     });
     await shield.deployed();

--- a/test/unit/SmartContracts/shield.unit.test.mjs
+++ b/test/unit/SmartContracts/shield.unit.test.mjs
@@ -201,6 +201,7 @@ describe('Testing Shield Contract', function () {
       expect(
         ShieldInstance.connect(sanctionedSigner).submitTransaction(depositTransaction),
       ).to.be.revertedWith('You are on the Chainalysis sanctions list');
+      await ShieldInstance.connect(owner[0]);
     });
 
     it('succeeds and sets is Escrowed to true for a deposit transaction of an ERC721 token', async function () {
@@ -316,7 +317,7 @@ describe('Testing Shield Contract', function () {
     it('fails if user is not whitelisted and whitelisting is active', async function () {
       await X509Instance.enableWhitelisting(true);
       await expect(ShieldInstance.submitTransaction(withdrawTransaction)).to.be.revertedWith(
-        'You are not authorised to transact using Nightfall',
+        'Shield: You are not authorised to transact using Nightfall',
       );
     });
 

--- a/test/unit/SmartContracts/shield.unit.test.mjs
+++ b/test/unit/SmartContracts/shield.unit.test.mjs
@@ -200,7 +200,7 @@ describe('Testing Shield Contract', function () {
       await Erc20MockInstance.approve(shieldAddress, '10');
       expect(
         ShieldInstance.connect(sanctionedSigner).submitTransaction(depositTransaction),
-      ).to.be.revertedWith('You are on the Chainalysis sanctions list');
+      ).to.be.revertedWith('Shield: You are on the Chainalysis sanctions list');
       await ShieldInstance.connect(owner[0]);
     });
 
@@ -1100,7 +1100,7 @@ describe('Testing Shield Contract', function () {
 
       await expect(
         ShieldInstance.finaliseWithdrawal(block, withdrawTransaction, index, siblingPath),
-      ).to.be.revertedWith('You are not authorised to transact using Nightfall');
+      ).to.be.revertedWith('Shield: You are not authorised to transact using Nightfall');
     });
 
     it('fails to finalise withdrawal if tokenType is ERC20 and tokenId not zero', async function () {

--- a/test/unit/SmartContracts/state.unit.test.mjs
+++ b/test/unit/SmartContracts/state.unit.test.mjs
@@ -13,6 +13,12 @@ describe('State contract State functions', function () {
   let addressC;
   let transactionsCreated;
   let shield;
+  let sanctionedSigner;
+
+  before(async () => {
+    const owner = await ethers.getSigners();
+    [, , , , sanctionedSigner] = owner;
+  });
 
   beforeEach(async () => {
     [addr1, addr2, addressC] = await ethers.getSigners();
@@ -70,8 +76,16 @@ describe('State contract State functions', function () {
     const X509Instance = await upgrades.deployProxy(X509Deployer);
     const x509Address = X509Instance.address;
 
+    const SanctionsListMockDeployer = await ethers.getContractFactory('SanctionsListMock');
+    const sanctionsListMockInstance = await SanctionsListMockDeployer.deploy(
+      sanctionedSigner.address,
+    );
+    const sanctionsListAddress = sanctionsListMockInstance.address;
+
     const Shield = await ethers.getContractFactory('Shield');
-    shield = await upgrades.deployProxy(Shield, [x509Address], { initializer: 'initializeState' });
+    shield = await upgrades.deployProxy(Shield, [sanctionsListAddress, x509Address], {
+      initializer: 'initializeState',
+    });
     await shield.deployed();
 
     const Utils = await ethers.getContractFactory('Utils');


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

This PR adds checking against the Chainalysis sanctions-screening oracle smart contract before allowing a deposit or final withdrawal transaction.  More details are give in [sanctions_list.md](https://github.com/EYBlockchain/nightfall_3/blob/westlad/sanctions/doc/sanctions_list.md)

## Does this close any currently open issues?

fixes #1209

## What commands can I run to test the change? 

All tests have been upgraded to test this functionality via a stub contract, so normal test scripts can be run. In particular, the Shield contract unit and the erc20 token integration tests now specifically test this functionality.

## Any other comments?

None