### PR TITLE
chore: remove hashing function

### DIFF
--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -5,7 +5,6 @@ import Queue from 'queue';
 import Web3 from 'web3';
 import WebSocket from 'ws';
 import crypto from 'crypto';
-import config from 'config';
 import ReconnectingWebSocket from 'reconnecting-websocket';
 import EventEmitter from 'events';
 import logger from '@polygon-nightfall/common-files/utils/logger.mjs';

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -107,10 +107,7 @@ class Nf3 {
     this.ethereumSigningKey = ethereumSigningKey;
     this.zkpKeys = zkpKeys;
     this.currentEnvironment = environment;
-    axios.defaults.headers.common['X-APP-TOKEN'] = crypto
-      .createHash('sha256')
-      .update(environment.PROPOSER_KEY)
-      .digest('hex');
+    axios.defaults.headers.common['X-APP-TOKEN'] = environment.PROPOSER_KEY;
   }
 
   /**
@@ -120,10 +117,7 @@ class Nf3 {
    */
   // eslint-disable-next-line class-methods-use-this
   async setApiKey(key) {
-    axios.defaults.headers.common['X-APP-TOKEN'] = crypto
-      .createHash('sha256')
-      .update(key)
-      .digest('hex');
+    axios.defaults.headers.common['X-APP-TOKEN'] = key;
   }
 
   /**

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -1,6 +1,7 @@
 /* eslint class-methods-use-this: "off" */
 
 import axios from 'axios';
+import config from 'config';
 import Queue from 'queue';
 import Web3 from 'web3';
 import WebSocket from 'ws';

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -5,6 +5,7 @@ import Queue from 'queue';
 import Web3 from 'web3';
 import WebSocket from 'ws';
 import crypto from 'crypto';
+import config from 'config';
 import ReconnectingWebSocket from 'reconnecting-websocket';
 import EventEmitter from 'events';
 import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
@@ -31,6 +32,8 @@ import {
 const userQueue = new Queue({ autostart: true, concurrency: 1 });
 const challengerQueue = new Queue({ autostart: true, concurrency: 1 });
 const liquidityProviderQueue = new Queue({ autostart: true, concurrency: 1 });
+const environmentConfig =
+  config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
 
 /**
 @class
@@ -106,7 +109,8 @@ class Nf3 {
     this.ethereumSigningKey = ethereumSigningKey;
     this.zkpKeys = zkpKeys;
     this.currentEnvironment = environment;
-    axios.defaults.headers.common['X-APP-TOKEN'] = environment.AUTH_TOKEN;
+    axios.defaults.headers.common['X-APP-TOKEN'] =
+      environmentConfig.AUTH_TOKEN || '0ce4fee0-c765-43d6-973c-d404bfdde2e9';
   }
 
   /**

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -107,7 +107,7 @@ class Nf3 {
     this.ethereumSigningKey = ethereumSigningKey;
     this.zkpKeys = zkpKeys;
     this.currentEnvironment = environment;
-    axios.defaults.headers.common['X-APP-TOKEN'] = environment.PROPOSER_KEY;
+    axios.defaults.headers.common['X-APP-TOKEN'] = environment.AUTH_TOKEN;
   }
 
   /**

--- a/cli/package.json
+++ b/cli/package.json
@@ -17,6 +17,7 @@
     "clear": "^0.1.0",
     "cli-table": "^0.3.6",
     "commander": "^8.2.0",
+    "config": "^3.3.8",
     "cors": "^2.8.5",
     "express": "^4.17.3",
     "figlet": "^1.5.2",

--- a/config/default.js
+++ b/config/default.js
@@ -187,6 +187,7 @@ module.exports = {
         process.env.CHALLENGER_KEY ||
         process.env.BOOT_CHALLENGER_KEY ||
         '0xd42905d0582c476c4b74757be6576ec323d715a0c7dcff231b6348b7ab0190eb',
+      AUTH_TOKEN: process.env.AUTH_TOKEN || '0ce4fee0-c765-43d6-973c-d404bfdde2e9',
     },
     aws: {
       name: 'AWS',

--- a/config/default.js
+++ b/config/default.js
@@ -201,6 +201,7 @@ module.exports = {
       adversarialOptimistWsUrl: `wss://${process.env.OPTIMIST_HOST}`,
       PROPOSER_KEY: process.env.PROPOSER_KEY,
       CHALLENGER_KEY: process.env.CHALLENGER_KEY,
+      AUTH_TOKEN: process.env.AUTH_TOKEN,
     },
     polygonEdge: {
       name: 'Polygon Edge',
@@ -220,6 +221,7 @@ module.exports = {
       adversarialOptimistApiUrl: 'http://localhost:8088',
       adversarialOptimistWsUrl: 'ws://localhost:8089',
       web3WsUrl: `ws://localhost:10002/ws`,
+      AUTH_TOKEN: process.env.AUTH_TOKEN,
     },
   },
   TEST_OPTIONS: {

--- a/nightfall-optimist/src/utils/auth.mjs
+++ b/nightfall-optimist/src/utils/auth.mjs
@@ -1,11 +1,5 @@
-import config from 'config';
-import crypto from 'crypto';
-
-const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
-
 export default function auth(req, res, next) {
-  const token = req.headers['x-app-token'];
-  if (token === crypto.createHash('sha256').update(environment.PROPOSER_KEY).digest('hex'))
-    return next();
+  const token = req.headers['X-APP-TOKEN'];
+  if (token === process.env.PROPOSER_KEY) return next();
   return res.status(401).send('Unauthorized');
 }

--- a/nightfall-optimist/src/utils/auth.mjs
+++ b/nightfall-optimist/src/utils/auth.mjs
@@ -1,5 +1,5 @@
 export default function auth(req, res, next) {
   const token = req.headers['X-APP-TOKEN'];
-  if (token === process.env.PROPOSER_KEY) return next();
+  if (token === process.env.AUTH_TOKEN) return next();
   return res.status(401).send('Unauthorized');
 }

--- a/nightfall-optimist/src/utils/auth.mjs
+++ b/nightfall-optimist/src/utils/auth.mjs
@@ -1,5 +1,8 @@
+import config from 'config';
+const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
+
 export default function auth(req, res, next) {
-  const token = req.headers['X-APP-TOKEN'];
-  if (token === process.env.AUTH_TOKEN) return next();
+  const token = req.headers['x-app-token'];
+  if (token === environment.AUTH_TOKEN) return next();
   return res.status(401).send('Unauthorized');
 }

--- a/nightfall-optimist/src/utils/auth.mjs
+++ b/nightfall-optimist/src/utils/auth.mjs
@@ -1,4 +1,5 @@
 import config from 'config';
+
 const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
 
 export default function auth(req, res, next) {

--- a/test/circuits.test.mjs
+++ b/test/circuits.test.mjs
@@ -3,7 +3,6 @@ import chai from 'chai';
 import chaiHttp from 'chai-http';
 import chaiAsPromised from 'chai-as-promised';
 import config from 'config';
-import crypto from 'crypto';
 import axios from 'axios';
 import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
 import Nf3 from '../cli/lib/nf3.mjs';
@@ -42,12 +41,7 @@ const { optimistApiUrl } = environment;
 */
 describe('General Circuit Test', () => {
   before(async () => {
-    const ethPrivateKey = environment.PROPOSER_KEY;
-
-    axios.defaults.headers.common['X-APP-TOKEN'] = crypto
-      .createHash('sha256')
-      .update(ethPrivateKey)
-      .digest('hex');
+    axios.defaults.headers.common['X-APP-TOKEN'] = environment.AUTH_TOKEN;
 
     // we must set the URL from the point of view of the client container
     await axios.post(`${optimistApiUrl}/proposer/register`, {

--- a/test/e2e/protocol/proposer.test.mjs
+++ b/test/e2e/protocol/proposer.test.mjs
@@ -84,7 +84,7 @@ describe('Basic Proposer tests', () => {
   });
 
   it('Should access any public route with the correct API key', async () => {
-    bootProposer.setApiKey(environment.PROPOSER_KEY);
+    bootProposer.setApiKey(environment.AUTH_TOKEN);
     const { status } = await axios.get(`${environment.optimistApiUrl}/proposer/mempool`);
     expect(status).to.equal(200);
   });
@@ -97,7 +97,7 @@ describe('Basic Proposer tests', () => {
     } catch (err) {
       expect(err);
     } finally {
-      bootProposer.setApiKey(environment.PROPOSER_KEY);
+      bootProposer.setApiKey(environment.AUTH_TOKEN);
     }
   });
 
@@ -109,7 +109,7 @@ describe('Basic Proposer tests', () => {
     } catch (err) {
       expect(err);
     } finally {
-      bootProposer.setApiKey(environment.PROPOSER_KEY);
+      bootProposer.setApiKey(environment.AUTH_TOKEN);
     }
   });
 

--- a/test/multisig/administrator.test.mjs
+++ b/test/multisig/administrator.test.mjs
@@ -5,7 +5,6 @@ import chai from 'chai';
 import chaiHttp from 'chai-http';
 import config from 'config';
 import chaiAsPromised from 'chai-as-promised';
-import crypto from 'crypto';
 import axios from 'axios';
 import { Web3Client } from '../utils.mjs';
 import Nf3 from '../../cli/lib/nf3.mjs';
@@ -44,12 +43,8 @@ describe(`Testing Administrator`, () => {
 
   before(async () => {
     await nf3User.init(mnemonics.user1);
-    const ethPrivateKey = environment.PROPOSER_KEY;
 
-    axios.defaults.headers.common['X-APP-TOKEN'] = crypto
-      .createHash('sha256')
-      .update(ethPrivateKey)
-      .digest('hex');
+    axios.defaults.headers.common['X-APP-TOKEN'] = environment.AUTH_TOKEN;
 
     stateContract = await getContractInstance('State', nf3User);
     proposersContract = await getContractInstance('Proposers', nf3User);


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
This removes the existing hash function from the auth logic . It serves the purpose of simplifying and using an .env variable as the auth token for the proposer routes.
## Does this close any currently open issues?
no
## What commands can I run to test the change? 
npm run test-e2e-protocol            
## Any other comments?
It is suggested for the deployer to use UUID(https://www.uuidgenerator.net/) as the authentication token. However, the code doesn't stop the deployer to use whatever string they want.

Updated administrator and circuits tests.