### PR TITLE
Minor maxNonFeeNullifiers logic fixes

### DIFF
--- a/nightfall-client/src/utils/getCommitmentInfo.mjs
+++ b/nightfall-client/src/utils/getCommitmentInfo.mjs
@@ -44,8 +44,13 @@ export const getCommitmentInfo = async txInfo => {
 
   logger.debug(`Fee will be added as part of the transaction commitments: ${addedFee > 0n}`);
 
-  let value = totalValueToSend + addedFee;
-  const feeValue = fee.bigInt - addedFee;
+  let value = totalValueToSend;
+  let feeValue = fee.bigInt;
+
+  if (maxNonFeeNullifiers === undefined || maxNonFeeNullifiers !== 0) {
+    value += addedFee;
+    feeValue -= addedFee;
+  }
 
   if (maxNonFeeNullifiers === undefined) {
     maxNonFeeNullifiers = feeValue > 0n ? maxNullifiers - 1 : maxNullifiers;
@@ -92,6 +97,8 @@ export const getCommitmentInfo = async txInfo => {
         // this can only happen when the token to send is the fee token
         // we need to set the value here instead of the feeValue
         value = providedValue >= value ? 0n : value - providedValue;
+        maxNonFeeNullifiers =
+          providedValue >= value ? 0 : maxNonFeeNullifiers - validatedProvidedCommitments.length;
       } else {
         maxNonFeeNullifiers = 0;
       }


### PR DESCRIPTION
When performing any action (deposit, transfer, burn...) the function `getCommitmentsInfo` is called. This function has two parameters called `maxNullifiers`, which is the max number of nullifiers that the circuits allow, and `maxNonFeeNullifiers`, which is the max number of nullifiers that aren't used for the fee. If not specified, this second parameter is `undefined` by definition.

Also, if the token transferred ercAddress is the same than the fee ercAddress, the values are added together and fee is set to zero. This is done because when a commitment is selected is moved to `pendingNullified` and so if this wasn't done an error would be thrown. However, this should only be done if `maxNonFeeNullifiers` is not set to zero and hence this is fixed in this PR.

The second fix is related to the provided commitments logic. If a user provides a commitment hash, the code make sure that the amount provided is higher than the needed for transfer. However, it may happen that the user transfers MATIC (or the fee ercAddress token) and the amount is enough for covering value but not the fee. `maxNonFeeNullifiers` needs to be modified accordingly.





