### PR TITLE
fix deployer get circuits in some cases

### DIFF
--- a/nightfall-deployer/src/circuit-setup.mjs
+++ b/nightfall-deployer/src/circuit-setup.mjs
@@ -69,20 +69,18 @@ async function setupCircuits() {
   const circuitsToSetup = await await walk(config.CIRCUITS_HOME);
   // then we'll get all of the vks (some may not exist but we'll handle that in
   // a moments). We'll grab promises and then resolve them after the loop.
-  const resp = [];
+  const vks = [];
 
   for (const circuit of circuitsToSetup) {
     logger.debug(`checking for existing setup for ${circuit}`);
 
     const folderpath = circuit.slice(0, -7); // remove the .circom extension
-    resp.push(
-      axios.get(`${config.PROTOCOL}${config.CIRCOM_WORKER_HOST}/vk`, {
-        params: { folderpath },
-      }),
-    );
+    const r = await axios.get(`${config.PROTOCOL}${config.CIRCOM_WORKER_HOST}/vk`, {
+      params: { folderpath },
+    });
+    vks.push(r.data.vk);
   }
 
-  const vks = (await Promise.all(resp)).map(r => r.data.vk);
   const circuitHashes = [];
   const oldCircuitHashes = [];
 

--- a/worker/src/routes/vk.mjs
+++ b/worker/src/routes/vk.mjs
@@ -10,6 +10,7 @@ router.get('/', async (req, res, next) => {
   try {
     const { folderpath } = req.query;
     const vk = await getVerificationKeyByCircuitPath(folderpath);
+
     return res.send({ vk });
   } catch (err) {
     return next(err);

--- a/worker/src/routes/vk.mjs
+++ b/worker/src/routes/vk.mjs
@@ -1,4 +1,5 @@
 import express from 'express';
+import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
 import { getVerificationKeyByCircuitPath } from '../utils/filing.mjs';
 
 const router = express.Router();
@@ -8,9 +9,10 @@ const router = express.Router();
  */
 router.get('/', async (req, res, next) => {
   try {
+    logger.debug(`Received request to /vk ${req.query.folderpath}`);
     const { folderpath } = req.query;
     const vk = await getVerificationKeyByCircuitPath(folderpath);
-
+    logger.debug(`Returning vk ${folderpath}`);
     return res.send({ vk });
   } catch (err) {
     return next(err);

--- a/worker/src/routes/vk.mjs
+++ b/worker/src/routes/vk.mjs
@@ -1,5 +1,4 @@
 import express from 'express';
-import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
 import { getVerificationKeyByCircuitPath } from '../utils/filing.mjs';
 
 const router = express.Router();
@@ -9,10 +8,8 @@ const router = express.Router();
  */
 router.get('/', async (req, res, next) => {
   try {
-    logger.debug(`Received request to /vk ${req.query.folderpath}`);
     const { folderpath } = req.query;
     const vk = await getVerificationKeyByCircuitPath(folderpath);
-    logger.debug(`Returning vk ${folderpath}`);
     return res.send({ vk });
   } catch (err) {
     return next(err);

--- a/worker/src/utils/filing.mjs
+++ b/worker/src/utils/filing.mjs
@@ -13,16 +13,8 @@ export const getVerificationKeyByCircuitPath = async circuitPath => {
   if (fs.existsSync(vkPath)) {
     logger.debug(`Exporting verification key with snarkjs for ${vkPath}`);
 
-    let vk;
-    try {
-      vk = await snarkjs.zKey.exportVerificationKey(vkPath);
-      logger.debug(`Exported verification key for ${vkPath}`);
-    } catch (error) {
-      logger.error({
-        msg: 'Error snarkjs exportVerificationKey',
-        error,
-      });
-    }
+    const vk = await snarkjs.zKey.exportVerificationKey(vkPath);
+    logger.debug(`Exported verification key for ${vkPath}`);
     return vk;
   }
 

--- a/worker/src/utils/filing.mjs
+++ b/worker/src/utils/filing.mjs
@@ -13,8 +13,17 @@ export const getVerificationKeyByCircuitPath = async circuitPath => {
   if (fs.existsSync(vkPath)) {
     logger.debug(`Exporting verification key with snarkjs for ${vkPath}`);
 
-    const vk = await snarkjs.zKey.exportVerificationKey(vkPath);
-    logger.debug(`Exported verification key for ${vkPath}`);
+    let vk;
+    try {
+      vk = await snarkjs.zKey.exportVerificationKey(vkPath);
+      logger.debug(`Exported verification key for ${vkPath}`);
+    } catch (error) {
+      logger.error({
+        msg: 'Error snarkjs exportVerificationKey',
+        error,
+      });
+      throw new Error(error);
+    }
     return vk;
   }
 

--- a/worker/src/utils/filing.mjs
+++ b/worker/src/utils/filing.mjs
@@ -11,7 +11,18 @@ const outputPath = `/app/output`;
 export const getVerificationKeyByCircuitPath = async circuitPath => {
   const vkPath = `${outputPath}/${circuitPath}/${path.basename(circuitPath)}.zkey`;
   if (fs.existsSync(vkPath)) {
-    const vk = await snarkjs.zKey.exportVerificationKey(vkPath);
+    logger.debug(`Exporting verification key with snarkjs for ${vkPath}`);
+
+    let vk;
+    try {
+      vk = await snarkjs.zKey.exportVerificationKey(vkPath);
+      logger.debug(`Exported verification key for ${vkPath}`);
+    } catch (error) {
+      logger.error({
+        msg: 'Error snarkjs exportVerificationKey',
+        error,
+      });
+    }
     return vk;
   }
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
In some cases the deployer gets stucked checking the circuits and downloading them from the worker.
It has been detected that the function that sometimes is blocking the `deployer` is `getVerificationKeyByCircuitPath` from the `worker` in `filling.mjs` in the line when the verification key is exported with snarkjs (`snarkjs.zKey.exportVerificationKey`).

```
export const getVerificationKeyByCircuitPath = async circuitPath => {
  const vkPath = `${outputPath}/${circuitPath}/${path.basename(circuitPath)}.zkey`;
  if (fs.existsSync(vkPath)) {
    const vk = await snarkjs.zKey.exportVerificationKey(vkPath);
    return vk;
  }

  logger.warn({ msg: 'Unable to locate file', vkPath });

  return null;
};
```
If we don't do all the calls in parallel to get the verification keys of the circuits with `promise.all` and we do them sequentially then it's working fine.

## Does this close any currently open issues?
No

## What commands can I run to test the change? 
./bin/start-nightfall

## Any other comments?
No
