### PR TITLE
Chait/optimist fixes

### DIFF
--- a/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
+++ b/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
@@ -2,11 +2,7 @@
  * Module to handle new Transactions being posted
  */
 import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
-import {
-  saveTransaction,
-  getBlockByTransactionHash,
-  getTransactionByTransactionHash,
-} from '../services/database.mjs';
+import { saveTransaction } from '../services/database.mjs';
 import checkTransaction from '../services/transaction-checker.mjs';
 import TransactionError from '../classes/transaction-error.mjs';
 import { getTransactionSubmittedCalldata } from '../services/process-calldata.mjs';

--- a/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
+++ b/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
@@ -11,7 +11,7 @@ import { getTransactionSubmittedCalldata } from '../services/process-calldata.mj
  * This handler runs whenever a new transaction is submitted to the blockchain
  */
 async function transactionSubmittedEventHandler(eventParams) {
-  const { offchain = false, fromBlockProposer, blockNumberL2 = -1, ...data } = eventParams;
+  const { offchain = false, fromBlockProposer = false, blockNumberL2 = -1, ...data } = eventParams;
   let transaction;
   if (offchain) {
     transaction = data;

--- a/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
+++ b/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
@@ -12,42 +12,10 @@ import TransactionError from '../classes/transaction-error.mjs';
 import { getTransactionSubmittedCalldata } from '../services/process-calldata.mjs';
 
 /**
- * It's possible this is a replay or a re-mine of a transaction that's already
- * in a block. Check for this.  This is not part of the general transaction
- * check because we don't want to do it as part of the block check, only when the
- * transaction is received. If we did it as part of the block check it would fail
- * because at that point we're bound to have the transaction both in the mempool and
- * in the block.
- */
-async function checkAlreadyInBlock(_transaction) {
-  const transaction = { ..._transaction };
-  const [block] = await getBlockByTransactionHash(transaction.transactionHash);
-
-  if (!block) return transaction; // all ok, we've not seen this before
-
-  const storedTransaction = await getTransactionByTransactionHash(transaction.transactionHash);
-
-  if (storedTransaction?.blockNumber) {
-    // it's a re-play of an existing transaction that's in a block
-    throw new TransactionError('This transaction has been processed previously', 6);
-  }
-
-  // it's a re-mine of an existing transaction that's in a block
-  transaction.mempool = false; // we don't want to put it in another block or we'll get a duplicate transaction challenge
-
-  logger.debug({
-    msg: 'Transaction has been re-mined but is already in a block - mempool set to false',
-    transactionHash: transaction.transactionHash,
-  });
-
-  return transaction; // but it's otherwise ok
-}
-
-/**
  * This handler runs whenever a new transaction is submitted to the blockchain
  */
 async function transactionSubmittedEventHandler(eventParams) {
-  const { offchain = false, fromBlockProposer, ...data } = eventParams;
+  const { offchain = false, fromBlockProposer, blockNumberL2 = -1, ...data } = eventParams;
   let transaction;
   if (offchain) {
     transaction = data;
@@ -65,23 +33,18 @@ async function transactionSubmittedEventHandler(eventParams) {
   });
 
   try {
-    transaction = await checkAlreadyInBlock(transaction);
-    // save transaction if not in block
+    // the transaction is received from block proposer event handler, save first and then check for validity
+    // otherwise (received from client directly or from smart contract's submitTransaction)
+    // don't save if the transaction is not valid.
     if (fromBlockProposer) {
-      await saveTransaction({ ...transaction });
-    }
-
-    logger.info({
-      msg: 'Checking transaction validity...',
-    });
-
-    await checkTransaction(transaction, true);
-    logger.info({
-      msg: 'Transaction checks passed',
-    });
-
-    // save it
-    if (!fromBlockProposer) {
+      await saveTransaction({ ...transaction, blockNumberL2 });
+      logger.info({ msg: 'Checking transaction validity...' });
+      await checkTransaction(transaction, true);
+      logger.info({ msg: 'Transaction checks passed' });
+    } else {
+      logger.info({ msg: 'Checking transaction validity...' });
+      await checkTransaction(transaction, true);
+      logger.info({ msg: 'Transaction checks passed' });
       await saveTransaction({ ...transaction });
     }
   } catch (err) {


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
`checkAlreadyInBlock` inside `transactionSubmittedEventHandler` is not be relevant because checking for duplicate transaction hashes is an incomplete check. Duplicacy check is done by commitments and nullifiers which is handled inside `checkTransaction` already. Also, this function caters to remine logic before the code transitioned to waiting for certain number of confirmation blocks before assuming the event is final to be processed.. Also error thrown from `checkAlreadyInBlock` would create a challenge incorrectly because it does not hold the necessary arguments required by `services/challenges.mjs`.  On a different note, if optimist receives a transaction as part of an L2 block that it was not aware of, then optimist  does not save `l2BlockNumber` whilst saving this transaction to it’s database. As a result, when `rollbackEventHandler` is called during a rollback of an L2 block, if an incorrect transaction, for example duplicate nullifier/commitment is being deleted, it risks deleting the original correct transaction too.
An even more important implication of this, when `removeTransactionsFromMemPool` which removes transactions from mempool is called inside `blockProposedEventHandler` for transactions in an L2 block, it does not work correctly because this function updates transactions by querying based on `blockNumberL2` too which in this case is unset. 

## Does this close any currently open issues?
Fixes the issues
https://github.com/EYBlockchain/nightfall_3_private/issues/236
https://github.com/EYBlockchain/nightfall_3_private/issues/234

## What commands can I run to test the change? 
github actions

## Any other comments?

