### PR TITLE
Calculate slot value in PoS dynamically

### DIFF
--- a/nightfall-deployer/contracts/Config.sol
+++ b/nightfall-deployer/contracts/Config.sol
@@ -15,7 +15,6 @@ contract Config is Ownable, Structures {
     uint96 minimumStake;
     uint96 blockStake;
     uint256 rotateProposerBlocks;
-    uint256 valuePerSlot; // amount of value of a slot
     uint256 proposerSetCount; // number of slots to pop after shuffling slots that will build the proposer set
     uint256 sprintsInSpan; // number of sprints of a span
     uint256 maxProposers; // maximum number of proposers for the PoS
@@ -30,7 +29,6 @@ contract Config is Ownable, Structures {
         minimumStake = 1000000 wei;
         blockStake = 1 wei;
         rotateProposerBlocks = 20;
-        valuePerSlot = minimumStake / 10;
         proposerSetCount = 5;
         sprintsInSpan = 5;
         maxProposers = 100;
@@ -110,20 +108,6 @@ contract Config is Ownable, Structures {
     function removeRestriction(address tokenAddr) external onlyOwner {
         delete erc20limit[tokenAddr][0];
         delete erc20limit[tokenAddr][1];
-    }
-
-    /**
-     * @dev Set value per slot in PoS
-     */
-    function setValuePerSlot(uint256 _valuePerSlot) external onlyOwner {
-        valuePerSlot = _valuePerSlot;
-    }
-
-    /**
-     * @dev Get value per slot in PoS
-     */
-    function getValuePerSlot() public view returns (uint256) {
-        return valuePerSlot;
     }
 
     /**

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -609,7 +609,7 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Config {
         uint256 weight;
 
         uint256 slotValue; // we calculate the slotValue depending on the proposer stakes
-        uint256 maximumSlots = 10; // maximum slots we want for the bigger proposer stake
+        uint256 maximumSlots = 10; // maximum slots we want for the biggest proposer stake
         while (p.nextAddress != currentProposer.thisAddress) {
             stake = getStakeAccount(p.thisAddress);
             if (slotValue < stake.amount / maximumSlots) {

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -608,49 +608,38 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Config {
         TimeLockedStake memory stake;
         uint256 weight;
 
-        uint256 slotValue;
-        if (numProposers == 1) {
-            stake = getStakeAccount(p.thisAddress);
-            slotValue = stake.amount / 10;
-        } else {
-            while (p.nextAddress != currentProposer.thisAddress) {
-                stake = getStakeAccount(p.thisAddress);
-                if (slotValue < stake.amount / 10) {
-                    slotValue = stake.amount / 10;
-                }
-                p = proposers[p.nextAddress];
-            }
+        uint256 slotValue; // we calculate the slotValue depending on the proposer stakes
+        while (p.nextAddress != currentProposer.thisAddress) {
             stake = getStakeAccount(p.thisAddress);
             if (slotValue < stake.amount / 10) {
                 slotValue = stake.amount / 10;
             }
+            p = proposers[p.nextAddress];
         }
+        stake = getStakeAccount(p.thisAddress);
+        if (slotValue < stake.amount / 10) {
+            slotValue = stake.amount / 10;
+        }
+
+        p = currentProposer;
 
         // 1) remove all slots
         delete slots;
         // 2) assign slots based on the stake of the proposers
-        if (numProposers == 1) {
+        while (p.nextAddress != currentProposer.thisAddress) {
             stake = getStakeAccount(p.thisAddress);
             weight = stake.amount / slotValue;
+            if (weight == 0) weight = 1;
             for (uint256 i = 0; i < weight; i++) {
                 slots.push(p.thisAddress);
             }
-        } else {
-            while (p.nextAddress != currentProposer.thisAddress) {
-                stake = getStakeAccount(p.thisAddress);
-                weight = stake.amount / slotValue;
-                if (weight < 1) weight = 1;
-                for (uint256 i = 0; i < weight; i++) {
-                    slots.push(p.thisAddress);
-                }
-                p = proposers[p.nextAddress];
-            }
-            stake = getStakeAccount(p.thisAddress);
-            weight = stake.amount / slotValue;
-            if (weight < 1) weight = 1;
-            for (uint256 i = 0; i < weight; i++) {
-                slots.push(p.thisAddress);
-            }
+            p = proposers[p.nextAddress];
+        }
+        stake = getStakeAccount(p.thisAddress);
+        weight = stake.amount / slotValue;
+        if (weight == 0) weight = 1;
+        for (uint256 i = 0; i < weight; i++) {
+            slots.push(p.thisAddress);
         }
     }
 

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -609,16 +609,17 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Config {
         uint256 weight;
 
         uint256 slotValue; // we calculate the slotValue depending on the proposer stakes
+        uint256 minimumSlots = 10; // minimum slots we want for the bigger proposer stake
         while (p.nextAddress != currentProposer.thisAddress) {
             stake = getStakeAccount(p.thisAddress);
-            if (slotValue < stake.amount / 10) {
-                slotValue = stake.amount / 10;
+            if (slotValue < stake.amount / minimumSlots) {
+                slotValue = stake.amount / minimumSlots;
             }
             p = proposers[p.nextAddress];
         }
         stake = getStakeAccount(p.thisAddress);
-        if (slotValue < stake.amount / 10) {
-            slotValue = stake.amount / 10;
+        if (slotValue < stake.amount / minimumSlots) {
+            slotValue = stake.amount / minimumSlots;
         }
 
         p = currentProposer;

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -609,17 +609,17 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Config {
         uint256 weight;
 
         uint256 slotValue; // we calculate the slotValue depending on the proposer stakes
-        uint256 minimumSlots = 10; // minimum slots we want for the bigger proposer stake
+        uint256 maximumSlots = 10; // maximum slots we want for the bigger proposer stake
         while (p.nextAddress != currentProposer.thisAddress) {
             stake = getStakeAccount(p.thisAddress);
-            if (slotValue < stake.amount / minimumSlots) {
-                slotValue = stake.amount / minimumSlots;
+            if (slotValue < stake.amount / maximumSlots) {
+                slotValue = stake.amount / maximumSlots;
             }
             p = proposers[p.nextAddress];
         }
         stake = getStakeAccount(p.thisAddress);
-        if (slotValue < stake.amount / minimumSlots) {
-            slotValue = stake.amount / minimumSlots;
+        if (slotValue < stake.amount / maximumSlots) {
+            slotValue = stake.amount / maximumSlots;
         }
 
         p = currentProposer;

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -591,7 +591,7 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Config {
      * @dev Initialize a new span
      */
     function initializeSpan() internal {
-        fillSlots(); // 1) initialize slots based on the stake and valuePerSlot
+        fillSlots(); // 1) initialize slots based on the stake
         shuffleSlots(); // 2) shuffle the slots
         spanProposerSet(); // 3) pop the proposer set from shuffled slots
     }

--- a/test/multisig/administrator.test.mjs
+++ b/test/multisig/administrator.test.mjs
@@ -153,27 +153,6 @@ describe(`Testing Administrator`, () => {
       expect(Number(rotateProposerBlocks)).to.be.equal(amount2);
     });
 
-    it('Set value per slot in PoS with the multisig', async () => {
-      const transactions = await nfMultiSig.setValuePerSlot(
-        amount1,
-        signingKeys.user1,
-        addresses.user1,
-        await multisigContract.methods.nonce().call(),
-        [],
-      );
-      const approved = await nfMultiSig.setValuePerSlot(
-        amount1,
-        signingKeys.user2,
-        addresses.user1,
-        await multisigContract.methods.nonce().call(),
-        transactions,
-      );
-      await nfMultiSig.multiSig.executeMultiSigTransactions(approved, signingKeys.user1);
-      const rotateProposerBlocks = await shieldContract.methods.getValuePerSlot().call();
-
-      expect(Number(rotateProposerBlocks)).to.be.equal(amount1);
-    });
-
     it('Set proposer set count in PoS with the multisig', async () => {
       const transactions = await nfMultiSig.setProposerSetCount(
         amount1 / 2,
@@ -524,13 +503,6 @@ describe(`Testing Administrator`, () => {
       const rotateProposerBlocks = await shieldContract.methods.getRotateProposerBlocks().call();
 
       expect(Number(rotateProposerBlocks)).to.be.equal(amount2);
-    });
-
-    it('Set value per slot in PoS without multisig', async () => {
-      await shieldContract.methods.setValuePerSlot(amount1).send({ from: nf3User.ethereumAddress });
-      const rotateProposerBlocks = await shieldContract.methods.getValuePerSlot().call();
-
-      expect(Number(rotateProposerBlocks)).to.be.equal(amount1);
     });
 
     it('Set proposer set count in PoS without multisig', async () => {

--- a/test/multisig/nightfall-multisig.mjs
+++ b/test/multisig/nightfall-multisig.mjs
@@ -327,29 +327,6 @@ export class NightfallMultiSig {
   }
 
   /**
-  This function sets the value per slot for PoS
-  */
-  async setValuePerSlot(newValuePerSlot, signingKey, executorAddress, _nonce, transactions) {
-    let nonce = _nonce;
-    if (!Number.isInteger(nonce)) nonce = await this.multiSig.getMultiSigNonce();
-
-    return Promise.all(
-      this.contractInstancesConfigurables().map(async (configurable, i) => {
-        const contractInstance = configurable;
-        const data = contractInstance.methods.setValuePerSlot(newValuePerSlot).encodeABI();
-        return this.multiSig.addMultiSigSignature(
-          data,
-          signingKey,
-          contractInstance.options.address,
-          executorAddress,
-          nonce + i,
-          transactions.flat(),
-        );
-      }),
-    );
-  }
-
-  /**
   This function sets the proposer set count for PoS
   */
   async setProposerSetCount(

--- a/test/ping-pong/index.mjs
+++ b/test/ping-pong/index.mjs
@@ -183,29 +183,6 @@ const setMinimumStake = async amount => {
 };
 
 /**
-Set the value per slot parameter for the proposers
-*/
-const setValuePerSlot = async amount => {
-  const transactions = await nfMultiSig.setValuePerSlot(
-    amount,
-    signingKeys.user1,
-    addresses.user1,
-    await multisigContract.methods.nonce().call(),
-    [],
-  );
-  const approved = await nfMultiSig.setValuePerSlot(
-    amount,
-    signingKeys.user2,
-    addresses.user1,
-    await multisigContract.methods.nonce().call(),
-    transactions,
-  );
-  await nfMultiSig.multiSig.executeMultiSigTransactions(approved, signingKeys.user1);
-  const valuePerSlot = await shieldContract.methods.getValuePerSlot().call();
-  console.log('VALUE PER SLOT SET: ', valuePerSlot);
-};
-
-/**
 Set parameters config for the test
 */
 export async function setParametersConfig() {
@@ -234,7 +211,6 @@ export async function setParametersConfig() {
 
   await setBlockStake(amountBlockStake);
   await setMinimumStake(amountMinimumStake);
-  await setValuePerSlot(amountMinimumStake / 10);
 }
 
 /**

--- a/test/unit/SmartContracts/state.unit.test.mjs
+++ b/test/unit/SmartContracts/state.unit.test.mjs
@@ -567,55 +567,6 @@ describe('State contract State functions', function () {
     expect(await state.currentSprint()).to.equal(prevSprint + 1);
   });
 
-  it('should not change current proposer with numProposers > 1 and getMinimumStake() / getValuePerSlot() -1 wei in stake', async function () {
-    const newUrl = 'url';
-    const newFee = 100;
-    const amount = (await state.getMinimumStake()).div(await state.getValuePerSlot()).sub(1);
-    const challengeLocked = 5;
-
-    expect((await state.getCurrentProposer()).thisAddress).to.equal(ethers.constants.AddressZero);
-    expect((await state.getProposer(addr1.address)).thisAddress).to.equal(
-      ethers.constants.AddressZero,
-    );
-
-    await state.setProposer(addr1.address, [
-      addr1.address,
-      addr1.address,
-      addr2.address,
-      newUrl,
-      newFee,
-      false,
-      0,
-    ]);
-
-    expect((await state.getProposer(addr1.address)).thisAddress).to.equal(addr1.address);
-    expect((await state.proposers(addr1.address)).thisAddress).to.equal(addr1.address);
-    expect((await state.proposers(addr1.address)).nextAddress).to.equal(addr2.address);
-    expect((await state.proposers(addr1.address)).url).to.equal(newUrl);
-    expect((await state.proposers(addr1.address)).fee).to.equal(newFee);
-
-    await state.setProposer(addr2.address, [
-      addr2.address,
-      addr2.address,
-      addr2.address,
-      newUrl,
-      newFee,
-      false,
-      0,
-    ]);
-    await state.setNumProposers(2);
-    await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await state.setStakeAccount(addr2.address, amount, challengeLocked);
-    await state.setCurrentProposer(addr1.address);
-
-    expect((await state.getCurrentProposer()).thisAddress).to.equal(addr1.address);
-    const prevSprint = await state.currentSprint();
-
-    await expect(state.changeCurrentProposer()).to.be.reverted;
-
-    expect(await state.currentSprint()).to.equal(prevSprint);
-  });
-
   it('should proposeBlock', async function () {
     const newUrl = 'url';
     const newFee = 100;

--- a/test/unit/utils/shieldStorage.mjs
+++ b/test/unit/utils/shieldStorage.mjs
@@ -4,9 +4,9 @@ import { setStorageAt } from '@nomicfoundation/hardhat-network-helpers';
 
 const { ethers } = hardhat;
 
-const whitelistSlot = 163;
-const txInfoSlot = 166;
-const advancedWithdrawalSlot = 167;
+const whitelistSlot = 162;
+const txInfoSlot = 165;
+const advancedWithdrawalSlot = 166;
 
 export async function setTransactionInfo(shieldAddress, transactionHash, isEscrowed, isWithdrawn) {
   const index = ethers.utils.solidityKeccak256(

--- a/test/unit/utils/stateStorage.mjs
+++ b/test/unit/utils/stateStorage.mjs
@@ -5,10 +5,10 @@ import { setStorageAt, time } from '@nomicfoundation/hardhat-network-helpers';
 
 const { ethers } = hardhat;
 
-const blockHashesSlot = 162;
-const stakeAccountsSlot = 165;
-const feeBookIndex = 166;
-const claimedBlockStakesSlot = 167;
+const blockHashesSlot = 161;
+const stakeAccountsSlot = 164;
+const feeBookIndex = 165;
+const claimedBlockStakesSlot = 166;
 
 export async function setBlockPaymentClaimed(stateAddress, blockHash) {
   const index = ethers.utils.solidityKeccak256(


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Fix #1189 . Calculate the slot value dynamically for calculating the staking power of each proposer in next span of the PoS.

## Does this close any currently open issues?
Yes. #1189 

## What commands can I run to test the change? 
npm run test-e2e-protocol

## Any other comments?
No
