### PR TITLE
fix: bumping circom version to 2.1.2

### DIFF
--- a/nightfall-deployer/circuits/burn.circom
+++ b/nightfall-deployer/circuits/burn.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 
 include "./common/utils/calculate_keys.circom";
 include "./common/utils/array_uint32_to_bits.circom";

--- a/nightfall-deployer/circuits/common/utils/array_uint32_to_bits.circom
+++ b/nightfall-deployer/circuits/common/utils/array_uint32_to_bits.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 
 include "../../../node_modules/circomlib/circuits/bitify.circom";
 

--- a/nightfall-deployer/circuits/common/utils/calculate_keys.circom
+++ b/nightfall-deployer/circuits/common/utils/calculate_keys.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 
 include "../../../node_modules/circomlib/circuits/poseidon.circom";
 include "../../../node_modules/circomlib/circuits/bitify.circom";

--- a/nightfall-deployer/circuits/common/utils/calculate_root.circom
+++ b/nightfall-deployer/circuits/common/utils/calculate_root.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 
 include "../../../node_modules/circomlib/circuits/poseidon.circom";
 include "../../../node_modules/circomlib/circuits/bitify.circom";

--- a/nightfall-deployer/circuits/common/utils/kem_dem.circom
+++ b/nightfall-deployer/circuits/common/utils/kem_dem.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 
 include "../../../node_modules/circomlib/circuits/poseidon.circom";
 include "../../../node_modules/circomlib/circuits/escalarmulany.circom";

--- a/nightfall-deployer/circuits/common/verifiers/commitments/verify_commitments.circom
+++ b/nightfall-deployer/circuits/common/verifiers/commitments/verify_commitments.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 
 include "../../../../node_modules/circomlib/circuits/poseidon.circom";
 

--- a/nightfall-deployer/circuits/common/verifiers/commitments/verify_commitments_generic.circom
+++ b/nightfall-deployer/circuits/common/verifiers/commitments/verify_commitments_generic.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 
 include "../../../../node_modules/circomlib/circuits/comparators.circom";
 include "../../../../node_modules/circomlib/circuits/mux1.circom";

--- a/nightfall-deployer/circuits/common/verifiers/commitments/verify_commitments_optional.circom
+++ b/nightfall-deployer/circuits/common/verifiers/commitments/verify_commitments_optional.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 include "../../../../node_modules/circomlib/circuits/poseidon.circom";
 include "../../../../node_modules/circomlib/circuits/comparators.circom";
 include "../../../../node_modules/circomlib/circuits/mux1.circom";

--- a/nightfall-deployer/circuits/common/verifiers/nullifiers/verify_nullifiers.circom
+++ b/nightfall-deployer/circuits/common/verifiers/nullifiers/verify_nullifiers.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 
 include "../../../../node_modules/circomlib/circuits/comparators.circom";
 include "../../../../node_modules/circomlib/circuits/poseidon.circom";

--- a/nightfall-deployer/circuits/common/verifiers/nullifiers/verify_nullifiers_generic.circom
+++ b/nightfall-deployer/circuits/common/verifiers/nullifiers/verify_nullifiers_generic.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 
 include "../../../../node_modules/circomlib/circuits/comparators.circom";
 include "../../../../node_modules/circomlib/circuits/mux1.circom";

--- a/nightfall-deployer/circuits/common/verifiers/nullifiers/verify_nullifiers_optional.circom
+++ b/nightfall-deployer/circuits/common/verifiers/nullifiers/verify_nullifiers_optional.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 
 include "../../../../node_modules/circomlib/circuits/comparators.circom";
 include "../../../../node_modules/circomlib/circuits/mux1.circom";

--- a/nightfall-deployer/circuits/common/verifiers/verify_duplicates.circom
+++ b/nightfall-deployer/circuits/common/verifiers/verify_duplicates.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 
 /**
  * Check that there are no duplicate commitments nor nullifiers in the same transaction

--- a/nightfall-deployer/circuits/common/verifiers/verify_encryption.circom
+++ b/nightfall-deployer/circuits/common/verifiers/verify_encryption.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 
 include "../../../node_modules/circomlib/circuits/bitify.circom";
 include "../../../node_modules/circomlib/circuits/pointbits.circom";

--- a/nightfall-deployer/circuits/deposit.circom
+++ b/nightfall-deployer/circuits/deposit.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 
 include "./common/verifiers/verify_duplicates.circom";
 include "./common/verifiers/commitments/verify_commitments.circom";

--- a/nightfall-deployer/circuits/tokenise.circom
+++ b/nightfall-deployer/circuits/tokenise.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 
 include "./common/utils/calculate_keys.circom";
 include "./common/utils/array_uint32_to_bits.circom";

--- a/nightfall-deployer/circuits/transfer.circom
+++ b/nightfall-deployer/circuits/transfer.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 
 include "./common/utils/calculate_keys.circom";
 include "./common/utils/array_uint32_to_bits.circom";

--- a/nightfall-deployer/circuits/withdraw.circom
+++ b/nightfall-deployer/circuits/withdraw.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.0;
+pragma circom 2.1.2;
 
 include "./common/utils/calculate_keys.circom";
 include "./common/utils/array_uint32_to_bits.circom";

--- a/test/unit/circuits/common/utils/calculate_keys.circom.test.mjs
+++ b/test/unit/circuits/common/utils/calculate_keys.circom.test.mjs
@@ -15,7 +15,7 @@ describe('Test calculate keys', function () {
 
   before(async () => {
     const circuitCode = `
-            pragma circom 2.1.0;
+            pragma circom 2.1.2;
             include "../../../../../nightfall-deployer/circuits/common/utils/calculate_keys.circom";
             component main = CalculateKeys();
         `;

--- a/test/unit/circuits/common/utils/calculate_root.circom.test.mjs
+++ b/test/unit/circuits/common/utils/calculate_root.circom.test.mjs
@@ -19,7 +19,7 @@ describe('Test calculate root', function () {
 
   it('Should set the correct order of the pathNode and siblingNode if order is 1', async () => {
     const circuitCode = `
-            pragma circom 2.1.0;
+            pragma circom 2.1.2;
             include "../../../../../nightfall-deployer/circuits/common/utils/calculate_root.circom";
             component main = OrderFields();
         `;
@@ -47,7 +47,7 @@ describe('Test calculate root', function () {
 
   it('Should set the correct order of the pathNode and siblingNode if order is 0', async () => {
     const circuitCode = `
-            pragma circom 2.1.0;
+            pragma circom 2.1.2;
             include "../../../../../nightfall-deployer/circuits/common/utils/calculate_root.circom";
             component main = OrderFields();
         `;
@@ -75,7 +75,7 @@ describe('Test calculate root', function () {
 
   it('Should calculate root of the merkle tree from the hash, siblingPath and order', async () => {
     const circuitCode = `
-            pragma circom 2.1.0;
+            pragma circom 2.1.2;
             include "../../../../../nightfall-deployer/circuits/common/utils/calculate_root.circom";
             component main = CalculateRoot();
         `;

--- a/test/unit/circuits/common/utils/kem_dem.circom.test.mjs
+++ b/test/unit/circuits/common/utils/kem_dem.circom.test.mjs
@@ -45,7 +45,7 @@ describe('Test Kem Dem', function () {
 
   it('Should verify KEM', async () => {
     const circuitCode = `
-            pragma circom 2.1.0;
+            pragma circom 2.1.2;
             include "../../../../../nightfall-deployer/circuits/common/utils/kem_dem.circom";
             component main = Kem();
         `;
@@ -70,7 +70,7 @@ describe('Test Kem Dem', function () {
 
   it('Should verify DEM', async () => {
     const circuitCode = `
-            pragma circom 2.1.0;
+            pragma circom 2.1.2;
             include "../../../../../nightfall-deployer/circuits/common/utils/kem_dem.circom";
             component main = Dem(3);
         `;
@@ -95,7 +95,7 @@ describe('Test Kem Dem', function () {
 
   it('Should verify KEM-DEM', async () => {
     const circuitCode = `
-            pragma circom 2.1.0;
+            pragma circom 2.1.2;
             include "../../../../../nightfall-deployer/circuits/common/utils/kem_dem.circom";
             component main = KemDem(3);
         `;

--- a/test/unit/circuits/common/verifiers/commitments/verify_commitments.circom.test.mjs
+++ b/test/unit/circuits/common/verifiers/commitments/verify_commitments.circom.test.mjs
@@ -24,7 +24,7 @@ describe('Test verify commitments', function () {
 
   before(async () => {
     const circuitCode = `
-            pragma circom 2.1.0;
+            pragma circom 2.1.2;
             include "../../../../../../nightfall-deployer/circuits/common/verifiers/commitments/verify_commitments.circom";
             component main = VerifyCommitments(1);
         `;

--- a/test/unit/circuits/common/verifiers/commitments/verify_commitments_generic.circom.test.mjs
+++ b/test/unit/circuits/common/verifiers/commitments/verify_commitments_generic.circom.test.mjs
@@ -26,7 +26,7 @@ describe('Test verify commitments generic', function () {
 
   before(async () => {
     const circuitCode = `
-            pragma circom 2.1.0;
+            pragma circom 2.1.2;
             include "../../../../../../nightfall-deployer/circuits/common/verifiers/commitments/verify_commitments_generic.circom";
             component main = VerifyCommitmentsGeneric(1);
         `;

--- a/test/unit/circuits/common/verifiers/commitments/verify_commitments_optional.circom.test.mjs
+++ b/test/unit/circuits/common/verifiers/commitments/verify_commitments_optional.circom.test.mjs
@@ -24,7 +24,7 @@ describe('Test verify commitments optional', function () {
 
   before(async () => {
     const circuitCode = `
-            pragma circom 2.1.0;
+            pragma circom 2.1.2;
             include "../../../../../../nightfall-deployer/circuits/common/verifiers/commitments/verify_commitments_optional.circom";
             component main = VerifyCommitmentsOptional(1);
         `;

--- a/test/unit/circuits/common/verifiers/nullifiers/verify_nullifiers.circom.test.mjs
+++ b/test/unit/circuits/common/verifiers/nullifiers/verify_nullifiers.circom.test.mjs
@@ -28,7 +28,7 @@ describe('Test verify nullifiers', async function () {
 
   before(async () => {
     const circuitCode = `
-            pragma circom 2.1.0;
+            pragma circom 2.1.2;
             include "../../../../../../nightfall-deployer/circuits/common/verifiers/nullifiers/verify_nullifiers.circom";
             component main = VerifyNullifiers(1);
         `;

--- a/test/unit/circuits/common/verifiers/nullifiers/verify_nullifiers_generic.circom.test.mjs
+++ b/test/unit/circuits/common/verifiers/nullifiers/verify_nullifiers_generic.circom.test.mjs
@@ -31,7 +31,7 @@ describe('Test verify nullifiers generic', async function () {
 
   before(async () => {
     const circuitCode = `
-            pragma circom 2.1.0;
+            pragma circom 2.1.2;
             include "../../../../../../nightfall-deployer/circuits/common/verifiers/nullifiers/verify_nullifiers_generic.circom";
             component main = VerifyNullifiersGeneric(1);
         `;

--- a/test/unit/circuits/common/verifiers/nullifiers/verify_nullifiers_optional.circom.test.mjs
+++ b/test/unit/circuits/common/verifiers/nullifiers/verify_nullifiers_optional.circom.test.mjs
@@ -28,7 +28,7 @@ describe('Test verify nullifiers optional', async function () {
 
   before(async () => {
     const circuitCode = `
-            pragma circom 2.1.0;
+            pragma circom 2.1.2;
             include "../../../../../../nightfall-deployer/circuits/common/verifiers/nullifiers/verify_nullifiers_optional.circom";
             component main = VerifyNullifiersOptional(1);
         `;

--- a/test/unit/circuits/common/verifiers/verify_duplicates.circom.test.mjs
+++ b/test/unit/circuits/common/verifiers/verify_duplicates.circom.test.mjs
@@ -17,7 +17,7 @@ describe('Test verify duplicates', function () {
 
   before(async () => {
     const circuitCode = `
-            pragma circom 2.1.0;
+            pragma circom 2.1.2;
             include "../../../../../nightfall-deployer/circuits/common/verifiers/verify_duplicates.circom";
             component main = VerifyDuplicates(4,4);
         `;

--- a/test/unit/circuits/common/verifiers/verify_encryption.circom.test.mjs
+++ b/test/unit/circuits/common/verifiers/verify_encryption.circom.test.mjs
@@ -28,7 +28,7 @@ describe('Test verify encryption', function () {
 
   before(async () => {
     const circuitCode = `
-            pragma circom 2.1.0;
+            pragma circom 2.1.2;
             include "../../../../../nightfall-deployer/circuits/common/verifiers/verify_encryption.circom";
             component main = VerifyEncryption();
         `;


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Updates circom circuits from version 2.1.0 to 2.1.2, which fixes a bug in the witness generator (although it doesn't impact our project because we are using wasm files to generate the witness)


