### PR TITLE
ChangeCurrentProposer - calculation of the next proposers

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -8,6 +8,7 @@ import 'solidity-coverage';
 import 'hardhat-gas-reporter';
 
 const config: HardhatUserConfig = {
+  defaultNetwork: "hardhat",
   solidity: {
     version: '0.8.17',
     settings: {
@@ -15,6 +16,12 @@ const config: HardhatUserConfig = {
         enabled: true,
         runs: 200,
       },
+    },
+  },
+  networks: {
+    hardhat: {
+      chainId: 1337,
+      allowUnlimitedContractSize: true
     },
   },
   gasReporter: { enabled: true },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -8,7 +8,6 @@ import 'solidity-coverage';
 import 'hardhat-gas-reporter';
 
 const config: HardhatUserConfig = {
-  defaultNetwork: "hardhat",
   solidity: {
     version: '0.8.17',
     settings: {
@@ -16,12 +15,6 @@ const config: HardhatUserConfig = {
         enabled: true,
         runs: 200,
       },
-    },
-  },
-  networks: {
-    hardhat: {
-      chainId: 1337,
-      allowUnlimitedContractSize: true
     },
   },
   gasReporter: { enabled: true },

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -36,7 +36,7 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Key_Registry, Config {
     address[] public slots; // slots based on proposers stake
     ProposerSet[] public proposersSet; // proposer set for next span
     uint256 public currentSprint; // the current sprint of the span
-    address[] public proposersList;
+    address[] public spanProposersList;
 
     function initialize() public override(Pausable, Key_Registry, Config) {
         Pausable.initialize();
@@ -543,7 +543,7 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Key_Registry, Config {
             currentSprint = 0; // We don't have sprints because always same proposer
             addressBestPeer = currentProposer.thisAddress;
         } else {
-            addressBestPeer = proposersList[currentSprint];
+            addressBestPeer = spanProposersList[currentSprint];
             currentSprint += 1;
 
             if (currentSprint == sprintsInSpan) {
@@ -561,13 +561,14 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Key_Registry, Config {
         emit NewCurrentProposer(currentProposer.thisAddress);
     }
 
-    function getProposersList() public view returns (address[] memory) {
-        return proposersList;
+    function getSpanProposersList() public view returns (address[] memory) {
+        return spanProposersList;
     }
 
     function calculateNextProposers(address addressBestPeer) internal {
         ProposerSet memory peer;
         uint256 totalEffectiveWeight = 0;
+        delete spanProposersList;
         for (uint256 j = 0; j < proposerSetCount; j++) {
             for (uint256 i = 0; i < proposersSet.length; i++) {
                 peer = proposersSet[i];
@@ -589,7 +590,7 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Key_Registry, Config {
                     totalEffectiveWeight
                 );
 
-            proposersList.push(addressBestPeer);
+            spanProposersList.push(addressBestPeer);
         }
     }
 

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -562,10 +562,6 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Key_Registry, Config {
         emit NewCurrentProposer(currentProposer.thisAddress);
     }
 
-    function getSpanProposersList() public view returns (address[] memory) {
-        return spanProposersList;
-    }
-
     function calculateNextProposers(address addressBestPeer) internal {
         ProposerSet memory peer;
         uint256 totalEffectiveWeight = 0;

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -366,8 +366,9 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Key_Registry, Config {
     }
 
     function setNumProposers(uint256 np) public onlyProposer {
+        uint256 prevNumProposers = numProposers;
         numProposers = np;
-        if (numProposers == 2) {
+        if (numProposers == 2 && prevNumProposers == 1) {
             initializeSpan();
             calculateNextProposers(address(0));
         }

--- a/test/unit/SmartContracts/state.unit.test.mjs
+++ b/test/unit/SmartContracts/state.unit.test.mjs
@@ -1158,49 +1158,10 @@ describe('State contract State functions', function () {
     expect(stakeAccount.amount).to.equal(amount);
     expect(stakeAccount.time).to.equal(0);
     expect(stakeAccount.challengeLocked).to.equal(challengeLocked - amount);
-    expect(await state.pendingWithdrawals(addressC.address, 0)).to.equal(badBlock.blockStake);
-    expect(await state.pendingWithdrawals(addressC.address, 1)).to.equal(0);
-  });
-
-  it('should setBlockStakeWithdrawn', async function () {
-    const newUrl = 'url';
-    const newFee = 100;
-    const amount = 100;
-    const challengeLocked = 5;
-
-    await state.setProposer(addr1.address, [
-      addr1.address,
-      addr1.address,
-      addr1.address,
-      newUrl,
-      newFee,
-      false,
-      0,
-    ]);
-    await state.setCurrentProposer(addr1.address);
-    await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
-      shield.address,
-      calculateTransactionHash(transactionsCreated.withdrawTransaction),
-      true,
-      false,
+    expect((await state.pendingWithdrawalsFees(addressC.address)).feesEth).to.equal(
+      badBlock.blockStake,
     );
-    await setTransactionInfo(
-      shield.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      false,
-    );
-    await state.proposeBlock(
-      transactionsCreated.block,
-      [transactionsCreated.withdrawTransaction, transactionsCreated.depositTransaction],
-      { value: 10 },
-    );
-
-    const { blockHash } = await state.blockHashes(0);
-    expect(await state.isBlockStakeWithdrawn(blockHash)).to.equal(false);
-    await state.setBlockStakeWithdrawn(blockHash);
-    expect(await state.isBlockStakeWithdrawn(blockHash)).to.equal(true);
+    expect((await state.pendingWithdrawalsFees(addressC.address)).feesMatic).to.equal(0);
   });
 
   it('Should build spanProposersList and change current proposer', async function () {

--- a/test/unit/SmartContracts/state.unit.test.mjs
+++ b/test/unit/SmartContracts/state.unit.test.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable no-await-in-loop */
 import { expect } from 'chai';
 import hardhat from 'hardhat';
 import {
@@ -369,12 +370,12 @@ describe('State contract State functions', function () {
     expect((await state.proposers(addr1.address)).thisAddress).to.equal(
       ethers.constants.AddressZero,
     );
-    expect((await state.proposers(addr1.address)).nextAddress).to.equal(ethers.constants.AddressZero);
+    expect((await state.proposers(addr1.address)).nextAddress).to.equal(
+      ethers.constants.AddressZero,
+    );
     expect((await state.proposers(addr1.address)).url).to.equal('');
     expect((await state.proposers(addr1.address)).fee).to.equal(0);
-
     expect((await state.proposers(addr2.address)).nextAddress).to.equal(addr2.address);
-
   });
 
   it('should remove proposer without proposer rotation', async function () {
@@ -1244,7 +1245,9 @@ describe('State contract State functions', function () {
       prevSprint = await state.currentSprint();
       await state.setProposerStartBlock(0);
       await state.changeCurrentProposer();
-      expect((prevSprint.add(1)).mod(await state.getSprintsInSpan())).to.equal((await state.currentSprint()).mod((await state.getSprintsInSpan())));
+      expect(prevSprint.add(1).mod(await state.getSprintsInSpan())).to.equal(
+        (await state.currentSprint()).mod(await state.getSprintsInSpan()),
+      );
     }
   });
 });

--- a/test/unit/SmartContracts/state.unit.test.mjs
+++ b/test/unit/SmartContracts/state.unit.test.mjs
@@ -337,12 +337,11 @@ describe('State contract State functions', function () {
       false,
       0,
     ]);
-
-    // expect((await state.getProposer(addr1.address)).thisAddress).to.equal(addr1.address);
-    // expect((await state.proposers(addr1.address)).thisAddress).to.equal(addr1.address);
-    // expect((await state.proposers(addr2.address)).nextAddress).to.equal(addr2.address);
-    // expect((await state.proposers(addr1.address)).url).to.equal(newUrl);
-    // expect((await state.proposers(addr1.address)).fee).to.equal(newFee);
+    expect((await state.getProposer(addr1.address)).thisAddress).to.equal(addr1.address);
+    expect((await state.proposers(addr1.address)).thisAddress).to.equal(addr1.address);
+    expect((await state.proposers(addr1.address)).nextAddress).to.equal(addr1.address);
+    expect((await state.proposers(addr1.address)).url).to.equal(newUrl);
+    expect((await state.proposers(addr1.address)).fee).to.equal(newFee);
     await state.setProposer(addr2.address, [
       addr2.address,
       addr2.address,
@@ -352,14 +351,17 @@ describe('State contract State functions', function () {
       false,
       0,
     ]);
+
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
     await state.setStakeAccount(addr2.address, amount, challengeLocked);
     await state.setCurrentProposer(addr1.address);
-
     await state.setNumProposers(2);
 
+
     expect((await state.getCurrentProposer()).thisAddress).to.equal(addr1.address);
+
     await state.removeProposer(addr1.address);
+
     expect((await state.getCurrentProposer()).thisAddress).to.equal(addr2.address);
 
     expect((await state.getProposer(addr1.address)).thisAddress).to.equal(
@@ -1196,68 +1198,5 @@ describe('State contract State functions', function () {
     expect(await state.isBlockStakeWithdrawn(blockHash)).to.equal(false);
     await state.setBlockStakeWithdrawn(blockHash);
     expect(await state.isBlockStakeWithdrawn(blockHash)).to.equal(true);
-  });
-
-  it('should rewardChallenger', async function () {
-    const newUrl = 'url';
-    const newFee = 100;
-    const amount = 100;
-    const challengeLocked = 300;
-
-    await state.setProposer(addr1.address, [
-      addr1.address,
-      addr1.address,
-      addr1.address,
-      newUrl,
-      newFee,
-      false,
-      0,
-    ]);
-    await state.setProposer(addr2.address, [
-      addr2.address,
-      addr2.address,
-      addr2.address,
-      newUrl,
-      newFee,
-      false,
-      0,
-    ]);
-    await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await state.setStakeAccount(addr2.address, amount, challengeLocked);
-    await state.setCurrentProposer(addr1.address);
-    await state.setNumProposers(2);
-    await setTransactionInfo(
-      shield.address,
-      calculateTransactionHash(transactionsCreated.withdrawTransaction),
-      true,
-      false,
-    );
-    await setTransactionInfo(
-      shield.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      false,
-    );
-    await state.proposeBlock(
-      transactionsCreated.block,
-      [transactionsCreated.withdrawTransaction, transactionsCreated.depositTransaction],
-      { value: 10 },
-    );
-
-    const badBlock = {
-      blockHash: (await state.blockHashes(0)).blockHash,
-      time: (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp,
-      proposer: addr2.address,
-      blockStake: amount,
-    };
-
-    await state.connect(addressC).rewardChallenger(addressC.address, addr2.address, [badBlock]);
-
-    const stakeAccount = await state.getStakeAccount(addr2.address);
-    expect(stakeAccount.amount).to.equal(amount);
-    expect(stakeAccount.time).to.equal(0);
-    expect(stakeAccount.challengeLocked).to.equal(challengeLocked - amount);
-    expect(await state.pendingWithdrawals(addressC.address, 0)).to.equal(badBlock.blockStake);
-    expect(await state.pendingWithdrawals(addressC.address, 1)).to.equal(0);
   });
 });

--- a/test/unit/SmartContracts/state.unit.test.mjs
+++ b/test/unit/SmartContracts/state.unit.test.mjs
@@ -1226,7 +1226,7 @@ describe('State contract State functions', function () {
 
     const signers = [];
     for (let i = 0; i < 10; i++) {
-      signers.push(ethers.Wallet.createRandom())
+      signers.push(ethers.Wallet.createRandom());
     }
 
     expect((await state.getCurrentProposer()).thisAddress).to.equal(ethers.constants.AddressZero);
@@ -1263,8 +1263,8 @@ describe('State contract State functions', function () {
     for (let i = 0; i < signers.length; i++) {
       await state.setProposer(signers[i].address, [
         signers[i].address,
-        i == signers.length - 1 ? signers[0].address : signers[i + 1].address,
-        i == signers.length - 1 ? signers[0].address : signers[i + 1].address,
+        i === signers.length - 1 ? signers[0].address : signers[i + 1].address,
+        i === signers.length - 1 ? signers[0].address : signers[i + 1].address,
         newUrl,
         newFee,
         false,
@@ -1293,7 +1293,7 @@ describe('State contract State functions', function () {
 
     const signers = [];
     for (let i = 0; i < 20; i++) {
-      signers.push(ethers.Wallet.createRandom())
+      signers.push(ethers.Wallet.createRandom());
     }
 
     expect((await state.getCurrentProposer()).thisAddress).to.equal(ethers.constants.AddressZero);
@@ -1330,8 +1330,8 @@ describe('State contract State functions', function () {
     for (let i = 0; i < signers.length; i++) {
       await state.setProposer(signers[i].address, [
         signers[i].address,
-        i == signers.length - 1 ? signers[0].address : signers[i + 1].address,
-        i == signers.length - 1 ? signers[0].address : signers[i + 1].address,
+        i === signers.length - 1 ? signers[0].address : signers[i + 1].address,
+        i === signers.length - 1 ? signers[0].address : signers[i + 1].address,
         newUrl,
         newFee,
         false,
@@ -1360,7 +1360,7 @@ describe('State contract State functions', function () {
 
     const signers = [];
     for (let i = 0; i < 30; i++) {
-      signers.push(ethers.Wallet.createRandom())
+      signers.push(ethers.Wallet.createRandom());
     }
 
     expect((await state.getCurrentProposer()).thisAddress).to.equal(ethers.constants.AddressZero);
@@ -1397,8 +1397,8 @@ describe('State contract State functions', function () {
     for (let i = 0; i < signers.length; i++) {
       await state.setProposer(signers[i].address, [
         signers[i].address,
-        i == signers.length - 1 ? signers[0].address : signers[i + 1].address,
-        i == signers.length - 1 ? signers[0].address : signers[i + 1].address,
+        i === signers.length - 1 ? signers[0].address : signers[i + 1].address,
+        i === signers.length - 1 ? signers[0].address : signers[i + 1].address,
         newUrl,
         newFee,
         false,
@@ -1427,7 +1427,7 @@ describe('State contract State functions', function () {
 
     const signers = [];
     for (let i = 0; i < 50; i++) {
-      signers.push(ethers.Wallet.createRandom())
+      signers.push(ethers.Wallet.createRandom());
     }
 
     expect((await state.getCurrentProposer()).thisAddress).to.equal(ethers.constants.AddressZero);
@@ -1464,8 +1464,8 @@ describe('State contract State functions', function () {
     for (let i = 0; i < signers.length; i++) {
       await state.setProposer(signers[i].address, [
         signers[i].address,
-        i == signers.length - 1 ? signers[0].address : signers[i + 1].address,
-        i == signers.length - 1 ? signers[0].address : signers[i + 1].address,
+        i === signers.length - 1 ? signers[0].address : signers[i + 1].address,
+        i === signers.length - 1 ? signers[0].address : signers[i + 1].address,
         newUrl,
         newFee,
         false,

--- a/test/unit/SmartContracts/state.unit.test.mjs
+++ b/test/unit/SmartContracts/state.unit.test.mjs
@@ -1202,7 +1202,7 @@ describe('State contract State functions', function () {
     expect(await state.isBlockStakeWithdrawn(blockHash)).to.equal(true);
   });
 
-  it('Should build spanProposersList andn change current proposer', async function () {
+  it('Should build spanProposersList and change current proposer', async function () {
     const newUrl = 'url';
     const newFee = 100;
     const amount = await state.getMinimumStake();
@@ -1235,37 +1235,16 @@ describe('State contract State functions', function () {
       0,
     ]);
 
-
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
     await state.setStakeAccount(addr2.address, amount.mul(100000), challengeLocked);
     await state.setNumProposers(2);
 
     let prevSprint;
-    let prevList = await state.getSpanProposersList();
     for (let i = 0; i < (await state.getSprintsInSpan()).add(3); i++) {
       prevSprint = await state.currentSprint();
       await state.setProposerStartBlock(0);
       await state.changeCurrentProposer();
       expect((prevSprint.add(1)).mod(await state.getSprintsInSpan())).to.equal((await state.currentSprint()).mod((await state.getSprintsInSpan())));
     }
-    await state.setProposer(addr3.address, [
-      addr3.address,
-      addr1.address,
-      addr1.address,
-      newUrl,
-      newFee,
-      false,
-      0,
-    ]);
-    await state.setStakeAccount(addr3.address, amount.mul(10000000), challengeLocked);
-    await state.setNumProposers(3);
-    for (let i = 0; i < (await state.getSprintsInSpan()).add(3); i++) {
-      prevSprint = await state.currentSprint();
-      await state.setProposerStartBlock(0);
-      await state.changeCurrentProposer();
-      expect((prevSprint.add(1)).mod(await state.getSprintsInSpan())).to.equal((await state.currentSprint()).mod((await state.getSprintsInSpan())));
-    }
-    let propList = await state.getSpanProposersList();
-    expect(propList.length === prevList.length && propList.every(el => prevList.includes(el))).to.equal(false);
   });
 });

--- a/test/unit/SmartContracts/state.unit.test.mjs
+++ b/test/unit/SmartContracts/state.unit.test.mjs
@@ -321,6 +321,8 @@ describe('State contract State functions', function () {
   it('should remove current proposer', async function () {
     const newUrl = 'url';
     const newFee = 100;
+    const amount = await state.getMinimumStake();
+    const challengeLocked = 5;
 
     expect((await state.getCurrentProposer()).thisAddress).to.equal(ethers.constants.AddressZero);
     expect((await state.getProposer(addr1.address)).thisAddress).to.equal(
@@ -329,17 +331,18 @@ describe('State contract State functions', function () {
     await state.setProposer(addr1.address, [
       addr1.address,
       addr1.address,
-      addr2.address,
+      addr1.address,
       newUrl,
       newFee,
       false,
       0,
     ]);
-    expect((await state.getProposer(addr1.address)).thisAddress).to.equal(addr1.address);
-    expect((await state.proposers(addr1.address)).thisAddress).to.equal(addr1.address);
-    expect((await state.proposers(addr1.address)).nextAddress).to.equal(addr2.address);
-    expect((await state.proposers(addr1.address)).url).to.equal(newUrl);
-    expect((await state.proposers(addr1.address)).fee).to.equal(newFee);
+
+    // expect((await state.getProposer(addr1.address)).thisAddress).to.equal(addr1.address);
+    // expect((await state.proposers(addr1.address)).thisAddress).to.equal(addr1.address);
+    // expect((await state.proposers(addr2.address)).nextAddress).to.equal(addr2.address);
+    // expect((await state.proposers(addr1.address)).url).to.equal(newUrl);
+    // expect((await state.proposers(addr1.address)).fee).to.equal(newFee);
     await state.setProposer(addr2.address, [
       addr2.address,
       addr2.address,
@@ -349,15 +352,14 @@ describe('State contract State functions', function () {
       false,
       0,
     ]);
+    await state.setStakeAccount(addr1.address, amount, challengeLocked);
+    await state.setStakeAccount(addr2.address, amount, challengeLocked);
+    await state.setCurrentProposer(addr1.address);
 
     await state.setNumProposers(2);
 
-    await state.setCurrentProposer(addr1.address);
-
     expect((await state.getCurrentProposer()).thisAddress).to.equal(addr1.address);
-
     await state.removeProposer(addr1.address);
-
     expect((await state.getCurrentProposer()).thisAddress).to.equal(addr2.address);
 
     expect((await state.getProposer(addr1.address)).thisAddress).to.equal(
@@ -374,6 +376,8 @@ describe('State contract State functions', function () {
   it('should remove proposer without proposer rotation', async function () {
     const newUrl = 'url';
     const newFee = 100;
+    const amount = await state.getMinimumStake();
+    const challengeLocked = 5;
 
     expect((await state.getCurrentProposer()).thisAddress).to.equal(ethers.constants.AddressZero);
     expect((await state.getProposer(addr1.address)).thisAddress).to.equal(
@@ -403,9 +407,11 @@ describe('State contract State functions', function () {
       0,
     ]);
 
-    await state.setNumProposers(2);
+    await state.setStakeAccount(addr1.address, amount, challengeLocked);
+    await state.setStakeAccount(addr2.address, amount, challengeLocked);
 
     await state.setCurrentProposer(addr1.address);
+    await state.setNumProposers(2);
 
     expect((await state.getCurrentProposer()).thisAddress).to.equal(addr1.address);
 
@@ -429,6 +435,8 @@ describe('State contract State functions', function () {
   it('should change current proposer with maxProposers == 1', async function () {
     const newUrl = 'url';
     const newFee = 100;
+    const amount = await state.getMinimumStake();
+    const challengeLocked = 5;
 
     expect((await state.getCurrentProposer()).thisAddress).to.equal(ethers.constants.AddressZero);
     expect((await state.getProposer(addr1.address)).thisAddress).to.equal(
@@ -457,9 +465,11 @@ describe('State contract State functions', function () {
       false,
       0,
     ]);
+    await state.setStakeAccount(addr1.address, amount, challengeLocked);
+    await state.setStakeAccount(addr2.address, amount, challengeLocked);
+    await state.setCurrentProposer(addr2.address);
     await state.setNumProposers(2);
 
-    await state.setCurrentProposer(addr2.address);
     await state.setBootProposer(addr1.address);
 
     expect((await state.getCurrentProposer()).thisAddress).to.equal(addr2.address);
@@ -476,6 +486,8 @@ describe('State contract State functions', function () {
   it('should not change current proposer: State: Too soon to rotate proposer', async function () {
     const newUrl = 'url';
     const newFee = 100;
+    const amount = await state.getMinimumStake();
+    const challengeLocked = 5;
 
     expect((await state.getCurrentProposer()).thisAddress).to.equal(ethers.constants.AddressZero);
     expect((await state.getProposer(addr1.address)).thisAddress).to.equal(
@@ -504,9 +516,12 @@ describe('State contract State functions', function () {
       false,
       0,
     ]);
-    await state.setNumProposers(2);
+    await state.setStakeAccount(addr1.address, amount, challengeLocked);
+    await state.setStakeAccount(addr2.address, amount, challengeLocked);
 
     await state.setCurrentProposer(addr2.address);
+    await state.setNumProposers(2);
+
     await state.setBootProposer(addr1.address);
 
     expect((await state.getCurrentProposer()).thisAddress).to.equal(addr2.address);
@@ -570,7 +585,7 @@ describe('State contract State functions', function () {
     await state.setProposer(addr1.address, [
       addr1.address,
       addr1.address,
-      addr2.address,
+      addr1.address,
       newUrl,
       newFee,
       false,
@@ -579,7 +594,7 @@ describe('State contract State functions', function () {
 
     expect((await state.getProposer(addr1.address)).thisAddress).to.equal(addr1.address);
     expect((await state.proposers(addr1.address)).thisAddress).to.equal(addr1.address);
-    expect((await state.proposers(addr1.address)).nextAddress).to.equal(addr2.address);
+    expect((await state.proposers(addr1.address)).nextAddress).to.equal(addr1.address);
     expect((await state.proposers(addr1.address)).url).to.equal(newUrl);
     expect((await state.proposers(addr1.address)).fee).to.equal(newFee);
 
@@ -592,16 +607,16 @@ describe('State contract State functions', function () {
       false,
       0,
     ]);
-    await state.setNumProposers(2);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
     await state.setStakeAccount(addr2.address, amount, challengeLocked);
 
     await state.setCurrentProposer(addr1.address);
 
+    await state.setNumProposers(2);
+
     expect((await state.getCurrentProposer()).thisAddress).to.equal(addr1.address);
 
     const prevSprint = await state.currentSprint();
-
     await state.changeCurrentProposer();
 
     expect(await state.currentSprint()).to.equal(prevSprint + 1);
@@ -1102,20 +1117,22 @@ describe('State contract State functions', function () {
       false,
       0,
     ]);
-    await state.setNumProposers(2);
-    await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
     await state.setStakeAccount(addr2.address, amount, challengeLocked);
+
+    await state.setCurrentProposer(addr1.address);
+    await state.setNumProposers(2);
     await setTransactionInfo(
-      state.address,
+      shield.address,
       calculateTransactionHash(transactionsCreated.withdrawTransaction),
+      true,
       false,
     );
     await setTransactionInfo(
-      state.address,
+      shield.address,
       calculateTransactionHash(transactionsCreated.depositTransaction),
       true,
-      34,
+      false,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -1136,9 +1153,111 @@ describe('State contract State functions', function () {
     expect(stakeAccount.amount).to.equal(amount);
     expect(stakeAccount.time).to.equal(0);
     expect(stakeAccount.challengeLocked).to.equal(challengeLocked - amount);
-    expect((await state.pendingWithdrawalsFees(addressC.address)).feesEth).to.equal(
-      badBlock.blockStake,
+    expect(await state.pendingWithdrawals(addressC.address, 0)).to.equal(badBlock.blockStake);
+    expect(await state.pendingWithdrawals(addressC.address, 1)).to.equal(0);
+  });
+
+  it('should setBlockStakeWithdrawn', async function () {
+    const newUrl = 'url';
+    const newFee = 100;
+    const amount = 100;
+    const challengeLocked = 5;
+
+    await state.setProposer(addr1.address, [
+      addr1.address,
+      addr1.address,
+      addr1.address,
+      newUrl,
+      newFee,
+      false,
+      0,
+    ]);
+    await state.setCurrentProposer(addr1.address);
+    await state.setStakeAccount(addr1.address, amount, challengeLocked);
+    await setTransactionInfo(
+      shield.address,
+      calculateTransactionHash(transactionsCreated.withdrawTransaction),
+      true,
+      false,
     );
-    expect((await state.pendingWithdrawalsFees(addressC.address)).feesMatic).to.equal(0);
+    await setTransactionInfo(
+      shield.address,
+      calculateTransactionHash(transactionsCreated.depositTransaction),
+      true,
+      false,
+    );
+    await state.proposeBlock(
+      transactionsCreated.block,
+      [transactionsCreated.withdrawTransaction, transactionsCreated.depositTransaction],
+      { value: 10 },
+    );
+
+    const { blockHash } = await state.blockHashes(0);
+    expect(await state.isBlockStakeWithdrawn(blockHash)).to.equal(false);
+    await state.setBlockStakeWithdrawn(blockHash);
+    expect(await state.isBlockStakeWithdrawn(blockHash)).to.equal(true);
+  });
+
+  it('should rewardChallenger', async function () {
+    const newUrl = 'url';
+    const newFee = 100;
+    const amount = 100;
+    const challengeLocked = 300;
+
+    await state.setProposer(addr1.address, [
+      addr1.address,
+      addr1.address,
+      addr1.address,
+      newUrl,
+      newFee,
+      false,
+      0,
+    ]);
+    await state.setProposer(addr2.address, [
+      addr2.address,
+      addr2.address,
+      addr2.address,
+      newUrl,
+      newFee,
+      false,
+      0,
+    ]);
+    await state.setStakeAccount(addr1.address, amount, challengeLocked);
+    await state.setStakeAccount(addr2.address, amount, challengeLocked);
+    await state.setCurrentProposer(addr1.address);
+    await state.setNumProposers(2);
+    await setTransactionInfo(
+      shield.address,
+      calculateTransactionHash(transactionsCreated.withdrawTransaction),
+      true,
+      false,
+    );
+    await setTransactionInfo(
+      shield.address,
+      calculateTransactionHash(transactionsCreated.depositTransaction),
+      true,
+      false,
+    );
+    await state.proposeBlock(
+      transactionsCreated.block,
+      [transactionsCreated.withdrawTransaction, transactionsCreated.depositTransaction],
+      { value: 10 },
+    );
+
+    const badBlock = {
+      blockHash: (await state.blockHashes(0)).blockHash,
+      time: (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp,
+      proposer: addr2.address,
+      blockStake: amount,
+    };
+
+    await state.connect(addressC).rewardChallenger(addressC.address, addr2.address, [badBlock]);
+
+    const stakeAccount = await state.getStakeAccount(addr2.address);
+    expect(stakeAccount.amount).to.equal(amount);
+    expect(stakeAccount.time).to.equal(0);
+    expect(stakeAccount.challengeLocked).to.equal(challengeLocked - amount);
+    expect(await state.pendingWithdrawals(addressC.address, 0)).to.equal(badBlock.blockStake);
+    expect(await state.pendingWithdrawals(addressC.address, 1)).to.equal(0);
   });
 });

--- a/test/unit/SmartContracts/state.unit.test.mjs
+++ b/test/unit/SmartContracts/state.unit.test.mjs
@@ -1134,16 +1134,15 @@ describe('State contract State functions', function () {
     await state.setCurrentProposer(addr1.address);
     await state.setNumProposers(2);
     await setTransactionInfo(
-      shield.address,
+      state.address,
       calculateTransactionHash(transactionsCreated.withdrawTransaction),
-      true,
       false,
     );
     await setTransactionInfo(
-      shield.address,
+      state.address,
       calculateTransactionHash(transactionsCreated.depositTransaction),
       true,
-      false,
+      34,
     );
     await state.proposeBlock(
       transactionsCreated.block,

--- a/test/unit/SmartContracts/state.unit.test.mjs
+++ b/test/unit/SmartContracts/state.unit.test.mjs
@@ -357,7 +357,6 @@ describe('State contract State functions', function () {
     await state.setCurrentProposer(addr1.address);
     await state.setNumProposers(2);
 
-
     expect((await state.getCurrentProposer()).thisAddress).to.equal(addr1.address);
 
     await state.removeProposer(addr1.address);


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Instead of leaving it to the `changeCurrentProposer` each time to calculate from scratch the `nextProposer`, the next n are calculated all at once, so that we know in advance what the next ones will be, and stimulate to execute the function for changing proposer

- [x]  Smart contract functions
- [x]  gas comparison
- [x]  Test


### Gas comparison:
Gas comparison is made on two functions modified in this pr (`setNumProposers`, `changeCurrentProposer`).

#### setNumProposers(np)

| | Previous Version | New Version |
| :---         |     :---:      |          ---: |
| np != 2   | 33208  | 33246   |
| np == 2    | 36008       | 346445      |

In this case, the new version is more expensive in case `numproposers` = 2 because it is calculated the list of next proposers.

The first time the setNumProposers is executed with np == 2 and the changeCurrentProposer is called the cost in gas is:
| min | max | avg |
| :---         |     :---:      |          ---: |
| 637981  | 1047968  | 759665   |

#### changeCurrentProposer

| | Previous Version | New Version |
| :---         |     :---:      |          ---: |
| currentSprint != sprintsInSpan   | 315195 avg  | 118882 avg   |
| currentSprint == sprintsInSpan    | 315195 avg       | 325525 avg     |

Unlike the previous version, the `changeCurrentProposer` does not calculate the next proposer from scratch, but only calculates it when `currentsprint == sprintsInSpan`. so the cost is much lower in the case where `currentsprint != sprintsInSpan`, since the next proposer is simply taken from the list, while in the case where `currentsprint == sprintsInSpan` the cost is about the same as before since the whole list is calculated.

Gas cost was also evaluated with 10/20/30/50 proposers, but the number does not impact gas cost

## Does this close any currently open issues?
close #1223 
## What commands can I run to test the change? 
npm run unit-test-state

## Any other comments?

