### PR TITLE
Client was not doing rollbacks

### DIFF
--- a/nightfall-optimist/src/event-handlers/index.mjs
+++ b/nightfall-optimist/src/event-handlers/index.mjs
@@ -12,7 +12,6 @@ import rollbackEventHandler from './rollback.mjs';
 import committedToChallengeEventHandler from './challenge-commit.mjs';
 import instantWithdrawalRequestedEventHandler from './instant-withdrawal.mjs';
 import {
-  // removeRollbackEventHandler,
   removeBlockProposedEventHandler,
   removeCommittedToChallengeEventHandler,
   removeNewCurrentProposerEventHandler,
@@ -27,7 +26,6 @@ const eventHandlers = {
   NewCurrentProposer: newCurrentProposerEventHandler,
   InstantWithdrawalRequested: instantWithdrawalRequestedEventHandler,
   removers: {
-    // Rollback: removeRollbackEventHandler,
     BlockProposed: removeBlockProposedEventHandler,
     CommittedToChallenge: removeCommittedToChallengeEventHandler,
     TransactionSubmitted: removeTransactionSubmittedEventHandler,

--- a/nightfall-optimist/src/services/transaction-checker.mjs
+++ b/nightfall-optimist/src/services/transaction-checker.mjs
@@ -138,6 +138,11 @@ async function verifyProof(transaction) {
     }),
   );
 
+  logger.debug({
+    msg: 'The historic roots are the following',
+    historicRoots: historicRoots.map(h => h.root),
+  });
+
   const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
 
   const maticAddress = (

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -265,7 +265,7 @@ describe('Testing with an adversary', () => {
     });
 
     describe('Transfers rollback', async () => {
-      it.skip('Test duplicate transaction transfer', async () => {
+      it('Test duplicate transaction transfer', async () => {
         console.log('Testing duplicate transaction transfer...');
         await nf3User.transfer(
           'ValidTransaction',
@@ -372,7 +372,7 @@ describe('Testing with an adversary', () => {
     });
 
     describe('Withdraw rollbacks', async () => {
-      it.skip('Test duplicate transaction withdraw', async () => {
+      it('Test duplicate transaction withdraw', async () => {
         console.log('Testing duplicate transaction withdraw...');
         await nf3User.withdraw(
           'ValidTransaction',

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -227,7 +227,7 @@ export class Web3Client {
     for (let i = 0; i < length; i++) {
       const index = eventLogs.findIndex(e => e.eventName === expectedEvents[0]);
       const removed = index !== -1 && eventLogs.splice(index, 1);
-      eventsSeen.push(removed);
+      eventsSeen.push(...removed);
     }
 
     const blockHeaders = [];


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Since `emit Rollback` was moved into Challenges and the client was only listening for events for the State contract, rollback events weren't caught by the client, creating discrepancies between optimist and client database. 
In order to avoid similar issues in a future, the client is now subscribed to all the contracts. This doesn't have any impact to the client behaviour since all those events that are not handled are simply ignored.
State sync event handling has been fixed for both: client and optimist.
An additional log has been added to transaction checker to help us detect root discrepancies easier.
## Does this close any currently open issues?
N/A

## What commands can I run to test the change? 
N/A
## Any other comments?
N/A

