### PR TITLE
fix automatic changeCurrentProposer

### DIFF
--- a/apps/proposer/src/proposer.mjs
+++ b/apps/proposer/src/proposer.mjs
@@ -28,7 +28,7 @@ async function checkAndChangeProposer(nf3) {
       const spanProposersList = await nf3.spanProposersList(currentSprint);
       logger.info(`Proposer address: ${spanProposersList} and sprint: ${currentSprint}`);
       try {
-        if (spanProposersList[currentSprint] === nf3.ethereumAddress) {
+        if (spanProposersList === nf3.ethereumAddress) {
           logger.info(`${nf3.ethereumAddress} is Calling changeCurrentProposer`);
           await nf3.changeCurrentProposer();
         } else if (currentBlock - proposerStartBlock >= rotateProposerBlocks * MAX_ROTATE_TIMES) {

--- a/apps/proposer/src/proposer.mjs
+++ b/apps/proposer/src/proposer.mjs
@@ -25,10 +25,10 @@ async function checkAndChangeProposer(nf3) {
     const currentBlock = await nf3.web3.eth.getBlockNumber();
 
     if (currentBlock - proposerStartBlock >= rotateProposerBlocks && numproposers > 1) {
-      const spanProposersList = await nf3.spanProposersList(currentSprint);
-      logger.info(`Proposer address: ${spanProposersList} and sprint: ${currentSprint}`);
+      const spanProposersListAtPosition = await nf3.spanProposersList(currentSprint);
+      logger.info(`Proposer address: ${spanProposersListAtPosition} and sprint: ${currentSprint}`);
       try {
-        if (spanProposersList === nf3.ethereumAddress) {
+        if (spanProposersListAtPosition === nf3.ethereumAddress) {
           logger.info(`${nf3.ethereumAddress} is Calling changeCurrentProposer`);
           await nf3.changeCurrentProposer();
         } else if (currentBlock - proposerStartBlock >= rotateProposerBlocks * MAX_ROTATE_TIMES) {


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
fixed the typo in the condition `spanProposersList[currentSprint] === nf3.ethereumAddress` with `spanProposersListAtPosition === nf3.ethereumAddress`
that did not allow the changecurrentproposer to be called from the correct address

## Does this close any currently open issues?
No

## What commands can I run to test the change? 
./bin/start-multiproposer-test-env -g
docker logs -f proposer_1
docker logs -f proposer_2

