### PR TITLE
several fixes for aws deployment

### DIFF
--- a/.github/workflows/on-pull-request-master.yml
+++ b/.github/workflows/on-pull-request-master.yml
@@ -829,61 +829,61 @@ jobs:
           name: test-apps-logs
           path: ./test-apps.log
 
-  # test-client:
-  #   name: check client for liveliness
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: actions/setup-node@v1
-  #       with:
-  #         node-version: '16.17.0'
+   test-client:
+     name: check client for liveliness
+     runs-on: ubuntu-20.04
+     steps:
+       - uses: actions/checkout@v3
+       - uses: actions/setup-node@v1
+         with:
+           node-version: '16.17.0'
 
-  #     - name: Create env file
-  #       run: |
-  #         echo "ETH_NETWORK=goerli" > ./nightfall-client/client.env
-  #         echo "BLOCKCHAIN_WS_HOST=${{ secrets.GOERLI_ALCHEMY }}" >> ./nightfall-client/client.env
-  #         cat ./nightfall-client/client.env
+       - name: Create env file
+         run: |
+           echo "ETH_NETWORK=goerli" > ./nightfall-client/client.env
+           echo "BLOCKCHAIN_WS_HOST=${{ secrets.GOERLI_ALCHEMY }}" >> ./nightfall-client/client.env
+           cat ./nightfall-client/client.env
 
-  #     - name: Start client
-  #       run: |
-  #         cd nightfall-client && ./start-client &> ../test-client.log &disown
-  #         sleep 300
+       - name: Start client
+         run: |
+           cd nightfall-client && ./start-client &> ../test-client.log &disown
+           sleep 300
 
-  #     - name: Debug logs - after container startup
-  #       if: always()
-  #       run: cat test-client.log
+       - name: Debug logs - after container startup
+         if: always()
+         run: cat test-client.log
 
-  #     - name: 'Check client liveliness'
+       - name: 'Check client liveliness'
 
-  #       uses: Wandalen/wretry.action@v1.0.11
-  #       with:
-  #         command: |
-  #           curl -i http://localhost:8080/healthcheck
-  #         attempt_limit: 10
-  #         attempt_delay: 30000
+         uses: Wandalen/wretry.action@v1.0.11
+         with:
+           command: |
+             curl -i http://localhost:8080/healthcheck
+           attempt_limit: 10
+           attempt_delay: 30000
 
-  #     - name: 'Check access to contracts'
+       - name: 'Check access to contracts'
 
-  #       uses: Wandalen/wretry.action@v1.0.11
-  #       with:
-  #         command: |
-  #           curl -i http://localhost:8080/contract-address/Shield
-  #         attempt_limit: 10
-  #         attempt_delay: 30000
+         uses: Wandalen/wretry.action@v1.0.11
+         with:
+           command: |
+             curl -i http://localhost:8080/contract-address/Shield
+           attempt_limit: 10
+           attempt_delay: 30000
 
-  #     - name: Debug logs - after integration test run
-  #       if: always()
-  #       run: cat test-client.log
+       - name: Debug logs - after integration test run
+         if: always()
+         run: cat test-client.log
 
-  #     - name: If integration test failed, shutdown the Containers
-  #       if: failure()
-  #       run:
-  #         docker-compose -f docker/docker-compose.client.yml -f docker/docker-compose.client.dev.yml
-  #         -p nightfall_3 down -v
+       - name: If integration test failed, shutdown the Containers
+         if: failure()
+         run:
+           docker-compose -f docker/docker-compose.client.yml -f docker/docker-compose.client.dev.yml
+           -p nightfall_3 down -v
 
-  #     - name: If integration test failed, upload logs files as artifacts
-  #       if: failure()
-  #       uses: actions/upload-artifact@master
-  #       with:
-  #         name: test-client-logs
-  #         path: ./test-client.log
+       - name: If integration test failed, upload logs files as artifacts
+         if: failure()
+         uses: actions/upload-artifact@master
+         with:
+           name: test-client-logs
+           path: ./test-client.log

--- a/.github/workflows/on-pull-request-master.yml
+++ b/.github/workflows/on-pull-request-master.yml
@@ -829,61 +829,59 @@ jobs:
           name: test-apps-logs
           path: ./test-apps.log
 
-   test-client:
-     name: check client for liveliness
-     runs-on: ubuntu-20.04
-     steps:
-       - uses: actions/checkout@v3
-       - uses: actions/setup-node@v1
-         with:
-           node-version: '16.17.0'
+  test-client:
+    name: check client for liveliness
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '16.17.0'
 
-       - name: Create env file
-         run: |
-           echo "ETH_NETWORK=goerli" > ./nightfall-client/client.env
-           echo "BLOCKCHAIN_WS_HOST=${{ secrets.GOERLI_ALCHEMY }}" >> ./nightfall-client/client.env
-           cat ./nightfall-client/client.env
+      - name: Create env file
+        run: |
+          echo "ETH_NETWORK=goerli" > ./nightfall-client/client.env
+          echo "BLOCKCHAIN_WS_HOST=${{ secrets.GOERLI_ALCHEMY }}" >> ./nightfall-client/client.env
+          cat ./nightfall-client/client.env
 
-       - name: Start client
-         run: |
-           cd nightfall-client && ./start-client &> ../test-client.log &disown
-           sleep 300
+      - name: Start client
+        run: |
+          cd nightfall-client && ./start-client &> ../test-client.log &disown
+          sleep 300
 
-       - name: Debug logs - after container startup
-         if: always()
-         run: cat test-client.log
+      - name: Debug logs - after container startup
+        if: always()
+        run: cat test-client.log
 
-       - name: 'Check client liveliness'
+      - name: 'Check client liveliness'
+        uses: Wandalen/wretry.action@v1.0.11
+        with:
+          command: |
+            curl -i http://localhost:8080/healthcheck
+          attempt_limit: 10
+          attempt_delay: 30000
 
-         uses: Wandalen/wretry.action@v1.0.11
-         with:
-           command: |
-             curl -i http://localhost:8080/healthcheck
-           attempt_limit: 10
-           attempt_delay: 30000
+      - name: 'Check access to contracts'
+        uses: Wandalen/wretry.action@v1.0.11
+        with:
+          command: |
+            curl -i http://localhost:8080/contract-address/Shield
+          attempt_limit: 10
+          attempt_delay: 30000
 
-       - name: 'Check access to contracts'
+      - name: Debug logs - after integration test run
+        if: always()
+        run: cat test-client.log
 
-         uses: Wandalen/wretry.action@v1.0.11
-         with:
-           command: |
-             curl -i http://localhost:8080/contract-address/Shield
-           attempt_limit: 10
-           attempt_delay: 30000
+      - name: If integration test failed, shutdown the Containers
+        if: failure()
+        run:
+          docker-compose -f docker/docker-compose.client.yml -f docker/docker-compose.client.dev.yml
+          -p nightfall_3 down -v
 
-       - name: Debug logs - after integration test run
-         if: always()
-         run: cat test-client.log
-
-       - name: If integration test failed, shutdown the Containers
-         if: failure()
-         run:
-           docker-compose -f docker/docker-compose.client.yml -f docker/docker-compose.client.dev.yml
-           -p nightfall_3 down -v
-
-       - name: If integration test failed, upload logs files as artifacts
-         if: failure()
-         uses: actions/upload-artifact@master
-         with:
-           name: test-client-logs
-           path: ./test-client.log
+      - name: If integration test failed, upload logs files as artifacts
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: test-client-logs
+          path: ./test-client.log

--- a/bin/setup-nightfall
+++ b/bin/setup-nightfall
@@ -42,7 +42,7 @@ if [[ -z "${NF_SERVICES_TO_START}" || "${NF_SERVICES_TO_START}" == *"optimist"* 
 fi
 
 if [[ -z "${NF_SERVICES_TO_START}" || "${NF_SERVICES_TO_START}" == *"proposer"* ]]; then
-  docker-compose -f docker/docker-compose.apps.yml build ${NO_CACHE_FLAG} proposer
+  docker-compose -f docker/docker-compose.yml -f docker/docker-compose.apps.yml build ${NO_CACHE_FLAG} proposer
 fi
 
 if [[ -z "${NF_SERVICES_TO_START}" || "${NF_SERVICES_TO_START}" == *"worker"* ]]; then

--- a/common-files/utils/web3.mjs
+++ b/common-files/utils/web3.mjs
@@ -47,6 +47,19 @@ export default {
     this.web3.currentProvider.connection.close();
   },
 
+  async estimateGas(tx) {
+    let gas;
+    try {
+      gas = await this.web3.eth.estimateGas(tx);
+      logger.debug({ msg: 'Gas estimated at', gas });
+    } catch (error) {
+      gas = config.WEB3_OPTIONS.gas;
+      logger.warn({ msg: 'Gas estimation failed, use default', gas });
+    }
+    gas = Math.ceil(gas * 2); // 50% seems a more than reasonable buffer
+    return gas;
+  },
+
   // function only needed for infura deployment
   async submitRawTransaction(rawTransaction, contractAddress, value = 0) {
     if (!rawTransaction) throw Error('No tx data to sign');
@@ -63,16 +76,7 @@ export default {
       value,
       gasPrice: config.WEB3_OPTIONS.gasPrice,
     };
-    let gas;
-    try {
-      gas = await this.web3.eth.estimateGas(tx);
-      logger.debug({ msg: 'Gas estimated at', gas });
-    } catch (error) {
-      gas = config.WEB3_OPTIONS.gas;
-      logger.warn({ msg: 'Gas estimation failed, use default', gas });
-    }
-
-    tx.gas = Math.ceil(gas * 2); // 50% seems a more than reasonable buffer
+    tx.gas = await this.estimateGas(tx);
 
     const signed = await this.web3.eth.accounts.signTransaction(tx, config.ETH_PRIVATE_KEY);
     return this.web3.eth.sendSignedTransaction(signed.rawTransaction);

--- a/config/default.js
+++ b/config/default.js
@@ -6,8 +6,8 @@ function configureAWSBucket() {
 }
 
 module.exports = {
-  COMMITMENTS_DB: 'nightfall_commitments',
-  OPTIMIST_DB: 'optimist_data',
+  COMMITMENTS_DB: process.env.COMMITMENTS_DB || 'nightfall_commitments',
+  OPTIMIST_DB: process.env.OPTIMIST_DB || 'optimist_data',
   PROPOSER_COLLECTION: 'proposers',
   CHALLENGER_COLLECTION: 'challengers',
   TRANSACTIONS_COLLECTION: 'transactions',
@@ -36,7 +36,7 @@ module.exports = {
   LOG_HTTP_PAYLOAD_ENABLED: process.env.LOG_HTTP_PAYLOAD_ENABLED || 'true',
   LOG_HTTP_FULL_DATA: process.env.LOG_HTTP_FULL_DATA || 'false',
   MONGO_URL: process.env.MONGO_URL || 'mongodb://localhost:27017/',
-  PROTOCOL: 'http://',
+  PROTOCOL: process.env.PROTOCOL || 'http://', // connect to circom worker microservice like this
   WEBSOCKET_PORT: process.env.WEBSOCKET_PORT || 8080,
   WEBSOCKET_PING_TIME: 15000,
   CIRCOM_WORKER_HOST: process.env.CIRCOM_WORKER_HOST || 'worker',
@@ -136,6 +136,7 @@ module.exports = {
     DEFAULT_CIRCUIT_FILES_URL: 'https://nightfallv3-proving-files.s3.eu-west-1.amazonaws.com',
     DEFAULT_CONTRACT_FILES_URL: 'https://nightfallv3-proving-files.s3.eu-west-1.amazonaws.com',
   },
+  PROPOSER_MAX_BLOCK_PERIOD_MILIS: Number(process.env.PROPOSER_MAX_BLOCK_PERIOD) || 60 * 1000,
   ENVIRONMENTS: {
     mainnet: {
       name: 'Mainnet',
@@ -219,6 +220,8 @@ module.exports = {
       adversarialOptimistApiUrl: 'http://localhost:8088',
       adversarialOptimistWsUrl: 'ws://localhost:8089',
       web3WsUrl: `ws://localhost:10002/ws`,
+      PROPOSER_KEY: process.env.PROPOSER_KEY,
+      CHALLENGER_KEY: process.env.CHALLENGER_KEY,
     },
   },
   TEST_OPTIONS: {
@@ -237,13 +240,13 @@ module.exports = {
     signingKeys: {
       walletTest:
         process.env.WALLET_TEST_KEY ||
-        '0xd42905d0582c476c4b74757be6576ec323d715a0c7dcff231b6348b7ab0190eb',
+        '0x955ff4fac3c1ae8a1b7b9ff197476de1f93e9f0bf5f1c21ff16456e3c84da587',
       user1:
         process.env.USER1_KEY ||
         '0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69e',
       user2:
         process.env.USER2_KEY ||
-        '0x955ff4fac3c1ae8a1b7b9ff197476de1f93e9f0bf5f1c21ff16456e3c84da587',
+        '0xd42905d0582c476c4b74757be6576ec323d715a0c7dcff231b6348b7ab0190eb',
       proposer1:
         process.env.BOOT_PROPOSER_KEY ||
         '0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69d',
@@ -264,9 +267,9 @@ module.exports = {
         '0xfbc1ee1c7332e2e5a76a99956f50b3ba2639aff73d56477e877ef8390c41e0c6',
     },
     addresses: {
-      walletTest: process.env.WALLET_TEST_ADDRESS || '0xfCb059A4dB5B961d3e48706fAC91a55Bad0035C9',
+      walletTest: process.env.WALLET_TEST_ADDRESS || '0xb9e9997dF5b3ac021AB3B29C64F3c339A2546816',
       user1: process.env.USER1_ADDRESS || '0x9C8B2276D490141Ae1440Da660E470E7C0349C63',
-      user2: process.env.USER2_ADDRESS || '0xb9e9997dF5b3ac021AB3B29C64F3c339A2546816',
+      user2: process.env.USER2_ADDRESS || '0xfCb059A4dB5B961d3e48706fAC91a55Bad0035C9',
       proposer1: process.env.BOOT_PROPOSER_ADDRESS || '0xfeEDA3882Dd44aeb394caEEf941386E7ed88e0E0',
       proposer2: process.env.PROPOSER2_ADDRESS || '0xa12D5C4921518980c57Ce3fFe275593e4BAB9211',
       proposer3: process.env.PROPOSER3_ADDRESS || '0xdb080dC48961bC1D67a0A4151572eCb824cC76E8',

--- a/docker/docker-compose.apps.yml
+++ b/docker/docker-compose.apps.yml
@@ -5,6 +5,7 @@ services:
     build:
       dockerfile: docker/proposer.Dockerfile
       context: ..
+    image: ghcr.io/eyblockchain/nightfall3-proposer:latest
     ports:
       # to use with postman and etc
       - 8092:8092

--- a/docker/docker-compose.client.yml
+++ b/docker/docker-compose.client.yml
@@ -25,16 +25,13 @@ services:
       OPTIMIST_HOST: ${OPTIMIST_HOST:-optimist}
       OPTIMIST_PORT: ${OPTIMIST_PORT:-80}
       MONGO_URL: ${CLIENT_MONGO_URL:-mongodb://mongodb:27017}
-      RABBITMQ_HOST: ${RABBITMQ_HOST:-amqp://rabbitmq}
-      RABBITMQ_PORT: ${RABBITMQ_PORT:-5672}
-      ENABLE_QUEUE: ${ENABLE_QUEUE:-1}
       BLOCKCHAIN_URL: wss://${BLOCKCHAIN_WS_HOST}
       USE_EXTERNAL_NODE: 'true'
       AUTOSTART_RETRIES: 600
       ETH_NETWORK: ${ETH_NETWORK}
       CONTRACT_FILES_URL: ${CONTRACT_FILES_URL}
       BLOCKCHAIN_WS_HOST: ${BLOCKCHAIN_WS_HOST}
-
+      LAUNCH_LOCAL: 1
     command: ['npm', 'run', 'dev']
 
   rabbitmq:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -81,6 +81,7 @@ services:
     build:
       dockerfile: docker/hosted-utils-api-server.Dockerfile
       context: ..
+    image: ghcr.io/eyblockchain/nightfall3-hosted-utils-api-server:latest
     depends_on:
       - worker
     ports:

--- a/hosted-utils-api-server/entrypoint.sh
+++ b/hosted-utils-api-server/entrypoint.sh
@@ -19,7 +19,7 @@ for PROVING_FILE_FOLDERS in * ; do
     echo -e "\t\t\"zkeyh\": \"${HF_ZKEY}\"," >> s3_hash.txt
     echo -e "\t\t\"zkey\": \"circuits/${PROVING_FILE_FOLDERS}/${PROVING_FILE_FOLDERS}.zkey\"," >> s3_hash.txt
     echo -e "\t\t\"wasmh\": \"${HF_WASM}\"," >> s3_hash.txt
-    echo -e "\t\t\"wasm\": \"circuits/${PROVING_FILE_FOLDERS}/${PROVING_FILE_FOLDERS}_js/${PROVING_FILE_FOLDERS}.wasm\"" >> s3_hash.txt
+    echo -e "\t\t\"wasm\": \"circuits/${PROVING_FILE_FOLDERS}/${PROVING_FILE_FOLDERS}.wasm\"" >> s3_hash.txt
     echo -e "\t}," >> s3_hash.txt
   fi
 done

--- a/hosted-utils-api-server/entrypoint.sh
+++ b/hosted-utils-api-server/entrypoint.sh
@@ -13,11 +13,11 @@ for PROVING_FILE_FOLDERS in * ; do
   echo $PROVING_FILE_FOLDERS
   if [ -d "${PROVING_FILE_FOLDERS}" ]; then
     HF_ZKEY=$(cat hash.txt | grep ${PROVING_FILE_FOLDERS}.zkey | awk '{print $1}')
-    HF_WASM=$(cat hash.txt | grep ${PROVING_FILE_FOLDERS}/${PROVING_FILE_FOLDERS}_js/${PROVING_FILE_FOLDERS}.wasm | awk '{print $1}')
+    HF_WASM=$(cat hash.txt | grep ${PROVING_FILE_FOLDERS}.wasm | awk '{print $1}')
     echo -e "\t{" >> s3_hash.txt
     echo -e "\t\t\"name\": \"${PROVING_FILE_FOLDERS}\","  >> s3_hash.txt
-    echo -e "\t\t\"zkeyh\": \"${HF_ZKEY}\"," >> s3_hash.txt
-    echo -e "\t\t\"zkey\": \"circuits/${PROVING_FILE_FOLDERS}/${PROVING_FILE_FOLDERS}.zkey\"," >> s3_hash.txt
+    echo -e "\t\t\"zkh\": \"${HF_ZKEY}\"," >> s3_hash.txt
+    echo -e "\t\t\"zk\": \"circuits/${PROVING_FILE_FOLDERS}/${PROVING_FILE_FOLDERS}.zkey\"," >> s3_hash.txt
     echo -e "\t\t\"wasmh\": \"${HF_WASM}\"," >> s3_hash.txt
     echo -e "\t\t\"wasm\": \"circuits/${PROVING_FILE_FOLDERS}/${PROVING_FILE_FOLDERS}.wasm\"" >> s3_hash.txt
     echo -e "\t}," >> s3_hash.txt

--- a/nightfall-client/src/app.mjs
+++ b/nightfall-client/src/app.mjs
@@ -21,6 +21,14 @@ import {
 
 const app = express();
 
+// Add check for syncing state. If it is in syncing state, just respond 400
+app.use((req, res, next) => {
+  if (req.app.get('isSyncing')) {
+    res.sendStatus(400);
+    return res.status;
+  }
+  return next();
+});
 setupHttpDefaults(
   app,
   app => {

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -244,11 +244,11 @@ export async function getWalletBalanceUnfiltered() {
   const db = connection.db(COMMITMENTS_DB);
   const query = { isNullified: false, isOnChain: { $gte: 0 } };
   const options = {
-    projection: {
-      compressedZkpPublicKey: 1,
-      preimage: { ercAddress: 1, tokenId: 1, value: 1 },
-      _id: 0,
-    },
+    compressedZkpPublicKey: 1,
+    'preimage.ercAddress': 1,
+    'preimage.tokenId': 1,
+    'preimage.value': 1,
+    _id: 0,
   };
   const wallet = await db.collection(COMMITMENTS_COLLECTION).find(query, options).toArray();
   // the below is a little complex.  First we extract the ercAddress, tokenId and value
@@ -289,11 +289,11 @@ export async function getWalletBalance(compressedZkpPublicKey, ercList) {
   const db = connection.db(COMMITMENTS_DB);
   const query = { isNullified: false, isOnChain: { $gte: 0 } };
   const options = {
-    projection: {
-      compressedZkpPublicKey: 1,
-      preimage: { ercAddress: 1, tokenId: 1, value: 1 },
-      _id: 0,
-    },
+    compressedZkpPublicKey: 1,
+    'preimage.ercAddress': 1,
+    'preimage.tokenId': 1,
+    'preimage.value': 1,
+    _id: 0,
   };
   const wallet = await db.collection(COMMITMENTS_COLLECTION).find(query, options).toArray();
   // the below is a little complex.  First we extract the ercAddress, tokenId and value
@@ -346,11 +346,11 @@ export async function getWalletPendingDepositBalance(compressedZkpPublicKey, erc
   const db = connection.db(COMMITMENTS_DB);
   const query = { isDeposited: true, isNullified: false, isOnChain: { $eq: -1 } };
   const options = {
-    projection: {
-      compressedZkpPublicKey: 1,
-      preimage: { ercAddress: 1, tokenId: 1, value: 1 },
-      _id: 0,
-    },
+    compressedZkpPublicKey: 1,
+    'preimage.ercAddress': 1,
+    'preimage.tokenId': 1,
+    'preimage.value': 1,
+    _id: 0,
   };
   const wallet = await db.collection(COMMITMENTS_COLLECTION).find(query, options).toArray();
   // the below is a little complex.  First we extract the ercAddress, tokenId and value
@@ -407,11 +407,11 @@ export async function getWalletPendingSpentBalance(compressedZkpPublicKey, ercLi
   const db = connection.db(COMMITMENTS_DB);
   const query = { isNullified: true, isNullifiedOnChain: { $eq: -1 } };
   const options = {
-    projection: {
-      compressedZkpPublicKey: 1,
-      preimage: { ercAddress: 1, tokenId: 1, value: 1 },
-      _id: 0,
-    },
+    compressedZkpPublicKey: 1,
+    'preimage.ercAddress': 1,
+    'preimage.tokenId': 1,
+    'preimage.value': 1,
+    _id: 0,
   };
   const wallet = await db.collection(COMMITMENTS_COLLECTION).find(query, options).toArray();
   // the below is a little complex.  First we extract the ercAddress, tokenId and value
@@ -470,11 +470,11 @@ export async function getWalletCommitments(compressedZkpPublicKeyList, ercList) 
   const db = connection.db(COMMITMENTS_DB);
   const query = { isNullified: false, isOnChain: { $gte: 0 } };
   const options = {
-    projection: {
-      compressedZkpPublicKey: 1,
-      preimage: { ercAddress: 1, tokenId: 1, value: 1 },
-      _id: 0,
-    },
+    compressedZkpPublicKey: 1,
+    'preimage.ercAddress': 1,
+    'preimage.tokenId': 1,
+    'preimage.value': 1,
+    _id: 0,
   };
   const wallet = await db.collection(COMMITMENTS_COLLECTION).find(query, options).toArray();
   // the below is a little complex.  First we extract the ercAddress, tokenId and value

--- a/nightfall-client/start-client
+++ b/nightfall-client/start-client
@@ -54,5 +54,6 @@ trap "docker-compose $FILE -p 'nightfall_3' down --remove-orphans -t 1; exit 1" 
 docker-compose $FILE -p 'nightfall_3' down --remove-orphans
 
 echo "docker-compose $FILE -p 'nightfall_3' up -d --remove-orphans"
+docker-compose $FILE pull
 docker-compose $FILE -p 'nightfall_3' up -d --remove-orphans
 docker-compose -p 'nightfall_3' $FILE logs -f

--- a/nightfall-deployer/src/circuit-setup.mjs
+++ b/nightfall-deployer/src/circuit-setup.mjs
@@ -14,8 +14,6 @@ import utils from '@polygon-nightfall/common-files/utils/crypto/merkle-tree/util
 import { waitForContract } from '@polygon-nightfall/common-files/utils/contract.mjs';
 import crypto from 'crypto';
 
-const web3 = Web3.connection();
-
 const fsPromises = fs.promises;
 
 /**

--- a/nightfall-deployer/src/circuit-setup.mjs
+++ b/nightfall-deployer/src/circuit-setup.mjs
@@ -184,7 +184,7 @@ async function setupCircuits() {
           gas = config.WEB3_OPTIONS.gas;
           logger.warn({ msg: 'Gas estimation failed, use default', gas });
         }
-        
+
         tx.gas = Math.ceil(gas * 2); // 50% seems a more than reasonable buffer
 
         const signedTx = await web3.eth.accounts.signTransaction(tx, config.ETH_PRIVATE_KEY);
@@ -209,6 +209,7 @@ async function setupCircuits() {
       // on networks like Edge, there's no account management so we need to encodeABI()
       // since methods like send() don't work
       if (config.ETH_PRIVATE_KEY) {
+        let gas;
         const fromAddress = await web3.eth.accounts.privateKeyToAccount(config.ETH_PRIVATE_KEY);
         const tx = {
           from: fromAddress.address,
@@ -223,7 +224,7 @@ async function setupCircuits() {
           gas = config.WEB3_OPTIONS.gas;
           logger.warn({ msg: 'Gas estimation failed, use default', gas });
         }
-        
+
         tx.gas = Math.ceil(gas * 2); // 50% seems a more than reasonable buffer
 
         const signedTx = await web3.eth.accounts.signTransaction(tx, config.ETH_PRIVATE_KEY);

--- a/nightfall-deployer/src/circuit-setup.mjs
+++ b/nightfall-deployer/src/circuit-setup.mjs
@@ -169,13 +169,23 @@ async function setupCircuits() {
       // on networks like Edge, there's no account management so we need to encodeABI()
       // since methods like send() don't work
       if (config.ETH_PRIVATE_KEY) {
+        let gas;
+        const fromAddress = await web3.eth.accounts.privateKeyToAccount(config.ETH_PRIVATE_KEY);
         const tx = {
-          from: process.env.FROM_ADDRESS,
+          from: fromAddress.address,
           to: keyRegistry.options.address,
           data: call.encodeABI(),
-          gas: config.WEB3_OPTIONS.gas,
           gasPrice: config.WEB3_OPTIONS.gasPrice,
         };
+        try {
+          gas = await web3.eth.estimateGas(tx);
+          logger.debug({ msg: 'Gas estimated at', gas });
+        } catch (error) {
+          gas = config.WEB3_OPTIONS.gas;
+          logger.warn({ msg: 'Gas estimation failed, use default', gas });
+        }
+        
+        tx.gas = Math.ceil(gas * 2); // 50% seems a more than reasonable buffer
 
         const signedTx = await web3.eth.accounts.signTransaction(tx, config.ETH_PRIVATE_KEY);
         await web3.eth.sendSignedTransaction(signedTx.rawTransaction);
@@ -199,13 +209,22 @@ async function setupCircuits() {
       // on networks like Edge, there's no account management so we need to encodeABI()
       // since methods like send() don't work
       if (config.ETH_PRIVATE_KEY) {
+        const fromAddress = await web3.eth.accounts.privateKeyToAccount(config.ETH_PRIVATE_KEY);
         const tx = {
-          from: process.env.FROM_ADDRESS,
+          from: fromAddress.address,
           to: keyRegistry.options.address,
           data: call.encodeABI(),
-          gas: config.WEB3_OPTIONS.gas,
           gasPrice: config.WEB3_OPTIONS.gasPrice,
         };
+        try {
+          gas = await web3.eth.estimateGas(tx);
+          logger.debug({ msg: 'Gas estimated at', gas });
+        } catch (error) {
+          gas = config.WEB3_OPTIONS.gas;
+          logger.warn({ msg: 'Gas estimation failed, use default', gas });
+        }
+        
+        tx.gas = Math.ceil(gas * 2); // 50% seems a more than reasonable buffer
 
         const signedTx = await web3.eth.accounts.signTransaction(tx, config.ETH_PRIVATE_KEY);
         await web3.eth.sendSignedTransaction(signedTx.rawTransaction);

--- a/nightfall-deployer/src/circuit-setup.mjs
+++ b/nightfall-deployer/src/circuit-setup.mjs
@@ -169,26 +169,7 @@ async function setupCircuits() {
       // on networks like Edge, there's no account management so we need to encodeABI()
       // since methods like send() don't work
       if (config.ETH_PRIVATE_KEY) {
-        let gas;
-        const fromAddress = await web3.eth.accounts.privateKeyToAccount(config.ETH_PRIVATE_KEY);
-        const tx = {
-          from: fromAddress.address,
-          to: keyRegistry.options.address,
-          data: call.encodeABI(),
-          gasPrice: config.WEB3_OPTIONS.gasPrice,
-        };
-        try {
-          gas = await web3.eth.estimateGas(tx);
-          logger.debug({ msg: 'Gas estimated at', gas });
-        } catch (error) {
-          gas = config.WEB3_OPTIONS.gas;
-          logger.warn({ msg: 'Gas estimation failed, use default', gas });
-        }
-
-        tx.gas = Math.ceil(gas * 2); // 50% seems a more than reasonable buffer
-
-        const signedTx = await web3.eth.accounts.signTransaction(tx, config.ETH_PRIVATE_KEY);
-        await web3.eth.sendSignedTransaction(signedTx.rawTransaction);
+        await Web3.submitRawTransaction(call.endcodeABI(), keyRegistry.options.address);
       } else {
         call.send();
       }
@@ -209,26 +190,7 @@ async function setupCircuits() {
       // on networks like Edge, there's no account management so we need to encodeABI()
       // since methods like send() don't work
       if (config.ETH_PRIVATE_KEY) {
-        let gas;
-        const fromAddress = await web3.eth.accounts.privateKeyToAccount(config.ETH_PRIVATE_KEY);
-        const tx = {
-          from: fromAddress.address,
-          to: keyRegistry.options.address,
-          data: call.encodeABI(),
-          gasPrice: config.WEB3_OPTIONS.gasPrice,
-        };
-        try {
-          gas = await web3.eth.estimateGas(tx);
-          logger.debug({ msg: 'Gas estimated at', gas });
-        } catch (error) {
-          gas = config.WEB3_OPTIONS.gas;
-          logger.warn({ msg: 'Gas estimation failed, use default', gas });
-        }
-
-        tx.gas = Math.ceil(gas * 2); // 50% seems a more than reasonable buffer
-
-        const signedTx = await web3.eth.accounts.signTransaction(tx, config.ETH_PRIVATE_KEY);
-        await web3.eth.sendSignedTransaction(signedTx.rawTransaction);
+        await Web3.submitRawTransaction(call.endcodeABI(), keyRegistry.options.address);
       } else {
         call.send();
       }

--- a/nightfall-optimist/src/routes/proposer.mjs
+++ b/nightfall-optimist/src/routes/proposer.mjs
@@ -66,6 +66,8 @@ router.post('/register', async (req, res, next) => {
       or we're just about to register them. We may or may not be registed locally
       with optimist though. Let's check and fix that if needed.
      */
+    const stateContractInstance = await waitForContract(STATE_CONTRACT_NAME);
+    const currentProposer = await stateContractInstance.methods.getCurrentProposer().call();
     if (!(await isRegisteredProposerAddressMine(address))) {
       logger.debug('Registering proposer locally');
       await setRegisteredProposerAddress(address, url); // save the registration address
@@ -79,13 +81,18 @@ router.post('/register', async (req, res, next) => {
         logger.warn(
           'Proposer was already registered on the blockchain but not with this Optimist instance - registering locally',
         );
-        const stateContractInstance = await waitForContract(STATE_CONTRACT_NAME);
-        const currentProposer = await stateContractInstance.methods.getCurrentProposer().call();
         if (address === currentProposer.thisAddress) {
           proposer.isMe = true;
           await enqueueEvent(() => logger.info('Start Queue'), 0); // kickstart the queue
         }
       }
+    } else if (address === currentProposer.thisAddress && !proposer.isMe) {
+      logger.warn(
+        'Proposer was already registered on the blockchain and with this Optimist instance, but proposer flag wasnt set - setting isMe flag',
+      );
+      proposer.isMe = true;
+      proposer.address = address;
+      await enqueueEvent(() => logger.info('Start Queue'), 0); // kickstart the queue
     }
     res.json({ txDataToSign });
   } catch (err) {
@@ -305,6 +312,12 @@ router.get('/mempool', async (req, res, next) => {
   }
 });
 
+/**
+ * Function to Propose a state update block  This just
+ * provides the tx data, the user will need to call the blockchain client
+ * @deprecated - this is now an automated process - no need to manually propose
+ * a block
+ */
 router.post('/encode', async (req, res, next) => {
   try {
     const { transactions, block } = req.body;

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -123,6 +123,7 @@ export async function conditionalMakeBlock(proposer) {
       const currentTime = new Date().now;
       if (
         transactionBatches.length === 0 &&
+        mempoolTransactionSizes.length &&
         (makeNow || currentTime - lastBlockTimestamp >= PROPOSER_MAX_BLOCK_PERIOD_MILIS)
       ) {
         transactionBatches.push(mempoolTransactionSizes.length);

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -82,8 +82,6 @@ export async function conditionalMakeBlock(proposer) {
 
   if (proposer.isMe) {
     logger.info(`I am the current proposer: ${proposer.isMe}`);
-  }
-  if (proposer.isMe) {
     // Get all the mempool transactions sorted by fee
     const mempoolTransactions = await getMempoolTxsSortedByFee();
 

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -29,7 +29,7 @@ const { STATE_CONTRACT_NAME, ZERO } = constants;
 
 let ws;
 let makeNow = false;
-let lastBlockTimestamp = new Date().now;
+let lastBlockTimestamp = new Date().getTime();
 
 export function setBlockAssembledWebSocketConnection(_ws) {
   ws = _ws;
@@ -98,6 +98,7 @@ export async function conditionalMakeBlock(proposer) {
 
     // Calculate the total number of bytes that are in the mempool
     const totalBytes = mempoolTransactionSizes.reduce((acc, curr) => acc + curr, 0);
+    const currentTime = new Date().getTime();
 
     if (totalBytes) {
       logger.info({
@@ -120,14 +121,11 @@ export async function conditionalMakeBlock(proposer) {
         }
       }
 
-      const currentTime = new Date().now;
       if (
         transactionBatches.length === 0 &&
-        mempoolTransactionSizes.length &&
         (makeNow || currentTime - lastBlockTimestamp >= PROPOSER_MAX_BLOCK_PERIOD_MILIS)
       ) {
         transactionBatches.push(mempoolTransactionSizes.length);
-        lastBlockTimestamp = currentTime;
       }
     }
 
@@ -137,6 +135,7 @@ export async function conditionalMakeBlock(proposer) {
     });
 
     if (transactionBatches.length >= 1) {
+      lastBlockTimestamp = currentTime;
       // TODO set an upper limit to numberOfProposableL2Blocks because a proposer
       /*
         might not be able to submit a large number of blocks before the next proposer becomes

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -121,9 +121,12 @@ export async function conditionalMakeBlock(proposer) {
           bytesSum += mempoolTransactionSizes[i];
         }
       }
-      
+
       const currentTime = new Date().now;
-      if (transactionBatches.length === 0 && (makeNow || currentTime - lastBlockTimestamp >= PROPOSER_MAX_BLOCK_PERIOD_MILIS)) {
+      if (
+        transactionBatches.length === 0 &&
+        (makeNow || currentTime - lastBlockTimestamp >= PROPOSER_MAX_BLOCK_PERIOD_MILIS)
+      ) {
         transactionBatches.push(mempoolTransactionSizes.length);
         lastBlockTimestamp = currentTime;
       }

--- a/wallet/package.json
+++ b/wallet/package.json
@@ -112,6 +112,7 @@
     "start:mainnet": "LOCAL_PROPOSER=false PUBLIC_URL='/nightfall/' REACT_APP_MODE=mainnet env-cmd -f .mainnet.env node scripts/start.js",
     "start:internal": "LOCAL_PROPOSER=false PUBLIC_URL='/nightfall/' REACT_APP_MODE=internal env-cmd -f .internal.env node scripts/start.js",
     "build": "LOCAL_PROPOSER=false REACT_APP_MODE=production PUBLIC_URL='https://wallet-beta.polygon.technology/nightfall/' node scripts/build.js",
+    "build:testnet": "LOCAL_PROPOSER=false REACT_APP_MODE=testnet PUBLIC_URL='https://wallet.testnet.polygon-nightfall.technology/' node scripts/build.js",
     "deploy": "npm run build && aws s3 sync build s3://pnf-dev-browser --cache-control max-age=172800 --delete && aws configure set preview.cloudfront true && aws cloudfront create-invalidation --distribution-id ENV3X13MLR5YT --paths \"/*\"",
     "deploy:testnet": "npm run build:testnet && aws s3 sync build s3://pnf-dev-browser --cache-control max-age=172800 --delete && aws configure set preview.cloudfront true && aws cloudfront create-invalidation --distribution-id ENV3X13MLR5YT --paths \"/*\"",
     "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register 'tests/unit/**/*.js'",

--- a/wallet/src/components/Transactions/index.jsx
+++ b/wallet/src/components/Transactions/index.jsx
@@ -127,8 +127,7 @@ const Transactions = () => {
       if (
         safeTransactionType === withdrawHash &&
         tx.isOnChain > 0 &&
-        tx.withdrawState !== 'finalised' &&
-        Math.floor(Date.now() / 1000) - tx.createdTime > 3600 * 24 * 7
+        tx.withdrawState !== 'finalised'
       ) {
         withdrawReady = await isValidWithdrawal(tx._id, shieldContractAddress);
       }

--- a/wallet/src/nightfall-browser/services/fetch-circuit.js
+++ b/wallet/src/nightfall-browser/services/fetch-circuit.js
@@ -18,9 +18,7 @@ export async function fetchCircuit(circuit, { utilApiServerUrl, isLocalRun, AWS:
   let { wasm, zkey, hash } = circuit; // keys path in bucket
   const { wasmh = null, zkeyh = null, hashh = null } = circuit; // keys hash in bucket
   if (isLocalRun) {
-    wasm = await fetch(
-      `${utilApiServerUrl}/${circuit.name}/${circuit.name}_js/${circuit.name}.wasm`,
-    )
+    wasm = await fetch(`${utilApiServerUrl}/${circuit.name}/${circuit.name}.wasm`)
       .then(response => response.body.getReader())
       .then(parseData)
       .then(mergeUint8Array);

--- a/wallet/src/nightfall-browser/services/fetch-circuit.js
+++ b/wallet/src/nightfall-browser/services/fetch-circuit.js
@@ -15,14 +15,14 @@ export async function fetchAWSfiles(Bucket, Key) {
 }
 
 export async function fetchCircuit(circuit, { utilApiServerUrl, isLocalRun, AWS: { s3Bucket } }) {
-  let { wasm, zkey, hash } = circuit; // keys path in bucket
-  const { wasmh = null, zkeyh = null, hashh = null } = circuit; // keys hash in bucket
+  let { wasm, zk, hash } = circuit; // keys path in bucket
+  const { wasmh = null, zkh = null, hashh = null } = circuit; // keys hash in bucket
   if (isLocalRun) {
     wasm = await fetch(`${utilApiServerUrl}/${circuit.name}/${circuit.name}.wasm`)
       .then(response => response.body.getReader())
       .then(parseData)
       .then(mergeUint8Array);
-    zkey = await fetch(`${utilApiServerUrl}/${circuit.name}/${circuit.name}.zkey`)
+    zk = await fetch(`${utilApiServerUrl}/${circuit.name}/${circuit.name}.zkey`)
       .then(response => response.body.getReader())
       .then(parseData)
       .then(mergeUint8Array);
@@ -33,8 +33,8 @@ export async function fetchCircuit(circuit, { utilApiServerUrl, isLocalRun, AWS:
       );
   } else {
     wasm = await fetchAWSfiles(s3Bucket, wasm);
-    zkey = await fetchAWSfiles(s3Bucket, zkey);
+    zk = await fetchAWSfiles(s3Bucket, zk);
     hash = await fetchAWSfiles(s3Bucket, hash);
   }
-  return { wasm, wasmh, zkey, zkeyh, hash, hashh };
+  return { wasm, wasmh, zk, zkh, hash, hashh };
 }

--- a/wallet/src/nightfall-browser/services/fetch-circuit.js
+++ b/wallet/src/nightfall-browser/services/fetch-circuit.js
@@ -34,7 +34,8 @@ export async function fetchCircuit(circuit, { utilApiServerUrl, isLocalRun, AWS:
   } else {
     wasm = await fetchAWSfiles(s3Bucket, wasm);
     zk = await fetchAWSfiles(s3Bucket, zk);
-    hash = await fetchAWSfiles(s3Bucket, hash);
+    // hash is already computed when writing s3_file at deployment time.
+    // no need to compute it here
   }
   return { wasm, wasmh, zk, zkh, hash, hashh };
 }

--- a/wallet/src/web-worker/index.js
+++ b/wallet/src/web-worker/index.js
@@ -32,13 +32,13 @@ export default async function fetchCircuitFileAndStoreInIndexedDB() {
       !(await checkIndexDBForCircuitHash(circuit))
     ) {
       console.log('Updating', circuit);
-      const { wasm, wasmh, zkey, zkeyh, hash, hashh } = await fetchCircuit(circuit, {
+      const { wasm, wasmh, zk, zkh, hash, hashh } = await fetchCircuit(circuit, {
         utilApiServerUrl,
         isLocalRun,
         AWS: { s3Bucket },
       });
       await storeCircuit(`${circuit.name}-wasm`, wasm, wasmh);
-      await storeCircuit(`${circuit.name}-zkey`, zkey, zkeyh);
+      await storeCircuit(`${circuit.name}-zkey`, zk, zkh);
       await storeCircuit(`${circuit.name}-hash`, hash, hashh);
     }
   }

--- a/worker/src/index.mjs
+++ b/worker/src/index.mjs
@@ -47,7 +47,11 @@ const checkCircuitsOutput = async () => {
             ? `${circuits.find(c => filename.includes(c))}/`
             : '';
 
+          if (!fs.existsSync(`${outputPath}/${circuit}`)) {
+            fs.mkdirSync(`${outputPath}/${circuit}`);
+          }
           if (extension === 'wasm') circuit = `${circuit}${circuit.slice(0, -1)}_js/`;
+
           if (!fs.existsSync(`${outputPath}/${circuit}`)) {
             fs.mkdirSync(`${outputPath}/${circuit}`);
           }

--- a/worker/src/index.mjs
+++ b/worker/src/index.mjs
@@ -33,7 +33,6 @@ const checkCircuitsOutput = async () => {
     const url = `${baseUrl}/proving_files/hash.txt`;
     const outputPath = `./output`;
     const circuits = ['deposit', 'transfer', 'withdraw', 'burn', 'tokenise'];
-
     const res = await axios.get(url); // get all circuit files
     const files = res.data.split('\n');
 
@@ -43,16 +42,20 @@ const checkCircuitsOutput = async () => {
       files.map(async f => {
         if (f) {
           const filename = f.split('  ')[1];
-          const circuit = circuits.find(c => filename.includes(c));
+          const extension = f.split('.')[1];
+          let circuit = circuits.find(c => filename.includes(c))
+            ? `${circuits.find(c => filename.includes(c))}/`
+            : '';
 
+          if (extension === 'wasm') circuit = `${circuit}${circuit.slice(0, -1)}_js/`;
           if (!fs.existsSync(`${outputPath}/${circuit}`)) {
             fs.mkdirSync(`${outputPath}/${circuit}`);
           }
 
-          const downloadPath = `${baseUrl}/proving_files/${circuit}/${filename}`;
+          const downloadPath = `${baseUrl}/proving_files/${circuit}${filename}`;
 
           try {
-            await downloadFile(downloadPath, `${outputPath}/${circuit}/${filename}`);
+            await downloadFile(downloadPath, `${outputPath}/${circuit}${filename}`);
           } catch (e) {
             logger.error({
               message: `ERROR downloading ${filename}`,

--- a/worker/src/index.mjs
+++ b/worker/src/index.mjs
@@ -32,7 +32,7 @@ const checkCircuitsOutput = async () => {
       : `${DEFAULT_CIRCUIT_FILES_URL}/${env}`;
     const url = `${baseUrl}/proving_files/hash.txt`;
     const outputPath = `./output`;
-    const circuits = ['deposit', 'transfer', 'withdraw'];
+    const circuits = ['deposit', 'transfer', 'withdraw', 'burn', 'tokenise'];
 
     const res = await axios.get(url); // get all circuit files
     const files = res.data.split('\n');


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
- `setContractState` and `transferOwnership` usually fail in goerli deployment. The reason is because there is no gas estimation being done
- Allow passing the name for both optimist and commitments db. The reason is to allow different optimists and clients to use the same AWS cluster and just have different names.
- `PROPOSER_MAX_BLOCK_PERIOD_MILIS` configures the maximum time that a proposer can wait to generate a block if there are pending transactions.
- AWS document db requires different format for db projections
- circuit registration usually failed in Goerli deployment because there was no gas estimation being done
- In some tests i found that the proposer wasn't set even though addresses matched. This case is fixed now
- Correct `proposer` and `hosted-utils-api-server` containers were not used. When nightfall is deployed with `start-nightfall`, old containers were used instead.
- Fixed client so that i downloads new circuits
- Enabled client liveness test back
- Recovered delete `build:testnet` from wallet package.json
- Make naming consistent between S3 and wallet
- Tentatively working testnet wallet
- Cilent start http ports at the beginning, but returns `400` while syncing. This is to ensure that AWS ECS service can verify container is alive

## Does this close any currently open issues?
No

## What commands can I run to test the change? 

## Any other comments?

