### PR TITLE
Mutliple adversary fixes

### DIFF
--- a/nightfall-optimist/src/event-handlers/block-proposed.mjs
+++ b/nightfall-optimist/src/event-handlers/block-proposed.mjs
@@ -94,7 +94,7 @@ async function blockProposedEventHandler(data) {
 
     // mark transactions so that they are out of the mempool,
     // so we don't try to use them in a block which we're proposing.
-    await removeTransactionsFromMemPool(block.transactionHashes, block.blockNumberL2); // TODO is await needed?
+    await removeTransactionsFromMemPool(block.transactionHashes, block.blockNumberL2);
     const blockCommitments = transactions
       .map(t => t.commitments.filter(c => c !== ZERO))
       .flat(Infinity);

--- a/nightfall-optimist/src/event-handlers/rollback.mjs
+++ b/nightfall-optimist/src/event-handlers/rollback.mjs
@@ -10,7 +10,7 @@ import {
   addTransactionsToMemPool,
   deleteBlock,
   findBlocksFromBlockNumberL2,
-  getTransactionsByTransactionHashes,
+  getTransactionsByTransactionHashesByL2Block,
   deleteTransactionsByTransactionHashes,
   deleteTreeByBlockNumberL2,
   getAllRegisteredProposersCount,
@@ -53,7 +53,9 @@ async function rollbackEventHandler(data) {
     const transactionHashesInBlock = blocksToBeDeleted[i].transactionHashes.flat(Infinity);
     // Use the transaction hashes to grab the actual transactions filtering out deposits - In Order.
     // eslint-disable-next-line no-await-in-loop
-    const blockTransactions = await getTransactionsByTransactionHashes(transactionHashesInBlock); // TODO move this to getTransactionsByTransactionHashes by l2 block number because transaction hash is not unique and might not pull the right l2 block number
+    const blockTransactions = await getTransactionsByTransactionHashesByL2Block(
+      transactionHashesInBlock,
+    );
     logger.info({
       msg: 'Rollback - blockTransactions to check:',
       blockTransactions,

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -11,6 +11,8 @@ import constants from '@polygon-nightfall/common-files/constants/index.mjs';
 import { waitForContract } from '@polygon-nightfall/common-files/utils/contract.mjs';
 import {
   removeTransactionsFromMemPool,
+  removeCommitmentsFromMemPool,
+  removeNullifiersFromMemPool,
   getMostProfitableTransactions,
   numberOfUnprocessedTransactions,
 } from './database.mjs';
@@ -159,6 +161,10 @@ export async function conditionalMakeBlock(proposer) {
         // remove the transactions from the mempool so we don't keep making new
         // blocks with them
         await removeTransactionsFromMemPool(block.transactionHashes);
+        await removeCommitmentsFromMemPool(
+          transactions.map(transaction => transaction.commitments),
+        );
+        await removeNullifiersFromMemPool(transactions.map(transaction => transaction.commitments));
       }
     }
   }

--- a/nightfall-optimist/src/services/check-block.mjs
+++ b/nightfall-optimist/src/services/check-block.mjs
@@ -227,7 +227,7 @@ export async function checkBlock(block, transactions) {
       await checkTransaction(transaction, false, { blockNumberL2: block.blockNumberL2 }); // eslint-disable-line no-await-in-loop
     }
   } catch (err) {
-    if (err.code + 2 === 2 || err.code + 2 === 3) {
+    if (err.code === 0 || err.code === 1) {
       let siblingPath1 = (await getTransactionHashSiblingInfo(transaction.transactionHash))
         .transactionHashSiblingPath;
       // case when block.build never was called

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -472,18 +472,6 @@ export async function deleteTransactionsByTransactionHashes(transactionHashes) {
   return db.collection(TRANSACTIONS_COLLECTION).deleteMany(query);
 }
 
-/*
-For added safety we only delete mempool: true, we should never be deleting
-transactions from our local db that have been spent.
-*/
-export async function deleteTransactionsByTransactionHashesL2BlockNumber(transactionHashes) {
-  const connection = await mongo.connection(MONGO_URL);
-  const db = connection.db(OPTIMIST_DB);
-  // We should not delete from a spent mempool
-  const query = { transactionHash: { $in: transactionHashes }, blockNumberL2: -1, mempool: true };
-  return db.collection(TRANSACTIONS_COLLECTION).deleteMany(query);
-}
-
 /**
  * Function that sets the Transactions's L1 blocknumber to null
  * to indicate that it's back in the L1 mempool (and will probably be re-mined

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -438,6 +438,28 @@ export async function getTransactionsByTransactionHashes(transactionHashes) {
   return transactions;
 }
 
+/**
+function to find transactions with a transactionHash in the array transactionHashes.
+*/
+export async function getTransactionsByTransactionHashesByL2Block(transactionHashes, block) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  const query = {
+    transactionHash: { $in: transactionHashes },
+    blockNumberL2: { $eq: block.blockNumberL2 },
+  };
+  const returnedTransactions = await db.collection(TRANSACTIONS_COLLECTION).find(query).toArray();
+  // Create a dictionary where we will store the correct position ordering
+  const positions = {};
+  // Use the ordering of txHashes in the block to fill the dictionary-indexed by txHash
+  // eslint-disable-next-line no-return-assign
+  transactionHashes.forEach((t, index) => (positions[t] = index));
+  const transactions = returnedTransactions.sort(
+    (a, b) => positions[a.transactionHash] - positions[b.transactionHash],
+  );
+  return transactions;
+}
+
 /*
 For added safety we only delete mempool: true, we should never be deleting
 transactions from our local db that have been spent.
@@ -447,6 +469,18 @@ export async function deleteTransactionsByTransactionHashes(transactionHashes) {
   const db = connection.db(OPTIMIST_DB);
   // We should not delete from a spent mempool
   const query = { transactionHash: { $in: transactionHashes }, mempool: true };
+  return db.collection(TRANSACTIONS_COLLECTION).deleteMany(query);
+}
+
+/*
+For added safety we only delete mempool: true, we should never be deleting
+transactions from our local db that have been spent.
+*/
+export async function deleteTransactionsByTransactionHashesL2BlockNumber(transactionHashes) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  // We should not delete from a spent mempool
+  const query = { transactionHash: { $in: transactionHashes }, blockNumberL2: -1, mempool: true };
   return db.collection(TRANSACTIONS_COLLECTION).deleteMany(query);
 }
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Rollback should retrieve transactions of an L2 block by its L2 block number and not just transaction hash because it is not unique in the event of duplicate transactions.

Today, transactions from mempool are removed after creating an L2 block during block assembly and receiving an L2 block as part of L2 block proposed event. It is important to note that commitments and nullifiers can have duplicates in mempool that have not been proposed yet, these transactions should also be removed from mempool. The PR fixes this.

Refactor check-block code.

Challenger might catch wrong proof error when the testing requires catching of duplicate nullifier/commitment. As long as the bad transaction is caught, we do not care which of the two reasons it is caught under. 

## Does this close any currently open issues?
239, 242, 243, 247 

## What commands can I run to test the change? 
Github action

## Any other comments?

