### PR TITLE
Optimist fixes

### DIFF
--- a/nightfall-optimist/src/event-handlers/block-proposed.mjs
+++ b/nightfall-optimist/src/event-handlers/block-proposed.mjs
@@ -101,8 +101,8 @@ async function blockProposedEventHandler(data) {
     const blockNullifiers = transactions
       .map(t => t.nullifiers.filter(c => c !== ZERO))
       .flat(Infinity);
-    await removeCommitmentsFromMemPool(blockCommitments);
-    await removeNullifiersFromMemPool(blockNullifiers);
+    await removeCommitmentsFromMemPool(blockCommitments, block.transactionHashes);
+    await removeNullifiersFromMemPool(blockNullifiers, block.transactionHashes);
 
     const latestTree = await getLatestTree();
     const updatedTimber = Timber.statelessUpdate(

--- a/nightfall-optimist/src/event-handlers/block-proposed.mjs
+++ b/nightfall-optimist/src/event-handlers/block-proposed.mjs
@@ -10,13 +10,13 @@ import BlockError from '../classes/block-error.mjs';
 import { createChallenge, commitToChallenge } from '../services/challenges.mjs';
 import {
   removeTransactionsFromMemPool,
-  removeCommitmentsFromMemPool,
-  removeNullifiersFromMemPool,
   saveBlock,
   getLatestTree,
   saveTree,
   getTransactionByTransactionHash,
   saveInvalidBlock,
+  deleteDuplicateCommitmentsFromMemPool,
+  deleteDuplicateNullifiersFromMemPool,
 } from '../services/database.mjs';
 import { getProposeBlockCalldata } from '../services/process-calldata.mjs';
 import { increaseBlockInvalidCounter } from '../services/debug-counters.mjs';
@@ -101,8 +101,8 @@ async function blockProposedEventHandler(data) {
     const blockNullifiers = transactions
       .map(t => t.nullifiers.filter(c => c !== ZERO))
       .flat(Infinity);
-    await removeCommitmentsFromMemPool(blockCommitments, block.transactionHashes);
-    await removeNullifiersFromMemPool(blockNullifiers, block.transactionHashes);
+    await deleteDuplicateCommitmentsFromMemPool(blockCommitments, block.transactionHashes);
+    await deleteDuplicateNullifiersFromMemPool(blockNullifiers, block.transactionHashes);
 
     const latestTree = await getLatestTree();
     const updatedTimber = Timber.statelessUpdate(

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -10,12 +10,7 @@ import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
 import { waitForTimeout } from '@polygon-nightfall/common-files/utils/utils.mjs';
 import constants from '@polygon-nightfall/common-files/constants/index.mjs';
 import { waitForContract } from '@polygon-nightfall/common-files/utils/contract.mjs';
-import {
-  removeTransactionsFromMemPool,
-  removeCommitmentsFromMemPool,
-  removeNullifiersFromMemPool,
-  getMempoolTxsSortedByFee,
-} from './database.mjs';
+import { removeTransactionsFromMemPool, getMempoolTxsSortedByFee } from './database.mjs';
 import Block from '../classes/block.mjs';
 import { Transaction } from '../classes/index.mjs';
 import {
@@ -25,7 +20,7 @@ import {
 } from './debug-counters.mjs';
 
 const { MAX_BLOCK_SIZE, MINIMUM_TRANSACTION_SLOTS, PROPOSER_MAX_BLOCK_PERIOD_MILIS } = config;
-const { STATE_CONTRACT_NAME, ZERO } = constants;
+const { STATE_CONTRACT_NAME } = constants;
 
 let ws;
 let makeNow = false;
@@ -227,12 +222,6 @@ export async function conditionalMakeBlock(proposer) {
         // remove the transactions from the mempool so we don't keep making new
         // blocks with them
         await removeTransactionsFromMemPool(block.transactionHashes);
-        await removeCommitmentsFromMemPool(
-          transactions.map(t => t.commitments.filter(c => c !== ZERO)).flat(Infinity),
-        );
-        await removeNullifiersFromMemPool(
-          transactions.map(t => t.nullifiers.filter(c => c !== ZERO)).flat(Infinity),
-        );
       }
     }
   }

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -373,24 +373,22 @@ export async function removeTransactionsFromMemPool(
 Function to remove a set of commitments from the layer 2 mempool once they've
 been processed into an L2 block
 */
-export async function removeCommitmentsFromMemPool(commitments) {
+export async function removeCommitmentsFromMemPool(commitments, transactionHashes) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
-  const query = { commitments: { $in: commitments } };
-  const update = { $set: { mempool: false } };
-  return db.collection(TRANSACTIONS_COLLECTION).updateMany(query, update);
+  const query = { commitments: { $in: commitments }, transactionHash: { $nin: transactionHashes } };
+  return db.collection(TRANSACTIONS_COLLECTION).deleteMany(query);
 }
 
 /**
 Function to remove a set of nullifiers from the layer 2 mempool once they've
 been processed into an L2 block
 */
-export async function removeNullifiersFromMemPool(nullifiers) {
+export async function removeNullifiersFromMemPool(nullifiers, transactionHashes) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
-  const query = { nullifiers: { $in: nullifiers } };
-  const update = { $set: { mempool: false } };
-  return db.collection(TRANSACTIONS_COLLECTION).updateMany(query, update);
+  const query = { nullifiers: { $in: nullifiers }, transactionHash: { $nin: transactionHashes } };
+  return db.collection(TRANSACTIONS_COLLECTION).deleteMany(query);
 }
 
 /**

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -164,10 +164,10 @@ export async function getBlockByBlockNumberL2(blockNumberL2) {
 function to delete a block. This is useful after a rollback event, whereby the
 block no longer exists
 */
-export async function deleteBlock(blockHash) {
+export async function deleteBlock(blockNumberL2) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
-  const query = { blockHash };
+  const query = { blockNumberL2: Number(blockNumberL2) };
   return db.collection(SUBMITTED_BLOCKS_COLLECTION).deleteOne(query);
 }
 
@@ -334,12 +334,12 @@ export async function saveTransaction(_transaction) {
 /**
 Function to add a set of transactions from the layer 2 mempool once a block has been rolled back
 */
-export async function addTransactionsToMemPool(block) {
+export async function addTransactionsToMemPool(transactionHashes, blockNumberL2) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   const query = {
-    transactionHash: { $in: block.transactionHashes },
-    blockNumberL2: { $eq: block.blockNumberL2 },
+    transactionHash: { $in: transactionHashes },
+    blockNumberL2: { $eq: Number(blockNumberL2) },
   };
   const update = {
     $set: {
@@ -471,7 +471,7 @@ export async function deleteTransactionsByTransactionHashes(transactionHashes) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   // We should not delete from a spent mempool
-  const query = { transactionHash: { $in: transactionHashes }, mempool: true };
+  const query = { transactionHash: { $in: transactionHashes } };
   return db.collection(TRANSACTIONS_COLLECTION).deleteMany(query);
 }
 

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -376,7 +376,11 @@ been processed into an L2 block
 export async function deleteDuplicateCommitmentsFromMemPool(commitments, transactionHashes) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
-  const query = { commitments: { $in: commitments }, transactionHash: { $nin: transactionHashes } };
+  const query = {
+    commitments: { $in: commitments },
+    transactionHash: { $nin: transactionHashes },
+    mempool: true,
+  };
   return db.collection(TRANSACTIONS_COLLECTION).deleteMany(query);
 }
 
@@ -387,7 +391,11 @@ been processed into an L2 block
 export async function deleteDuplicateNullifiersFromMemPool(nullifiers, transactionHashes) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
-  const query = { nullifiers: { $in: nullifiers }, transactionHash: { $nin: transactionHashes } };
+  const query = {
+    nullifiers: { $in: nullifiers },
+    transactionHash: { $nin: transactionHashes },
+    mempool: true,
+  };
   return db.collection(TRANSACTIONS_COLLECTION).deleteMany(query);
 }
 

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -373,7 +373,7 @@ export async function removeTransactionsFromMemPool(
 Function to remove a set of commitments from the layer 2 mempool once they've
 been processed into an L2 block
 */
-export async function removeCommitmentsFromMemPool(commitments, transactionHashes) {
+export async function deleteDuplicateCommitmentsFromMemPool(commitments, transactionHashes) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   const query = { commitments: { $in: commitments }, transactionHash: { $nin: transactionHashes } };
@@ -384,7 +384,7 @@ export async function removeCommitmentsFromMemPool(commitments, transactionHashe
 Function to remove a set of nullifiers from the layer 2 mempool once they've
 been processed into an L2 block
 */
-export async function removeNullifiersFromMemPool(nullifiers, transactionHashes) {
+export async function deleteDuplicateNullifiersFromMemPool(nullifiers, transactionHashes) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   const query = { nullifiers: { $in: nullifiers }, transactionHash: { $nin: transactionHashes } };

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -92,6 +92,7 @@ describe('Testing with an adversary', () => {
   let challengeSelector;
 
   const waitForRollback = async () => {
+    console.log('Waiting for rollback...');
     while (rollbackCount !== currentRollbacks + 1) {
       console.log(
         'Rollback count: ',
@@ -102,6 +103,7 @@ describe('Testing with an adversary', () => {
       );
       await new Promise(resolve => setTimeout(resolve, 3000));
     }
+    console.log('Rollback completed');
   };
 
   before(async () => {
@@ -210,9 +212,7 @@ describe('Testing with an adversary', () => {
         await nf3User.deposit('ValidTransaction', ercAddress, tokenType, value2, tokenId, fee);
         await makeBlockNow('DuplicateTransaction');
         await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-        console.log('Waiting for rollback...');
         await waitForRollback();
-        console.log('Rollback duplicate transaction deposit completed');
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeCommitment);
       });
 
@@ -221,9 +221,7 @@ describe('Testing with an adversary', () => {
         await nf3User.deposit('IncorrectInput', ercAddress, tokenType, value2, tokenId, 0);
         await makeBlockNow();
         await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-        console.log('Waiting for rollback...');
         await waitForRollback();
-        console.log('Rollback incorrect proof deposit completed');
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
 
@@ -232,9 +230,7 @@ describe('Testing with an adversary', () => {
         await nf3User.deposit('IncorrectProof', ercAddress, tokenType, value2, tokenId, 0);
         await makeBlockNow();
         await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-        console.log('Waiting for rollback...');
         await waitForRollback();
-        console.log('Rollback incorrect proof deposit completed');
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
     });
@@ -260,9 +256,7 @@ describe('Testing with an adversary', () => {
         );
         await makeBlockNow('DuplicateTransaction');
         await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-        console.log('Waiting for rollback...');
         await waitForRollback();
-        console.log('Rollback duplicate transaction transfer completed');
         expect(challengeSelector).to.be.oneOf([
           challengeSelectors.challengeCommitment,
           challengeSelectors.challengeNullifier,
@@ -283,9 +277,7 @@ describe('Testing with an adversary', () => {
         );
         await makeBlockNow();
         await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-        console.log('Waiting for rollback...');
         await waitForRollback();
-        console.log('Rollback duplicate nullifier transfer completed');
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeNullifier);
       });
 
@@ -303,9 +295,7 @@ describe('Testing with an adversary', () => {
         );
         await makeBlockNow();
         await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-        console.log('Waiting for rollback...');
         await waitForRollback();
-        console.log('Rollback  incorrect proof transfer completed');
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
 
@@ -322,9 +312,7 @@ describe('Testing with an adversary', () => {
         );
         await makeBlockNow();
         await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-        console.log('Waiting for rollback...');
         await waitForRollback();
-        console.log('Rollback  incorrect proof transfer completed');
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
 
@@ -342,9 +330,7 @@ describe('Testing with an adversary', () => {
         );
         await makeBlockNow();
         await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-        console.log('Waiting for rollback...');
         await waitForRollback();
-        console.log('Rollback incorrect historic root completed');
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeHistoricRoot);
       });
     });
@@ -370,9 +356,7 @@ describe('Testing with an adversary', () => {
         );
         await makeBlockNow('DuplicateTransaction');
         await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-        console.log('Waiting for rollback...');
         await waitForRollback();
-        console.log('Rollback duplicate transaction withdraw completed');
         expect(challengeSelector).to.be.oneOf([
           challengeSelectors.challengeCommitment,
           challengeSelectors.challengeNullifier,
@@ -393,9 +377,7 @@ describe('Testing with an adversary', () => {
         );
         await makeBlockNow();
         await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-        console.log('Waiting for rollback...');
         await waitForRollback();
-        console.log('Rollback  duplicate nullifier withdraw completed');
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeNullifier);
       });
 
@@ -413,9 +395,7 @@ describe('Testing with an adversary', () => {
         );
         await makeBlockNow();
         await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-        console.log('Waiting for rollback...');
         await waitForRollback();
-        console.log('Rollback incorrect proof withdraw completed');
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
 
@@ -433,9 +413,7 @@ describe('Testing with an adversary', () => {
         );
         await makeBlockNow();
         await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-        console.log('Waiting for rollback...');
         await waitForRollback();
-        console.log('Rollback incorrect proof withdraw completed');
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
 
@@ -453,9 +431,7 @@ describe('Testing with an adversary', () => {
         );
         await makeBlockNow();
         await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-        console.log('Waiting for rollback...');
         await waitForRollback();
-        console.log('Rollback incorrect historic root completed');
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeHistoricRoot);
       });
     });
@@ -467,9 +443,7 @@ describe('Testing with an adversary', () => {
       await nf3User.deposit('ValidTransaction', ercAddress, tokenType, value2, tokenId, 0);
       await makeBlockNow('IncorrectLeafCount');
       await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-      console.log('Waiting for rollback...');
       await waitForRollback();
-      console.log('Rollback incorrect leaf count completed');
       expect(challengeSelector).to.be.equal(challengeSelectors.challengeLeafCount);
     });
 
@@ -478,9 +452,7 @@ describe('Testing with an adversary', () => {
       await nf3User.deposit('ValidTransaction', ercAddress, tokenType, value2, tokenId, 0);
       await makeBlockNow('IncorrectTreeRoot');
       await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-      console.log('Waiting for rollback...');
       await waitForRollback();
-      console.log('Rollback incorrect tree root completed');
       expect(challengeSelector).to.be.equal(challengeSelectors.challengeRoot);
     });
 
@@ -489,9 +461,7 @@ describe('Testing with an adversary', () => {
       await nf3User.deposit('ValidTransaction', ercAddress, tokenType, value2, tokenId, 0);
       await makeBlockNow('IncorrectFrontierHash');
       await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-      console.log('Waiting for rollback...');
       await waitForRollback();
-      console.log('Rollback incorrect frontier hash completed');
       expect(challengeSelector).to.be.equal(challengeSelectors.challengeFrontier);
     });
   });


### PR DESCRIPTION
Once a block was assembled by a proposer, transactions were erased from the mempool by calling `removeTransactionsFromMempool` so that the same transaction isn't proposed twice. In addition to that, two extra functions were called: `removeNullifiersFromMempool` and `removeCommitmentsFromMempool`. Since a good optimist can not have duplicate nullifiers nor commitments in their DB (when transaction received, the fee is checked and only the one with highest fee is kept) those functions aren't needed anymore because they will have no impact.

On the other hand, this three functions are called when a block is proposed. In this case, it might be the case in which an optimist has a different transaction in his mempool with the same nullifier of a transaction that has been assembled into a block. However, there's no reason to keep those transactions in the mempool (the combination `mempool = false` and `blockNumberL1: -1` is a dead end) so it is better to simply remove it. 

This PR also fixes a race condition that was happening in the rollback. The way it was done, all transactions contained in a bad block were put back to the optimist's mempool, and then those that were invalid were removed. However, this means that for a brief period of time the optimist mempool contained invalid transactions, which means that if a outside call was made during that period the mempool would be desyncronized. This is fixed in this PR by only putting valid transactions back to the mempool.

Finally, it also removes the duplicate mempool check in the rollback. There is no need since in order for a rollback to happen, 
a block needs to be proposed first and all duplicates in the mempool are removed at that stage.
