### PR TITLE
Initial values for the PoS

### DIFF
--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -1095,6 +1095,16 @@ class Nf3 {
   }
 
   /**
+    Get rotate proposer blocks
+    @method
+    @async
+    @returns {array} A promise that resolves to the Ethereum call.
+    */
+  async getRotateProposerBlocks() {
+    return this.stateContract.methods.getRotateProposerBlocks().call();
+  }
+
+  /**
     Starts a Proposer that listens for blocks and submits block proposal
     transactions to the blockchain.
     @method

--- a/config/default.js
+++ b/config/default.js
@@ -233,7 +233,6 @@ module.exports = {
     gas: 10000000,
     gasCosts: 80000000000000000,
     fee: 1,
-    ROTATE_PROPOSER_BLOCKS: 20,
     signingKeys: {
       walletTest:
         process.env.WALLET_TEST_KEY ||

--- a/doc/pos.md
+++ b/doc/pos.md
@@ -21,15 +21,17 @@ the proposer selection process.
 Similar to Polygon approach we define these initial numbers that could be configured by the multisig
 administrator contract:
 
-- Each proposer slot is 1K MATIC. If a proposer has 10K stake of MATIC then it will have 10 slots
-  assigned. **1 Slot = 1K MATIC**
-- Proposer set for each span will be built from 5 slots after shuffling all the slots. (Random
+- Minimum stake will be 20K MATIC.
+- Block stake every time the proposer propose a block will be 200 MATIC.
+- Each proposer slot will be the calculated from the biggest stake divided by 10 in order to have 10
+  slots maximum for the proposer with the biggest stake. **1 Slot = MaxProsposerStake / 10 MATIC**
+- Proposer set for each span will be built from 10 slots after shuffling all the slots. (Random
   shuffling is employed by Ethereum 2.0 too. It helps to mitigate DoS attacks and collusion among
-  nodes) **Proposer set = 5 slots**
-- Span will have 5 sprints for a complete rotation of the proposer set. The same number as proposer
-  set count. **Span = 5 Sprints**
-- Sprint will be equal to ROTATE_PROPOSER_BLOCKS = 20. Probably we could increase this in mainnet.
-  **Sprint = 20 Blocks**.
+  nodes) **Proposer set = 10 slots**
+- Span will have 10 sprints for a complete rotation of the proposer set. The same number as proposer
+  set count. **Span = 10 Sprints**
+- Sprint will be equal to ROTATE_PROPOSER_BLOCKS = 32. Probably we could increase this in mainnet.
+  **Sprint = 32 Blocks**.
 - We will take into account to block the stake of the proposer for the blocks that are still pending
   in the CHALLENGE_PERIOD of the proposer so it could be slashed in case of bad blocks to cover this
   slash. And in the next span this proposer will have less staking power. (total stake - blocked

--- a/nightfall-deployer/contracts/Config.sol
+++ b/nightfall-deployer/contracts/Config.sol
@@ -25,11 +25,11 @@ contract Config is Ownable, Structures {
 
     function initialize() public virtual override onlyInitializing {
         Ownable.initialize();
-        minimumStake = 1000000 wei;
-        blockStake = 1 wei;
-        rotateProposerBlocks = 20;
-        proposerSetCount = 5;
-        sprintsInSpan = 5;
+        minimumStake = 1000000 wei; // 20000000000000 wei; // 20K MATIC in mainnet
+        blockStake = 1 wei; // 200000000000 wei; 200 MATIC in mainnet
+        rotateProposerBlocks = 32;
+        proposerSetCount = 10;
+        sprintsInSpan = 10;
         maxProposers = 100;
     }
 

--- a/test/e2e/protocol/proposer.test.mjs
+++ b/test/e2e/protocol/proposer.test.mjs
@@ -16,7 +16,6 @@ const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIR
 const {
   mnemonics,
   signingKeys,
-  ROTATE_PROPOSER_BLOCKS,
   fee,
   transferValue,
   tokenConfigs: { tokenType, tokenId },
@@ -43,6 +42,7 @@ let stateAddress;
 const eventLogs = [];
 let erc20Address;
 let minimumStake;
+let rotateProposerBlocks;
 
 const CHANGE_PROPOSER_NO_TIMES = 8;
 
@@ -80,6 +80,7 @@ describe('Basic Proposer tests', () => {
     await thirdProposer.init(mnemonics.proposer);
 
     minimumStake = await bootProposer.getMinimumStake();
+    rotateProposerBlocks = await bootProposer.getRotateProposerBlocks();
     stateAddress = await bootProposer.getContractAddress('State');
     stateABI = await nf3User.getContractAbi('State');
     erc20Address = await nf3User.getContractAddress('ERC20Mock');
@@ -231,7 +232,7 @@ describe('Basic Proposer tests', () => {
         const initBlock = await web3.eth.getBlockNumber();
         let currentBlock = initBlock;
 
-        while (currentBlock - initBlock < ROTATE_PROPOSER_BLOCKS) {
+        while (currentBlock - initBlock < rotateProposerBlocks) {
           await new Promise(resolve => setTimeout(resolve, 10000));
           currentBlock = await web3.eth.getBlockNumber();
         }

--- a/test/ping-pong/index.mjs
+++ b/test/ping-pong/index.mjs
@@ -18,8 +18,7 @@ import { NightfallMultiSig } from '../multisig/nightfall-multisig.mjs';
 
 const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
 
-const { mnemonics, signingKeys, addresses, zkpPublicKeys, ROTATE_PROPOSER_BLOCKS } =
-  config.TEST_OPTIONS;
+const { mnemonics, signingKeys, addresses, zkpPublicKeys } = config.TEST_OPTIONS;
 
 const { TX_WAIT = 1000, TEST_ERC20_ADDRESS } = process.env;
 
@@ -30,6 +29,7 @@ const amountMinimumStake = 100;
 let nfMultiSig;
 let multisigContract;
 let shieldContract;
+let rotateProposerBlocks;
 
 const TEST_LENGTH = 4;
 
@@ -52,6 +52,7 @@ export async function userTest(IS_TEST_RUNNER, optimistUrls) {
 
   const ercAddress = TEST_ERC20_ADDRESS || (await nf3.getContractAddress('ERC20Mock'));
 
+  rotateProposerBlocks = await nf3.getRotateProposerBlocks();
   const stateContract = await nf3.getContractInstance('State');
   const stateAddress = stateContract.options.address;
   web3Client.subscribeTo('logs', eventLogs, { address: stateAddress });
@@ -358,7 +359,7 @@ export async function proposerTest(optimistUrls, proposersStats, nf3Proposer) {
         const initBlock = await nf3Proposer.web3.eth.getBlockNumber();
         let currentBlock = initBlock;
 
-        while (currentBlock - initBlock < ROTATE_PROPOSER_BLOCKS) {
+        while (currentBlock - initBlock < rotateProposerBlocks) {
           await new Promise(resolve => setTimeout(resolve, 10000));
           currentBlock = await nf3Proposer.web3.eth.getBlockNumber();
         }


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Initial configuration for the PoS according to the conclusion in https://hackmd.io/m_85iGlMTzGkc4hZSElTKQ?both

### Decided values for mainnet
- MINIMUM_STAKE: 20K MATIC 
- BLOCK_STAKE: 200 MATIC
- ROTATE_PROPOSER_BLOCKS: 32 blocks
- VALUE_PER_SLOT: Maximum stake of a proposer / 10
- SPRINTS_IN_SPAN: 10
- PROPOSER_SET_COUNT: 10

## Does this close any currently open issues?
Yes. #1248.

## What commands can I run to test the change? 
npm run test-e2e-protocol

## Any other comments?
No
