### PR TITLE
User can provide either fee or value commitments

### DIFF
--- a/nightfall-client/src/routes/burn.mjs
+++ b/nightfall-client/src/routes/burn.mjs
@@ -9,6 +9,7 @@ router.post('/', async (req, res, next) => {
     // convert commitment from GN to hex form for transmission
     res.json({ txDataToSign, transaction });
   } catch (err) {
+    res.json({ error: err.message });
     next(err);
   }
 });

--- a/nightfall-client/src/routes/deposit.mjs
+++ b/nightfall-client/src/routes/deposit.mjs
@@ -14,6 +14,7 @@ router.post('/', async (req, res, next) => {
     // convert commitment from GN to hex form for transmission
     res.json({ txDataToSign, transaction });
   } catch (err) {
+    res.json({ error: err.message });
     next(err);
   }
 });

--- a/nightfall-client/src/routes/tokenise.mjs
+++ b/nightfall-client/src/routes/tokenise.mjs
@@ -9,6 +9,7 @@ router.post('/', async (req, res, next) => {
     // convert commitment from GN to hex form for transmission
     res.json({ txDataToSign, transaction });
   } catch (err) {
+    res.json({ error: err.message });
     next(err);
   }
 });

--- a/nightfall-client/src/routes/transfer.mjs
+++ b/nightfall-client/src/routes/transfer.mjs
@@ -11,11 +11,7 @@ router.post('/', async (req, res, next) => {
     const { rawTransaction: txDataToSign, transaction } = await transfer(req.body);
     res.json({ txDataToSign, transaction });
   } catch (err) {
-    if (err.message.includes('no commitment')) {
-      res.json({ error: 'No suitable commitments' });
-    } else if (err.message.includes('invalid commitment hashes')) {
-      res.json({ error: err.message });
-    }
+    res.json({ error: err.message });
     next(err);
   }
 });

--- a/nightfall-client/src/routes/withdraw.mjs
+++ b/nightfall-client/src/routes/withdraw.mjs
@@ -11,11 +11,7 @@ router.post('/', async (req, res, next) => {
     const { rawTransaction: txDataToSign, transaction } = await withdraw(req.body);
     res.json({ txDataToSign, transaction });
   } catch (err) {
-    if (err.message.includes('no commitment')) {
-      res.json({ error: 'No suitable commitments' });
-    } else if (err.message.includes('invalid commitment hashes')) {
-      res.json({ error: err.message });
-    }
+    res.json({ error: err.message });
     next(err);
   }
 });

--- a/nightfall-client/src/services/burn.mjs
+++ b/nightfall-client/src/services/burn.mjs
@@ -22,7 +22,7 @@ const { generalise } = gen;
 async function burn(burnParams) {
   logger.info('Creating a burn transaction');
   // let's extract the input items
-  const { providedCommitments, ...items } = burnParams;
+  const { providedCommitments, providedCommitmentsFee, ...items } = burnParams;
   const { rootKey, value, fee, tokenId } = generalise(items);
   const { compressedZkpPublicKey, nullifierKey } = new ZkpKeys(rootKey);
   const ercAddress = generalise(items.ercAddress.toLowerCase());
@@ -46,6 +46,7 @@ async function burn(burnParams) {
     maxNullifiers: VK_IDS[circuitName].numberNullifiers,
     maxNonFeeNullifiers: 1,
     providedCommitments,
+    providedCommitmentsFee,
   });
 
   const circuitHash = await getCircuitHash(circuitName);

--- a/nightfall-client/src/services/deposit.mjs
+++ b/nightfall-client/src/services/deposit.mjs
@@ -30,7 +30,7 @@ const { generalise } = gen;
 async function deposit(depositParams) {
   logger.info('Creating a deposit transaction');
   const { tokenType, providedCommitmentsFee, ...items } = depositParams;
-  const ercAddress = generalise(depositParams.ercAddress.toLowerCase());
+  const ercAddress = generalise(items.ercAddress.toLowerCase());
   // before we do anything else, long hex strings should be generalised to make subsequent manipulations easier
   const { tokenId, value, fee, rootKey } = generalise(items);
   const { compressedZkpPublicKey, nullifierKey } = new ZkpKeys(rootKey);

--- a/nightfall-client/src/services/deposit.mjs
+++ b/nightfall-client/src/services/deposit.mjs
@@ -27,12 +27,12 @@ const { VK_IDS } = config;
 const { SHIELD_CONTRACT_NAME, BN128_GROUP_ORDER, DEPOSIT, DEPOSIT_FEE } = constants;
 const { generalise } = gen;
 
-async function deposit(items) {
+async function deposit(depositParams) {
   logger.info('Creating a deposit transaction');
-
+  const { tokenType, providedCommitmentsFee, ...items } = depositParams;
+  const ercAddress = generalise(depositParams.ercAddress.toLowerCase());
   // before we do anything else, long hex strings should be generalised to make subsequent manipulations easier
   const { tokenId, value, fee, rootKey } = generalise(items);
-  const ercAddress = generalise(items.ercAddress.toLowerCase());
   const { compressedZkpPublicKey, nullifierKey } = new ZkpKeys(rootKey);
   const zkpPublicKey = ZkpKeys.decompressZkpPublicKey(compressedZkpPublicKey);
   const salt = await randValueLT(BN128_GROUP_ORDER);
@@ -75,6 +75,7 @@ async function deposit(items) {
         rootKey,
         maxNullifiers: VK_IDS[circuitName].numberNullifiers,
         maxNonFeeNullifiers: 0,
+        providedCommitmentsFee,
       });
     }
   } else {
@@ -106,7 +107,7 @@ async function deposit(items) {
     fee,
     historicRootBlockNumberL2: commitmentsInfo.blockNumberL2s,
     circuitHash,
-    tokenType: items.tokenType,
+    tokenType,
     tokenId,
     value,
     ercAddress,

--- a/nightfall-client/src/services/tokenise.mjs
+++ b/nightfall-client/src/services/tokenise.mjs
@@ -22,6 +22,7 @@ const { generalise } = gen;
 
 async function tokenise(items) {
   logger.info('Creating a tokenise transaction');
+  const { providedCommitmentsFee } = items;
   const {
     salt = (await randValueLT(BN128_GROUP_ORDER)).hex(),
     value = 0,
@@ -57,6 +58,7 @@ async function tokenise(items) {
     rootKey,
     maxNullifiers: VK_IDS[circuitName].numberNullifiers,
     maxNonFeeNullifiers: 0,
+    providedCommitmentsFee,
   });
 
   const circuitHash = await getCircuitHash(circuitName);

--- a/nightfall-client/src/services/transfer.mjs
+++ b/nightfall-client/src/services/transfer.mjs
@@ -33,7 +33,12 @@ const { generalise } = gen;
 async function transfer(transferParams) {
   logger.info('Creating a transfer transaction');
   // let's extract the input items
-  const { offchain = false, providedCommitments, ...items } = transferParams;
+  const {
+    offchain = false,
+    providedCommitments,
+    providedCommitmentsFee,
+    ...items
+  } = transferParams;
   const { tokenId, recipientData, rootKey, fee } = generalise(items);
   const { compressedZkpPublicKey, nullifierKey } = new ZkpKeys(rootKey);
   const ercAddress = generalise(items.ercAddress.toLowerCase());
@@ -69,6 +74,7 @@ async function transfer(transferParams) {
     rootKey,
     maxNullifiers: VK_IDS[circuitName].numberNullifiers,
     providedCommitments,
+    providedCommitmentsFee,
   });
 
   try {

--- a/nightfall-client/src/services/withdraw.mjs
+++ b/nightfall-client/src/services/withdraw.mjs
@@ -31,7 +31,12 @@ const MAX_WITHDRAW = 5192296858534827628530496329220096n; // 2n**112n
 async function withdraw(withdrawParams) {
   logger.info('Creating a withdraw transaction');
   // let's extract the input items
-  const { offchain = false, providedCommitments, ...items } = withdrawParams;
+  const {
+    offchain = false,
+    providedCommitments,
+    providedCommitmentsFee,
+    ...items
+  } = withdrawParams;
   const { tokenId, value, recipientAddress, rootKey, fee } = generalise(items);
   const { compressedZkpPublicKey, nullifierKey } = new ZkpKeys(rootKey);
   const ercAddress = generalise(items.ercAddress.toLowerCase());
@@ -60,6 +65,7 @@ async function withdraw(withdrawParams) {
     rootKey,
     maxNullifiers: VK_IDS[circuitName].numberNullifiers,
     providedCommitments,
+    providedCommitmentsFee,
   });
 
   try {

--- a/nightfall-client/src/utils/getCommitmentInfo.mjs
+++ b/nightfall-client/src/utils/getCommitmentInfo.mjs
@@ -28,6 +28,7 @@ export const getCommitmentInfo = async txInfo => {
     tokenId = generalise(0),
     rootKey,
     providedCommitments = [],
+    providedCommitmentsFee = [],
   } = txInfo;
 
   let { maxNullifiers, maxNonFeeNullifiers = undefined } = txInfo;
@@ -40,6 +41,7 @@ export const getCommitmentInfo = async txInfo => {
 
   const tokenIdArray = recipientZkpPublicKeysArray.map(() => tokenId);
 
+  // If ercAddress is the same as the feeAddress, we will set the fee as zero and only look for value
   const addedFee = maticAddress.hex(32) === ercAddress.hex(32) ? fee.bigInt : 0n;
 
   logger.debug(`Fee will be added as part of the transaction commitments: ${addedFee > 0n}`);
@@ -47,68 +49,180 @@ export const getCommitmentInfo = async txInfo => {
   let value = totalValueToSend;
   let feeValue = fee.bigInt;
 
+  // If maxNonFeeNullifiers is equal to zero, it means that we are not looking for non fee commitments and so
+  // we won't use addedFee logic
   if (maxNonFeeNullifiers === undefined || maxNonFeeNullifiers !== 0) {
     value += addedFee;
     feeValue -= addedFee;
   }
 
+  // Set maxNonFeeNullifiers if undefined. If fee is higher than zero it means we will need at least 1 slot
+  // for the fee, so maximum non fee will be maxNullifiers - 1. Otherwise all slots can be used for the transfer
   if (maxNonFeeNullifiers === undefined) {
     maxNonFeeNullifiers = feeValue > 0n ? maxNullifiers - 1 : maxNullifiers;
   }
 
-  logger.debug(`using user provided commitments: ${providedCommitments.length > 0}`);
-
   const spentCommitments = [];
   try {
     let validatedProvidedCommitments = [];
-    if (providedCommitments.length > 0) {
-      const commitmentHashes = providedCommitments.map(c => c.toString());
-      logger.debug({ msg: 'looking up these commitment hashes:', commitmentHashes });
-      const rawCommitments = await getCommitmentsByHash(
-        commitmentHashes,
-        compressedZkpPublicKey,
-        ercAddress,
-        tokenId,
-      );
+    let validatedProvidedCommitmentsFee = [];
+    let nonFeeCommitmentsProvided = false;
+    let feeCommitmentsProvided = false;
+    let providedValue = 0n;
+    let providedValueFee = 0n;
 
-      if (rawCommitments.length < commitmentHashes.length) {
-        const invalidHashes = commitmentHashes.filter(ch => {
-          for (const rc of rawCommitments) {
-            if (rc._id === ch) return false;
-          }
-          return true;
-        });
-        throw new Error(`invalid commitment hashes: ${invalidHashes}`);
-      }
-
-      const providedValue = rawCommitments
-        .map(c => generalise(c.preimage.value).bigInt)
-        .reduce((sum, c) => sum + c);
-
-      if (providedValue < totalValueToSend)
-        throw new Error('provided commitments do not cover the value');
-
-      // transform the hashes retrieved from the DB to well formed commitments
-      validatedProvidedCommitments = rawCommitments.map(ct => new Commitment(ct.preimage));
-      logger.debug({ providedValue });
-
-      if (maticAddress.hex(32) === ercAddress.hex(32)) {
-        // the user provieded enough commitments to cover the value but not the fee
-        // this can only happen when the token to send is the fee token
-        // we need to set the value here instead of the feeValue
-        value = providedValue >= value ? 0n : value - providedValue;
-        maxNonFeeNullifiers =
-          providedValue >= value ? 0 : maxNonFeeNullifiers - validatedProvidedCommitments.length;
-      } else {
-        maxNonFeeNullifiers = 0;
-      }
-
-      maxNullifiers -= validatedProvidedCommitments.length;
-
-      await Promise.all(validatedProvidedCommitments.map(c => markPending(c)));
-      spentCommitments.push(...validatedProvidedCommitments);
+    // Throw an error if more than the allowed number of max number of nullifiers are provided
+    if (providedCommitments.length + providedCommitmentsFee.length > maxNullifiers) {
+      throw new Error(`You can not provide more than ${maxNullifiers} commitments to be nullified`);
     }
 
+    // User has the ability to specify the commitments they wanna use. If that's the case, we will need to check that
+    // those commitments are valid and fulfill all the requirements. Otherwise, we will use our own algorithm to select
+    // the commitments used.
+    if (providedCommitments.length > 0) {
+      logger.debug({ msg: `using user provided commitments for the value`, providedCommitments });
+
+      const commitmentHashes = providedCommitments.map(c => c.toString());
+
+      // Search for the commitment hashes in the DB. The commitment will be considered valid
+      // as long as it is not already nullified
+      const rawCommitments = await getCommitmentsByHash(commitmentHashes, compressedZkpPublicKey);
+
+      // Filter which of those commitments belong to the ercAddress
+      const ercAddressCommitments = rawCommitments.filter(
+        c => c.preimage.ercAddress === generalise(ercAddress).hex(32),
+      );
+
+      logger.debug({ ercAddressCommitments });
+
+      if (ercAddressCommitments.length < providedCommitments.length) {
+        const ercAddressCommitmentsHashes = ercAddressCommitments.map(c => c._id);
+
+        const invalidHashes = providedCommitments.filter(c =>
+          ercAddressCommitmentsHashes.includes(c),
+        );
+
+        throw new Error(
+          `Some of the commitments provided for the value were invalid: ${invalidHashes.join(
+            ' , ',
+          )}`,
+        );
+      }
+
+      // Calculate the total value from the ercAddress commitments
+      providedValue = ercAddressCommitments
+        .map(c => generalise(c.preimage.value).bigInt)
+        .reduce((sum, c) => sum + c, 0n);
+
+      if (ercAddressCommitments.length > 0) {
+        if (providedValue < totalValueToSend) {
+          throw new Error('provided commitments do not cover the value');
+        } else {
+          nonFeeCommitmentsProvided = true;
+          validatedProvidedCommitments = ercAddressCommitments.map(
+            ct => new Commitment(ct.preimage),
+          );
+        }
+      }
+
+      // If ercAddress commitments are provided, we force maxNonFeeNullifiers to be zero so that our algorithm
+      // does not check for transfer commitments. We cannot rely on value to be zero due to ERC721 tokens
+      if (nonFeeCommitmentsProvided) {
+        logger.debug({ validatedProvidedCommitments, providedValue });
+        maxNonFeeNullifiers = 0;
+      }
+    }
+
+    if (providedCommitmentsFee.length > 0) {
+      logger.debug({ msg: `using user provided commitments for the fee`, providedCommitmentsFee });
+
+      const commitmentHashesFee = providedCommitmentsFee.map(c => c.toString());
+
+      // Search for the commitment hashes in the DB. The commitment will be considered valid
+      // as long as it is not already nullified
+      const rawCommitmentsFee = await getCommitmentsByHash(
+        commitmentHashesFee,
+        compressedZkpPublicKey,
+      );
+
+      // Filter which of those commitments belong to the ercAddress
+      const ercAddressCommitmentsFee = rawCommitmentsFee.filter(
+        c => c.preimage.ercAddress === generalise(maticAddress).hex(32),
+      );
+
+      logger.debug({ ercAddressCommitmentsFee });
+
+      if (ercAddressCommitmentsFee.length < providedCommitmentsFee.length) {
+        const ercAddressCommitmentsHashesFee = ercAddressCommitmentsFee.map(c => c._id);
+
+        const invalidHashesFee = providedCommitmentsFee.filter(
+          c => !ercAddressCommitmentsHashesFee.includes(c),
+        );
+
+        throw new Error(
+          `Some of the commitments provided for the fee were invalid: ${invalidHashesFee.join(
+            ' , ',
+          )}`,
+        );
+      }
+
+      // Calculate the total value from the ercAddress commitments
+      providedValueFee = ercAddressCommitmentsFee
+        .map(c => generalise(c.preimage.value).bigInt)
+        .reduce((sum, c) => sum + c, 0n);
+
+      if (ercAddressCommitmentsFee.length > 0) {
+        // Check if enough value is provided. Otherwise, throw an error because we assume that
+        // if the user provide the commitments he has full control of what is he spending
+        if (providedValueFee < fee.bigInt) {
+          throw new Error('provided commitments do not cover the fee');
+        } else {
+          feeCommitmentsProvided = true;
+          validatedProvidedCommitmentsFee = ercAddressCommitmentsFee.map(
+            ct => new Commitment(ct.preimage),
+          );
+        }
+      }
+
+      if (feeCommitmentsProvided) {
+        logger.debug({ validatedProvidedCommitmentsFee, providedValueFee });
+        // If ercAddressFee commitments are provided, we force feeValue to be zero so that our algorithm
+        // does not check for fee commitments
+        feeValue = 0n;
+      }
+    }
+
+    const validatedCommitments = [
+      ...validatedProvidedCommitments,
+      ...validatedProvidedCommitmentsFee,
+    ];
+
+    // If the user is transferring the same token as the fee, the case in which the user provided
+    // enough commitments to cover the value but not the fee is valid.
+    // If that is the case, we modify the parameters accordingly.
+    if (maticAddress.hex(32) === ercAddress.hex(32)) {
+      const totalProvidedValue = providedValue + providedValueFee;
+      if (totalProvidedValue < value) {
+        maxNonFeeNullifiers =
+          providedValue >= value ? 0 : maxNonFeeNullifiers - validatedCommitments.length;
+        value = providedValue >= value ? 0n : value - providedValue;
+      }
+    }
+
+    // Update max nullifiers so that validatedCommitments spots are not used
+    maxNullifiers -= validatedCommitments.length;
+
+    // Mark the commitments as pendingNullification
+    await Promise.all(validatedCommitments.map(c => markPending(c)));
+
+    // Store this commitments inside spentCommitment so that if anything goes wrong we can clear the pending
+    // commitments
+    spentCommitments.push(...validatedCommitments);
+
+    logger.debug({ maxNullifiers, maxNonFeeNullifiers, feeValue });
+
+    // Use our commitment selection algorithm to select the commitments the user is gonna use for the transfer
+    // and the fee
     const commitments = await findUsableCommitmentsMutex(
       compressedZkpPublicKey,
       ercAddress,
@@ -122,23 +236,27 @@ export const getCommitmentInfo = async txInfo => {
     logger.debug({ commitments });
     const { oldCommitments, oldCommitmentsFee } = commitments;
 
+    // Add oldcommitments and oldCommitmentsFee to spentCommitments so that if anything goes wrong we can clear the pending
     spentCommitments.push(...oldCommitments);
     spentCommitments.push(...oldCommitmentsFee);
+
+    // Add providedCommitments to oldCommitments array
     oldCommitments.push(...validatedProvidedCommitments);
+    oldCommitmentsFee.push(...validatedProvidedCommitmentsFee);
 
     logger.debug({
-      msg: `Found commitments ${addedFee > 0n ? 'including fee' : ''}`,
-      oldCommitments: oldCommitments.map(c =>
-        JSON.stringify({ addr: c.preimage.ercAddress.hex(32), value: c.preimage.value.bigInt }),
-      ),
+      msg: `Commitments used ${addedFee > 0n ? 'including fee' : ''}`,
+      oldCommitments,
     });
 
-    if (feeValue > 0n) {
-      logger.debug({ msg: 'Found commitments fee', oldCommitmentsFee });
+    if (fee.bigInt - addedFee > 0n) {
+      logger.debug({ msg: 'Commitments used for the fee', oldCommitmentsFee });
     }
 
     // Compute the nullifiers
-    const nullifiers = spentCommitments.map(commitment => new Nullifier(commitment, nullifierKey));
+    const nullifiers = [...oldCommitments, ...oldCommitmentsFee].map(
+      commitment => new Nullifier(commitment, nullifierKey),
+    );
 
     // then the new output commitment(s)
     const totalInputCommitmentValue = oldCommitments.reduce(
@@ -166,7 +284,7 @@ export const getCommitmentInfo = async txInfo => {
     );
 
     // we may need to return change to the recipient
-    const changeFee = totalInputCommitmentFeeValue - feeValue;
+    const changeFee = totalInputCommitmentFeeValue - (fee.bigInt - addedFee);
 
     logger.debug({ totalInputCommitmentFeeValue, changeFee });
 
@@ -194,7 +312,9 @@ export const getCommitmentInfo = async txInfo => {
     );
 
     // Commitment Tree Information
-    const commitmentTreeInfo = await Promise.all(spentCommitments.map(c => getSiblingInfo(c)));
+    const commitmentTreeInfo = await Promise.all(
+      [...oldCommitments, ...oldCommitmentsFee].map(c => getSiblingInfo(c)),
+    );
     const localSiblingPaths = commitmentTreeInfo.map(l => {
       const path = l.siblingPath.path.map(p => p.value);
       return generalise([l.root].concat(path.reverse()));
@@ -210,7 +330,7 @@ export const getCommitmentInfo = async txInfo => {
     });
 
     return {
-      oldCommitments: spentCommitments,
+      oldCommitments: [...oldCommitments, ...oldCommitmentsFee],
       nullifiers,
       newCommitments,
       localSiblingPaths,

--- a/test/adversary/adversary-code/commitment-storage.mjs
+++ b/test/adversary/adversary-code/commitment-storage.mjs
@@ -11,26 +11,31 @@ export async function getCommitmentsByHashFaulty(
 ) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(COMMITMENTS_DB);
-  const commitment = await db
-    .collection(COMMITMENTS_COLLECTION)
-    .find({
-      _id: { $in: hashes },
-      compressedZkpPublicKey: compressedZkpPublicKey.hex(32),
-      'preimage.ercAddress': generalise(ercAddress).hex(32),
-      'preimage.tokenId': generalise(tokenId).hex(32),
-    })
-    .toArray();
-  return commitment;
+  const query = {
+    _id: { $in: hashes },
+    compressedZkpPublicKey: compressedZkpPublicKey.hex(32),
+  };
+  return db.collection(COMMITMENTS_COLLECTION).find(query).toArray();
 }
 
 async function getAvailableCommitmentsFaulty(db, compressedZkpPublicKey, ercAddress, tokenId) {
   return db
     .collection(COMMITMENTS_COLLECTION)
     .find({
-      compressedZkpPublicKey: compressedZkpPublicKey.hex(32),
-      'preimage.ercAddress': ercAddress.hex(32),
-      'preimage.tokenId': tokenId.hex(32),
-      $or: [{ isNullified: true }, { isPendingNullification: true }],
+      $or: [
+        {
+          compressedZkpPublicKey: compressedZkpPublicKey.hex(32),
+          'preimage.ercAddress': ercAddress.hex(32),
+          'preimage.tokenId': tokenId.hex(32),
+          isPendingNullification: true,
+        },
+        {
+          compressedZkpPublicKey: compressedZkpPublicKey.hex(32),
+          'preimage.ercAddress': ercAddress.hex(32),
+          'preimage.tokenId': tokenId.hex(32),
+          isNullified: true,
+        },
+      ],
     })
     .toArray();
 }

--- a/test/adversary/adversary-code/commitment-storage.mjs
+++ b/test/adversary/adversary-code/commitment-storage.mjs
@@ -3,12 +3,7 @@
 /* eslint-disable no-undef */
 
 // ignore unused exports
-export async function getCommitmentsByHashFaulty(
-  hashes,
-  compressedZkpPublicKey,
-  ercAddress,
-  tokenId,
-) {
+export async function getCommitmentsByHashFaulty(hashes, compressedZkpPublicKey) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(COMMITMENTS_DB);
   const query = {
@@ -22,20 +17,10 @@ async function getAvailableCommitmentsFaulty(db, compressedZkpPublicKey, ercAddr
   return db
     .collection(COMMITMENTS_COLLECTION)
     .find({
-      $or: [
-        {
-          compressedZkpPublicKey: compressedZkpPublicKey.hex(32),
-          'preimage.ercAddress': ercAddress.hex(32),
-          'preimage.tokenId': tokenId.hex(32),
-          isPendingNullification: true,
-        },
-        {
-          compressedZkpPublicKey: compressedZkpPublicKey.hex(32),
-          'preimage.ercAddress': ercAddress.hex(32),
-          'preimage.tokenId': tokenId.hex(32),
-          isNullified: true,
-        },
-      ],
+      compressedZkpPublicKey: compressedZkpPublicKey.hex(32),
+      'preimage.ercAddress': ercAddress.hex(32),
+      'preimage.tokenId': tokenId.hex(32),
+      isNullifiedOnChain: { $ne: -1 },
     })
     .toArray();
 }

--- a/test/adversary/transpile-client-adversary.mjs
+++ b/test/adversary/transpile-client-adversary.mjs
@@ -38,6 +38,10 @@ const transpileTransactionType = (_pathToSrc, _pathToInject) => {
   const reModifyGetCommitmentsCall = `providedCommitments, transactionType});`;
   srcFile = srcFile.replace(regexModifyGetCommitmentsCall, reModifyGetCommitmentsCall);
 
+  const regexModifyGetCommitmentsCall2 = /providedCommitmentsFee,(\s)*}\);/g;
+  const reModifyGetCommitmentsCall2 = `providedCommitmentsFee, transactionType});`;
+  srcFile = srcFile.replace(regexModifyGetCommitmentsCall2, reModifyGetCommitmentsCall2);
+
   // Add incorrectTransactions file
   const srcPreamble = /(\n|.)*(?=const rawTransaction)/g;
   const srcPostamble = /const rawTransaction(\n|.)*/g;

--- a/test/e2e/tokens/erc1155.test.mjs
+++ b/test/e2e/tokens/erc1155.test.mjs
@@ -4,10 +4,15 @@ import chai from 'chai';
 import chaiHttp from 'chai-http';
 import chaiAsPromised from 'chai-as-promised';
 import config from 'config';
-import { generalise } from 'general-number';
+import gen from 'general-number';
 import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
 import Nf3 from '../../../cli/lib/nf3.mjs';
-import { emptyL2, expectTransaction, Web3Client } from '../../utils.mjs';
+import {
+  expectTransaction,
+  Web3Client,
+  getLayer2Balances,
+  getUserCommitments,
+} from '../../utils.mjs';
 import { getERCInfo } from '../../../cli/lib/tokens.mjs';
 
 // so we can use require with mjs file
@@ -17,6 +22,8 @@ chai.use(chaiAsPromised);
 
 const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
 
+const { generalise } = gen;
+
 const {
   fee,
   transferValue,
@@ -25,27 +32,45 @@ const {
   signingKeys,
 } = config.TEST_OPTIONS;
 
-const nf3Users = [new Nf3(signingKeys.user1, environment), new Nf3(signingKeys.user2, environment)];
-const nf3Proposer1 = new Nf3(signingKeys.proposer1, environment);
-
 const web3Client = new Web3Client();
-
-let erc1155Address;
-// why do we need an ERC20 token in an ERC1155 test, you ask?
-// let me tell you I also don't know, but I guess we just want to fill some blocks?
-let erc20Address;
-let stateAddress;
+const web3 = web3Client.getWeb3();
 const eventLogs = [];
-let availableTokenIds;
 let rollbackCount = 0;
 
+const nf3User = new Nf3(signingKeys.user1, environment);
+const nf3User2 = new Nf3(signingKeys.user2, environment);
+const nf3Proposer = new Nf3(signingKeys.proposer1, environment);
+
+let _tokenId;
+
+let erc1155Address;
+async function getLayer2Erc1155Balance(_nf3User) {
+  return (
+    (await _nf3User.getLayer2Balances())[erc1155Address]?.find(
+      e => e.tokenId === generalise(_tokenId).hex(32),
+    )?.balance || 0
+  );
+}
+
+async function makeBlock() {
+  await nf3Proposer.makeBlockNow();
+  await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+}
+
 describe('ERC1155 tests', () => {
+  let erc20Address;
+  let stateAddress;
+  let availableTokenIds;
+
   before(async () => {
-    await nf3Proposer1.init(mnemonics.proposer);
-    await nf3Proposer1.registerProposer('http://optimist', await nf3Proposer1.getMinimumStake());
+    await nf3User.init(mnemonics.user1);
+    await nf3User2.init(mnemonics.user2);
+
+    await nf3Proposer.init(mnemonics.proposer);
+    await nf3Proposer.registerProposer('http://optimist', await nf3Proposer.getMinimumStake());
 
     // Proposer listening for incoming events
-    const newGasBlockEmitter = await nf3Proposer1.startProposer();
+    const newGasBlockEmitter = await nf3Proposer.startProposer();
     newGasBlockEmitter.on('rollback', () => {
       rollbackCount += 1;
       logger.debug(
@@ -53,225 +78,321 @@ describe('ERC1155 tests', () => {
       );
     });
 
-    await nf3Users[0].init(mnemonics.user1);
-    await nf3Users[1].init(mnemonics.user2);
-    erc20Address = await nf3Users[0].getContractAddress('ERC20Mock');
-    erc1155Address = await nf3Users[0].getContractAddress('ERC1155Mock');
-
-    stateAddress = await nf3Users[0].stateContractAddress;
+    erc20Address = await nf3User.getContractAddress('ERC20Mock');
+    erc1155Address = await nf3User.getContractAddress('ERC1155Mock');
+    stateAddress = await nf3User.stateContractAddress;
     web3Client.subscribeTo('logs', eventLogs, { address: stateAddress });
 
-    const availableTokens = (
-      await getERCInfo(erc1155Address, nf3Users[0].ethereumAddress, web3Client.getWeb3(), {
+    availableTokenIds = (
+      await getERCInfo(erc1155Address, nf3User.ethereumAddress, web3, {
         details: true,
       })
-    ).details;
+    ).details.map(t => t.tokenId);
 
-    availableTokenIds = availableTokens.map(t => t.tokenId);
+    // eslint-disable-next-line prefer-destructuring
+    _tokenId = availableTokenIds[1];
 
-    await nf3Users[0].deposit(erc20Address, tokenType, transferValue, tokenId, 0);
+    await nf3User.deposit(erc20Address, tokenType, 10 * transferValue, tokenId, 0);
 
-    await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
+    await makeBlock();
+
+    await nf3User.deposit(erc1155Address, tokenTypeERC1155, 50 * transferValue, _tokenId, fee);
+
+    await makeBlock();
   });
 
-  describe('Deposit', () => {
-    it('should deposit some ERC1155 crypto into a ZKP commitment', async function () {
-      const tokenToDeposit = availableTokenIds.shift();
-
-      const beforeBalance =
-        (await nf3Users[0].getLayer2Balances())[erc1155Address]?.find(
-          e => e.tokenId === generalise(tokenToDeposit).hex(32),
-        )?.balance || 0;
-
-      const balanceL2FeeTokenBefore =
-        (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
-      // We create enough transactions to fill blocks full of deposits.
-      const res = await nf3Users[0].deposit(
+  describe('Deposits', () => {
+    it('Should increment user L2 balance after depositing some ERC1155', async function () {
+      const userL2Erc1155BeforeBalance = await getLayer2Erc1155Balance(nf3User);
+      const userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
+      const res = await nf3User.deposit(
         erc1155Address,
         tokenTypeERC1155,
         transferValue,
-        tokenToDeposit,
+        _tokenId,
         fee,
       );
       expectTransaction(res);
+      logger.debug(`Gas used was ${Number(res.gasUsed)}`);
+      await makeBlock();
 
-      await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
+      const userL2Erc1155BeforeAfter = await getLayer2Erc1155Balance(nf3User);
+      const userL2FeesBalanceAfter = await getLayer2Balances(nf3User, erc20Address);
 
-      const afterBalance =
-        (await nf3Users[0].getLayer2Balances())[erc1155Address]?.find(
-          e => e.tokenId === generalise(tokenToDeposit).hex(32),
-        )?.balance || 0;
-
-      const balanceL2FeeTokenAfter =
-        (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
-
-      expect(afterBalance - beforeBalance).to.be.equal(transferValue);
-      expect(balanceL2FeeTokenAfter - balanceL2FeeTokenBefore).to.be.equal(-fee);
+      expect(userL2Erc1155BeforeAfter - userL2Erc1155BeforeBalance).to.be.equal(transferValue);
+      expect(userL2FeesBalanceAfter - userL2FeesBalanceBefore).to.be.equal(-fee);
     });
   });
 
   describe('Transfer', () => {
-    it('should decrement the balance after transfer ERC1155 to other wallet and increment the other wallet', async function () {
-      const tokenToTransfer = availableTokenIds.shift();
+    it('Should decrement user L2 balance after transferring some ERC721 to other wallet, and increment the other wallet balance', async function () {
+      const userL2Erc1155BeforeBalance = await getLayer2Erc1155Balance(nf3User);
+      const user2L2Erc1155BeforeBalance = await getLayer2Erc1155Balance(nf3User2);
+      const userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
 
-      async function getBalances() {
-        return Promise.all([
-          (await nf3Users[0].getLayer2Balances())[erc1155Address]?.find(
-            e => e.tokenId === generalise(tokenToTransfer).hex(32),
-          )?.balance || 0,
-          (await nf3Users[1].getLayer2Balances())[erc1155Address]?.find(
-            e => e.tokenId === generalise(tokenToTransfer).hex(32),
-          )?.balance || 0,
-          (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0,
-        ]);
-      }
-
-      await nf3Users[0].deposit(
-        erc1155Address,
-        tokenTypeERC1155,
-        transferValue,
-        tokenToTransfer,
-        fee,
-      );
-
-      await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
-
-      const beforeBalances = await getBalances();
-
-      const res = await nf3Users[0].transfer(
+      const res = await nf3User.transfer(
         false,
         erc1155Address,
         tokenTypeERC1155,
         transferValue,
-        tokenToTransfer,
-        nf3Users[1].zkpKeys.compressedZkpPublicKey,
+        _tokenId,
+        nf3User2.zkpKeys.compressedZkpPublicKey,
         fee,
       );
       expectTransaction(res);
+      logger.debug(`Gas used was ${Number(res.gasUsed)}`);
+      await makeBlock();
 
-      await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
+      const userL2Erc1155BeforeAfter = await getLayer2Erc1155Balance(nf3User);
+      const user2L2Erc1155BeforeAfter = await getLayer2Erc1155Balance(nf3User2);
+      const userL2FeesBalanceAfter = await getLayer2Balances(nf3User, erc20Address);
 
-      const afterBalances = await getBalances();
-
-      expect(afterBalances[0] - beforeBalances[0]).to.be.equal(-transferValue);
-      expect(afterBalances[1] - beforeBalances[1]).to.be.equal(transferValue);
-      expect(afterBalances[2] - beforeBalances[2]).to.be.equal(-fee);
+      // Assertions user
+      expect(userL2Erc1155BeforeAfter - userL2Erc1155BeforeBalance).to.be.equal(-transferValue);
+      expect(userL2FeesBalanceAfter - userL2FeesBalanceBefore).to.be.equal(-fee);
+      // user 2
+      expect(user2L2Erc1155BeforeAfter - user2L2Erc1155BeforeBalance).to.be.equal(transferValue);
     });
-  });
 
-  describe('Withdraw', () => {
-    it('should withdraw from L2, checking for missing commitment', async function () {
-      const tokenToWithdraw = availableTokenIds.shift();
+    it('should perform a transfer by specifying the commitment that provides enough value to cover value + fee', async function () {
+      const userL2Erc1155BeforeBalance = await getLayer2Erc1155Balance(nf3User);
+      const user2L2Erc1155BeforeBalance = await getLayer2Erc1155Balance(nf3User2);
+      const userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
 
-      await nf3Users[0].deposit(
-        erc1155Address,
-        tokenTypeERC1155,
-        transferValue,
-        tokenToWithdraw,
-        fee,
+      const userCommitments = await getUserCommitments(
+        environment.clientApiUrl,
+        nf3User.zkpKeys.compressedZkpPublicKey,
       );
 
-      await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
+      const erc20Commitments = userCommitments
+        .filter(c => c.ercAddress === generalise(erc20Address).hex(32))
+        .filter(c => c.value >= generalise(fee).hex(32));
 
-      const beforeBalanceERC1155 = (await nf3Users[0].getLayer2Balances())[erc1155Address].find(
-        e => e.tokenId === generalise(tokenToWithdraw).hex(32),
-      ).balance;
-      const beforeBalanceERC20 =
-        (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
+      const erc1155Commitments = userCommitments.filter(
+        c =>
+          c.ercAddress === generalise(erc1155Address).hex(32) &&
+          c.tokenId === generalise(_tokenId).hex(32),
+      );
 
-      const rec = await nf3Users[0].withdraw(
+      const res = await nf3User.transfer(
         false,
         erc1155Address,
         tokenTypeERC1155,
         transferValue,
-        tokenToWithdraw,
-        nf3Users[0].ethereumAddress,
+        _tokenId,
+        nf3User2.zkpKeys.compressedZkpPublicKey,
         fee,
+        [erc1155Commitments[0].commitmentHash],
+        [erc20Commitments[0].commitmentHash],
       );
+      expectTransaction(res);
+      logger.debug(`Gas used was ${Number(res.gasUsed)}`);
+      await makeBlock();
 
-      await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
+      const userL2Erc1155BeforeAfter = await getLayer2Erc1155Balance(nf3User);
+      const user2L2Erc1155BeforeAfter = await getLayer2Erc1155Balance(nf3User2);
+      const userL2FeesBalanceAfter = await getLayer2Balances(nf3User, erc20Address);
 
-      expectTransaction(rec);
-      logger.debug(`Gas used was ${Number(rec.gasUsed)}`);
-
-      const afterBalanceERC1155 =
-        (await nf3Users[0].getLayer2Balances())[erc1155Address]?.find(
-          e => e.tokenId === generalise(tokenToWithdraw).hex(32),
-        )?.balance || 0;
-
-      const afterBalanceERC20 =
-        (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
-
-      expect(afterBalanceERC1155 - beforeBalanceERC1155).to.be.equal(-transferValue);
-      expect(afterBalanceERC20 - beforeBalanceERC20).to.be.equal(-fee);
+      // Assertions user
+      expect(userL2Erc1155BeforeAfter - userL2Erc1155BeforeBalance).to.be.equal(-transferValue);
+      expect(userL2FeesBalanceAfter - userL2FeesBalanceBefore).to.be.equal(-fee);
+      // user 2
+      expect(user2L2Erc1155BeforeAfter - user2L2Erc1155BeforeBalance).to.be.equal(transferValue);
     });
 
-    it('should withdraw from L2, checking for L1 balance (only with time-jump client)', async function () {
-      const nodeInfo = await web3Client.getInfo();
-      if (nodeInfo.includes('TestRPC')) {
-        const tokenToWithdraw = availableTokenIds.shift();
+    it('should perform a transfer by specifying the commitment that provides enough value to cover value', async function () {
+      const userL2Erc1155BeforeBalance = await getLayer2Erc1155Balance(nf3User);
+      const user2L2Erc1155BeforeBalance = await getLayer2Erc1155Balance(nf3User2);
+      const userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
 
-        await nf3Users[0].deposit(
+      const userCommitments = await getUserCommitments(
+        environment.clientApiUrl,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+      );
+
+      const erc1155Commitments = userCommitments.filter(
+        c =>
+          c.ercAddress === generalise(erc1155Address).hex(32) &&
+          c.tokenId === generalise(_tokenId).hex(32),
+      );
+
+      const res = await nf3User.transfer(
+        false,
+        erc1155Address,
+        tokenTypeERC1155,
+        transferValue,
+        _tokenId,
+        nf3User2.zkpKeys.compressedZkpPublicKey,
+        fee,
+        [erc1155Commitments[0].commitmentHash],
+        [],
+      );
+      expectTransaction(res);
+      logger.debug(`Gas used was ${Number(res.gasUsed)}`);
+      await makeBlock();
+
+      const userL2Erc1155BeforeAfter = await getLayer2Erc1155Balance(nf3User);
+      const user2L2Erc1155BeforeAfter = await getLayer2Erc1155Balance(nf3User2);
+      const userL2FeesBalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+
+      // Assertions user
+      expect(userL2Erc1155BeforeAfter - userL2Erc1155BeforeBalance).to.be.equal(-transferValue);
+      expect(userL2FeesBalanceAfter - userL2FeesBalanceBefore).to.be.equal(-fee);
+      // user 2
+      expect(user2L2Erc1155BeforeAfter - user2L2Erc1155BeforeBalance).to.be.equal(transferValue);
+    });
+
+    it('should perform a transfer by specifying the commitment that provides enough value to fee', async function () {
+      const userL2Erc1155BeforeBalance = await getLayer2Erc1155Balance(nf3User);
+      const user2L2Erc1155BeforeBalance = await getLayer2Erc1155Balance(nf3User2);
+      const userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
+
+      const userCommitments = await getUserCommitments(
+        environment.clientApiUrl,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+      );
+
+      const erc20Commitments = userCommitments
+        .filter(c => c.ercAddress === generalise(erc20Address).hex(32))
+        .filter(c => c.value >= generalise(fee).hex(32));
+
+      const res = await nf3User.transfer(
+        false,
+        erc1155Address,
+        tokenTypeERC1155,
+        transferValue,
+        _tokenId,
+        nf3User2.zkpKeys.compressedZkpPublicKey,
+        fee,
+        [],
+        [erc20Commitments[0].commitmentHash],
+      );
+      expectTransaction(res);
+      logger.debug(`Gas used was ${Number(res.gasUsed)}`);
+      await makeBlock();
+
+      const userL2Erc1155BeforeAfter = await getLayer2Erc1155Balance(nf3User);
+      const user2L2Erc1155BeforeAfter = await getLayer2Erc1155Balance(nf3User2);
+      const userL2FeesBalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+
+      // Assertions user
+      expect(userL2Erc1155BeforeAfter - userL2Erc1155BeforeBalance).to.be.equal(-transferValue);
+      expect(userL2FeesBalanceAfter - userL2FeesBalanceBefore).to.be.equal(-fee);
+      // user 2
+      expect(user2L2Erc1155BeforeAfter - user2L2Erc1155BeforeBalance).to.be.equal(transferValue);
+    });
+
+    it('should fail to perform a transfer if user specifies commitments for the value but it does not cover the whole value', async function () {
+      const userCommitments = await getUserCommitments(
+        environment.clientApiUrl,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+      );
+
+      const erc1155Commitments = userCommitments.filter(
+        c =>
+          c.ercAddress === generalise(erc1155Address).hex(32) &&
+          c.tokenId === generalise(_tokenId).hex(32),
+      );
+
+      try {
+        await nf3User.transfer(
+          false,
           erc1155Address,
           tokenTypeERC1155,
-          transferValue,
-          tokenToWithdraw,
+          Number(generalise(erc1155Commitments[0].value).bigInt + 1n),
+          _tokenId,
+          nf3User2.zkpKeys.compressedZkpPublicKey,
           fee,
+          [erc1155Commitments[0].commitmentHash],
+          [],
         );
+      } catch (err) {
+        expect(err.message).to.be.equal('provided commitments do not cover the value');
+      }
+    });
 
-        await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
+    it('should fail to perform a transfer if user specifies commitments for the fee but it does not cover the whole value', async function () {
+      const userCommitments = await getUserCommitments(
+        environment.clientApiUrl,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+      );
 
-        const beforeBalanceERC1155 =
-          (await nf3Users[0].getLayer2Balances())[erc1155Address]?.find(
-            e => e.tokenId === generalise(tokenToWithdraw).hex(32),
-          )?.balance || 0;
+      const erc20Commitments = userCommitments
+        .filter(c => c.ercAddress === generalise(erc20Address).hex(32))
+        .filter(c => c.value >= generalise(fee).hex(32));
 
-        const beforeBalanceERC20 =
-          (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
-
-        const rec = await nf3Users[0].withdraw(
+      try {
+        await nf3User.transfer(
           false,
           erc1155Address,
           tokenTypeERC1155,
           transferValue,
-          tokenToWithdraw,
-          nf3Users[0].ethereumAddress,
-          fee,
+          availableTokenIds[1],
+          nf3User2.zkpKeys.compressedZkpPublicKey,
+          Number(generalise(erc20Commitments[0].value).bigInt + 1n),
+          [],
+          [erc20Commitments[0].commitmentHash],
         );
-        expectTransaction(rec);
-        await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
+      } catch (err) {
+        expect(err.message).to.be.equal('provided commitments do not cover the fee');
+      }
+    });
+  });
 
-        const withdrawal = nf3Users[0].getLatestWithdrawHash();
+  describe('Withdrawals', () => {
+    let userL2Erc1155BeforeBalance;
+    let userL2FeesBalanceBefore;
+    let withdrawalTx;
+    let withdrawalTxHash;
 
-        await web3Client.timeJump(3600 * 24 * 10); // jump in time by 10 days
+    before(async function () {
+      _tokenId = availableTokenIds.shift();
+      await nf3User.deposit(erc1155Address, tokenTypeERC1155, transferValue, _tokenId, fee);
+      await makeBlock();
 
-        const commitments = await nf3Users[0].getPendingWithdraws();
+      userL2Erc1155BeforeBalance = await getLayer2Erc1155Balance(nf3User, _tokenId);
+      userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
+      withdrawalTx = await nf3User.withdraw(
+        false,
+        erc1155Address,
+        tokenTypeERC1155,
+        transferValue,
+        _tokenId,
+        nf3User.ethereumAddress,
+        fee,
+      );
+      withdrawalTxHash = nf3User.getLatestWithdrawHash();
+    });
 
-        expect(
-          commitments[nf3Users[0].zkpKeys.compressedZkpPublicKey][erc1155Address].length,
-        ).to.be.greaterThan(0);
-        expect(
-          commitments[nf3Users[0].zkpKeys.compressedZkpPublicKey][erc1155Address].filter(
-            c => c.valid === true,
-          ).length,
-        ).to.be.greaterThan(0);
+    it('Should withdraw from L2', async function () {
+      expectTransaction(withdrawalTx);
+      logger.debug(`Gas used was ${Number(withdrawalTx.gasUsed)}`);
+      await makeBlock();
 
-        const res = await nf3Users[0].finaliseWithdrawal(withdrawal);
-        expectTransaction(res);
+      const userL2Erc1155BeforeAfter = await getLayer2Erc1155Balance(nf3User);
+      const userL2FeesBalanceAfter = await getLayer2Balances(nf3User, erc20Address);
 
-        const afterBalanceERC1155 =
-          (await nf3Users[0].getLayer2Balances())[erc1155Address]?.find(
-            e => e.tokenId === generalise(tokenToWithdraw).hex(32),
-          )?.balance || 0;
+      expect(userL2Erc1155BeforeAfter - userL2Erc1155BeforeBalance).to.be.equal(-transferValue);
+      expect(userL2FeesBalanceAfter - userL2FeesBalanceBefore).to.be.equal(-fee);
+    });
 
-        const afterBalanceERC20 =
-          (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
-        expect(afterBalanceERC1155 - beforeBalanceERC1155).to.be.equal(-transferValue);
-        expect(afterBalanceERC20 - beforeBalanceERC20).to.be.equal(-fee);
-      } else {
+    it('Should finalise previous withdrawal from L2 to L1 (only with time-jump client)', async function () {
+      const nodeInfo = await web3Client.getInfo();
+      if (!nodeInfo.includes('TestRPC')) {
         logger.info('Not using a time-jump capable test client so this test is skipped');
         this.skip();
       }
+
+      const userL1BalanceBefore = await web3Client.getBalance(nf3User.ethereumAddress);
+
+      await web3Client.timeJump(3600 * 24 * 10);
+      const res = await nf3User.finaliseWithdrawal(withdrawalTxHash);
+      expectTransaction(res);
+      logger.debug(`Gas used was ${Number(res.gasUsed)}`);
+
+      const userL1BalanceAfter = await web3Client.getBalance(nf3User.ethereumAddress);
+      // Final L1 balance to be lesser than initial balance because of fees
+      expect(parseInt(userL1BalanceAfter, 10)).to.be.lessThan(parseInt(userL1BalanceBefore, 10));
     });
   });
 
@@ -282,10 +403,10 @@ describe('ERC1155 tests', () => {
   });
 
   after(async () => {
-    await nf3Proposer1.deregisterProposer();
-    await nf3Proposer1.close();
-    await nf3Users[0].close();
-    await nf3Users[1].close();
-    await web3Client.closeWeb3();
+    await nf3Proposer.deregisterProposer();
+    await nf3Proposer.close();
+    await nf3User.close();
+    await nf3User2.close();
+    web3Client.closeWeb3();
   });
 });

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -1,5 +1,6 @@
 /* eslint-disable no-await-in-loop */
 import chai from 'chai';
+import gen from 'general-number';
 import chaiHttp from 'chai-http';
 import chaiAsPromised from 'chai-as-promised';
 import config from 'config';
@@ -7,20 +8,21 @@ import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
 import Nf3 from '../../../cli/lib/nf3.mjs';
 import {
   depositNTransactions,
+  getLayer2Balances,
   expectTransaction,
   waitForSufficientBalance,
   waitForSufficientTransactionsMempool,
   Web3Client,
+  getUserCommitments,
 } from '../../utils.mjs';
 import { approve } from '../../../cli/lib/tokens.mjs';
 
-// so we can use require with mjs file
 const { expect } = chai;
 chai.use(chaiHttp);
 chai.use(chaiAsPromised);
 
+const { generalise } = gen;
 const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
-
 const {
   fee,
   transferValue,
@@ -29,40 +31,42 @@ const {
   signingKeys,
   restrictions: { erc20default },
 } = config.TEST_OPTIONS;
-
 const {
   RESTRICTIONS: {
     tokens: { blockchain: maxWithdrawValue },
   },
 } = config;
 
-const nf3Users = [
-  new Nf3(signingKeys.user1, environment),
-  new Nf3(signingKeys.user2, environment),
-  new Nf3(signingKeys.sanctionedUser, environment),
-];
-const nf3Proposer = new Nf3(signingKeys.proposer1, environment);
-
 const web3Client = new Web3Client();
-
-let erc20Address;
-let stateAddress;
+const web3 = web3Client.getWeb3();
 const eventLogs = [];
 const logs = {
   instantWithdraw: 0,
 };
 let rollbackCount = 0;
 
-const waitForTxExecution = async (count, txType) => {
-  while (count === logs[txType]) {
-    await new Promise(resolve => setTimeout(resolve, 3000));
-  }
-};
+const nf3User = new Nf3(signingKeys.user1, environment);
+const nf3User2 = new Nf3(signingKeys.user2, environment);
+const nf3UserSanctioned = new Nf3(signingKeys.sanctionedUser, environment);
+
+const nf3Proposer = new Nf3(signingKeys.proposer1, environment);
+
+async function makeBlock() {
+  logger.debug(`Make block...`);
+  await nf3Proposer.makeBlockNow();
+  await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+}
 
 describe('ERC20 tests', () => {
+  let erc20Address;
+  let stateAddress;
+
   before(async () => {
+    await nf3User.init(mnemonics.user1);
+    await nf3User2.init(mnemonics.user2);
+    await nf3UserSanctioned.init(mnemonics.sanctionedUser);
+
     await nf3Proposer.init(mnemonics.proposer);
-    // we must set the URL from the point of view of the client container
     await nf3Proposer.registerProposer('http://optimist', await nf3Proposer.getMinimumStake());
 
     // Proposer listening for incoming events
@@ -74,241 +78,263 @@ describe('ERC20 tests', () => {
       );
     });
 
-    await nf3Users[0].init(mnemonics.user1);
-    await nf3Users[1].init(mnemonics.user2);
-    await nf3Users[2].init(mnemonics.sanctionedUser);
-    erc20Address = await nf3Users[0].getContractAddress('ERC20Mock');
-
-    stateAddress = await nf3Users[0].stateContractAddress;
+    erc20Address = await nf3User.getContractAddress('ERC20Mock');
+    stateAddress = await nf3User.stateContractAddress;
     web3Client.subscribeTo('logs', eventLogs, { address: stateAddress });
   });
 
-  beforeEach(async function () {
-    if (this.currentTest.title === 'test should encounter zero rollbacks') return;
-    await nf3Users[0].deposit(erc20Address, tokenType, transferValue * 2, tokenId, fee);
-    await nf3Users[0].makeBlockNow();
-    await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-  });
-
   describe('Deposits', () => {
-    it('should increment the balance after deposit some ERC20 crypto', async function () {
-      const currentZkpPublicKeyBalance =
-        (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
-      await nf3Users[0].deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+    it('Should increment user L2 balance after depositing some ERC20', async function () {
+      const userL2BalanceBefore = await getLayer2Balances(nf3User, erc20Address);
 
-      await nf3Users[0].makeBlockNow();
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      const res = await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+      expectTransaction(res);
+      logger.debug(`Gas used was ${Number(res.gasUsed)}`);
+      await makeBlock();
 
-      const afterZkpPublicKeyBalance =
-        (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
-      expect(afterZkpPublicKeyBalance - currentZkpPublicKeyBalance).to.be.equal(
-        transferValue - fee,
-      );
+      const userL2BalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+      expect(userL2BalanceAfter - userL2BalanceBefore).to.be.equal(transferValue - fee);
     });
-    it('should fail to deposit if the user is sanctioned', async function () {
+
+    it('Should fail to deposit if the user is sanctioned', async function () {
       try {
-        // user 2 is sanctioned
-        await nf3Users[2].deposit(erc20Address, tokenType, transferValue, tokenId, fee);
-        expect.fail('Transaction has not been reverted by the EVM');
+        await nf3UserSanctioned.deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+        expect.fail('Throw error, deposit did not fail');
       } catch (err) {
-        console.log(err);
-        expect(err.message).to.satisfy(message =>
-          message.includes('Transaction has been reverted by the EVM'),
-        );
+        expect(err.message).to.include('Transaction has been reverted by the EVM');
       }
-    });
-
-    it('should increment the balance after deposit some ERC20 crypto and pay fee in L2', async function () {
-      const currentZkpPublicKeyBalance =
-        (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
-      await nf3Users[0].deposit(erc20Address, tokenType, transferValue, tokenId, fee, true);
-
-      await nf3Users[0].makeBlockNow();
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-
-      const afterZkpPublicKeyBalance =
-        (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
-      expect(afterZkpPublicKeyBalance - currentZkpPublicKeyBalance).to.be.equal(
-        transferValue - fee,
-      );
     });
   });
 
   describe('Transfers', () => {
-    it('should decrement the balance after transfer ERC20 to other wallet and increment the other wallet', async function () {
-      async function getBalances() {
-        return Promise.all([
-          (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0,
-          (await nf3Users[1].getLayer2Balances())[erc20Address]?.[0].balance || 0,
-        ]);
-      }
-
-      const beforeBalances = await getBalances();
-
-      const res = await nf3Users[0].transfer(
-        false,
-        erc20Address,
-        tokenType,
-        transferValue,
-        tokenId,
-        nf3Users[1].zkpKeys.compressedZkpPublicKey,
-        fee,
-      );
-      expectTransaction(res);
-
-      await nf3Users[0].makeBlockNow();
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-
-      const afterBalances = await getBalances();
-
-      expect(afterBalances[0] - beforeBalances[0]).to.be.equal(-(transferValue + fee));
-      expect(afterBalances[1] - beforeBalances[1]).to.be.equal(transferValue);
+    beforeEach(async () => {
+      await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+      await makeBlock();
     });
 
-    it('should transfer some ERC20 crypto (back to us) using ZKP', async function () {
-      const before = (await nf3Users[0].getLayer2Balances())[erc20Address][0].balance;
+    it('Should decrement user L2 balance after transferring some ERC20 to other wallet, and increment the other wallet balance', async function () {
+      const userL2BalanceBefore = await getLayer2Balances(nf3User, erc20Address);
+      const user2L2BalanceBefore = await getLayer2Balances(nf3User2, erc20Address);
 
-      const res = await nf3Users[0].transfer(
+      const res = await nf3User.transfer(
         false,
         erc20Address,
         tokenType,
         transferValue,
         tokenId,
-        nf3Users[0].zkpKeys.compressedZkpPublicKey,
+        nf3User2.zkpKeys.compressedZkpPublicKey,
         fee,
       );
       expectTransaction(res);
-      await nf3Users[0].makeBlockNow();
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-
       logger.debug(`Gas used was ${Number(res.gasUsed)}`);
+      await makeBlock();
 
-      const after = (await nf3Users[0].getLayer2Balances())[erc20Address][0].balance;
-      expect(after - before).to.be.equal(-fee);
+      const userL2BalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+      const user2L2BalanceAfter = await getLayer2Balances(nf3User2, erc20Address);
+
+      expect(userL2BalanceAfter - userL2BalanceBefore).to.be.equal(-(transferValue + fee));
+      expect(user2L2BalanceAfter - user2L2BalanceBefore).to.be.equal(transferValue);
+    });
+
+    it('Should be able to self-transfer some ERC20, and final balance stay the same minus the fee', async function () {
+      const userL2BalanceBefore = await getLayer2Balances(nf3User, erc20Address);
+
+      const res = await nf3User.transfer(
+        false,
+        erc20Address,
+        tokenType,
+        transferValue,
+        tokenId,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+        fee,
+      );
+      expectTransaction(res);
+      logger.debug(`Gas used was ${Number(res.gasUsed)}`);
+      await makeBlock();
+
+      const userL2BalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+      expect(userL2BalanceAfter - userL2BalanceBefore).to.be.equal(-fee);
+    });
+
+    it('should perform a transfer by specifying the commitment that provides enough value to cover value + fee', async function () {
+      const userL2BalanceBefore = await getLayer2Balances(nf3User, erc20Address);
+
+      const userCommitments = await getUserCommitments(
+        environment.clientApiUrl,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+      );
+
+      const erc20Commitments = userCommitments
+        .filter(c => c.ercAddress === generalise(erc20Address).hex(32))
+        .sort((a, b) => Number(generalise(a.value).bigInt - generalise(b.value).bigInt));
+
+      const usedCommitments = [];
+      let totalValue = 0;
+      let i = 0;
+
+      while (totalValue < transferValue + fee && i < erc20Commitments.length) {
+        usedCommitments.push(erc20Commitments[i].commitmentHash);
+        totalValue += Number(generalise(erc20Commitments[i].value).bigInt);
+        ++i;
+      }
+
+      const res = await nf3User.transfer(
+        false,
+        erc20Address,
+        tokenType,
+        transferValue,
+        tokenId,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+        fee,
+        usedCommitments,
+      );
+      expectTransaction(res);
+      await makeBlock();
+
+      const userL2BalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+      expect(userL2BalanceAfter - userL2BalanceBefore).to.be.equal(-fee);
+    });
+
+    it('should perform a transfer by specifying the commitment that provides enough value to cover value', async function () {
+      const userL2BalanceBefore = await getLayer2Balances(nf3User, erc20Address);
+
+      const userCommitments = await getUserCommitments(
+        environment.clientApiUrl,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+      );
+
+      const erc20Commitments = userCommitments
+        .filter(c => c.ercAddress === generalise(erc20Address).hex(32))
+        .sort((a, b) => Number(generalise(a.value).bigInt - generalise(b.value).bigInt));
+
+      const usedCommitments = [];
+      let totalValue = 0;
+      let i = 0;
+
+      while (totalValue < transferValue && i < erc20Commitments.length) {
+        usedCommitments.push(erc20Commitments[i].commitmentHash);
+        totalValue += Number(generalise(erc20Commitments[i].value).bigInt);
+        ++i;
+      }
+
+      const res = await nf3User.transfer(
+        false,
+        erc20Address,
+        tokenType,
+        transferValue,
+        tokenId,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+        fee,
+        usedCommitments,
+      );
+      expectTransaction(res);
+      await makeBlock();
+
+      const userL2BalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+      expect(userL2BalanceAfter - userL2BalanceBefore).to.be.equal(-fee);
+    });
+
+    it('should perform a transfer by specifying the commitment that provides enough value to cover value + fee', async function () {
+      const userCommitments = await getUserCommitments(
+        environment.clientApiUrl,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+      );
+
+      const erc20Commitments = userCommitments
+        .filter(c => c.ercAddress === generalise(erc20Address).hex(32))
+        .sort((a, b) => Number(generalise(a.value).bigInt - generalise(b.value).bigInt));
+
+      const usedCommitments = [];
+      let totalValue = 0;
+      let i = 0;
+
+      while (totalValue < transferValue && i < erc20Commitments.length) {
+        usedCommitments.push(erc20Commitments[i].commitmentHash);
+        totalValue += Number(generalise(erc20Commitments[i].value).bigInt);
+        ++i;
+      }
+
+      try {
+        await nf3User.transfer(
+          false,
+          erc20Address,
+          tokenType,
+          totalValue + 1,
+          tokenId,
+          nf3User.zkpKeys.compressedZkpPublicKey,
+          fee,
+          usedCommitments,
+        );
+      } catch (err) {
+        expect(err.message).to.be.equal('provided commitments do not cover the value');
+      }
     });
   });
 
-  describe('Normal withdraws from L2', () => {
-    it('should withdraw from L2, checking for missing commitment', async function () {
-      const beforeBalance = (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance;
-      const rec = await nf3Users[0].withdraw(
+  describe('Withdrawals', () => {
+    let userL2BalanceBefore;
+    let withdrawalTx;
+    let withdrawalTxHash;
+
+    before(async function () {
+      await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+      await makeBlock();
+
+      userL2BalanceBefore = await getLayer2Balances(nf3User, erc20Address);
+      withdrawalTx = await nf3User.withdraw(
         false,
         erc20Address,
         tokenType,
         transferValue / 2,
         tokenId,
-        nf3Users[0].ethereumAddress,
+        nf3User.ethereumAddress,
         fee,
       );
-      expectTransaction(rec);
-
-      await nf3Users[0].makeBlockNow();
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-
-      logger.debug(`Gas used was ${Number(rec.gasUsed)}`);
-      const afterBalance = (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance;
-      expect(afterBalance - beforeBalance).to.be.equal(-(transferValue / 2 + fee));
+      withdrawalTxHash = nf3User.getLatestWithdrawHash();
     });
 
-    it('Should create a failing finalise-withdrawal (because insufficient time has passed)', async function () {
-      let error = null;
+    it('Should withdraw from L2', async function () {
+      expectTransaction(withdrawalTx);
+      logger.debug(`Gas used was ${Number(withdrawalTx.gasUsed)}`);
+      await makeBlock();
+
+      const userL2BalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+      expect(userL2BalanceAfter - userL2BalanceBefore).to.be.equal(-(transferValue / 2 + fee));
+    });
+
+    it('Should fail at finalising previous withdrawal because it is too soon', async function () {
       try {
-        const rec = await nf3Users[0].withdraw(
-          false,
-          erc20Address,
-          tokenType,
-          Math.floor(transferValue / 2),
-          tokenId,
-          nf3Users[0].ethereumAddress,
-          fee,
-        );
-        expectTransaction(rec);
-
-        await nf3Users[0].makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-
-        const withdrawal = await nf3Users[0].getLatestWithdrawHash();
-        const res = await nf3Users[0].finaliseWithdrawal(withdrawal);
-        expectTransaction(res);
+        await nf3User.finaliseWithdrawal(withdrawalTxHash);
+        expect.fail('Throw error, finalising withdrawal did not fail');
       } catch (err) {
-        error = err;
+        expect(err.message).to.include('Transaction has been reverted by the EVM');
       }
-      expect(error.message).to.satisfy(
-        message =>
-          message.includes(
-            'Returned error: VM Exception while processing transaction: revert It is too soon to withdraw funds from this block',
-          ) || message.includes('Transaction has been reverted by the EVM'),
-      );
     });
 
-    it('should withdraw from L2, checking for L1 balance (only with time-jump client)', async function () {
+    it('Should finalise previous withdrawal from L2 to L1 (only with time-jump client)', async function () {
       const nodeInfo = await web3Client.getInfo();
-      if (nodeInfo.includes('TestRPC')) {
-        const startBalance = await web3Client.getBalance(nf3Users[0].ethereumAddress);
-
-        const rec = await nf3Users[0].withdraw(
-          false,
-          erc20Address,
-          tokenType,
-          Math.floor(transferValue / 2),
-          tokenId,
-          nf3Users[0].ethereumAddress,
-          fee,
-        );
-        expectTransaction(rec);
-
-        await nf3Users[0].makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-
-        const withdrawal = await nf3Users[0].getLatestWithdrawHash();
-
-        await web3Client.timeJump(3600 * 24 * 10); // jump in time by 10 days
-
-        const commitments = await nf3Users[0].getPendingWithdraws();
-        expect(
-          commitments[nf3Users[0].zkpKeys.compressedZkpPublicKey][erc20Address].length,
-        ).to.be.greaterThan(0);
-        expect(
-          commitments[nf3Users[0].zkpKeys.compressedZkpPublicKey][erc20Address].filter(
-            c => c.valid === true,
-          ).length,
-        ).to.be.greaterThan(0);
-
-        const res = await nf3Users[0].finaliseWithdrawal(withdrawal);
-        expectTransaction(res);
-
-        const endBalance = await web3Client.getBalance(nf3Users[0].ethereumAddress);
-        expect(parseInt(endBalance, 10)).to.be.lessThan(parseInt(startBalance, 10));
-      } else {
+      if (!nodeInfo.includes('TestRPC')) {
         logger.info('Not using a time-jump capable test client so this test is skipped');
         this.skip();
       }
-    });
 
-    it('should withdraw from L2 with some change', async function () {
-      const beforeBalance = (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance;
-      const rec = await nf3Users[0].withdraw(
-        false,
-        erc20Address,
-        tokenType,
-        Math.floor(transferValue / 2),
-        tokenId,
-        nf3Users[0].ethereumAddress,
-        fee,
-      );
-      expectTransaction(rec);
+      const userL1BalanceBefore = await web3Client.getBalance(nf3User.ethereumAddress);
 
-      await nf3Users[0].makeBlockNow();
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await web3Client.timeJump(3600 * 24 * 10);
+      const res = await nf3User.finaliseWithdrawal(withdrawalTxHash);
+      expectTransaction(res);
+      logger.debug(`Gas used was ${Number(res.gasUsed)}`);
 
-      logger.debug(`Gas used was ${Number(rec.gasUsed)}`);
-      const afterBalance = (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance;
-      expect(afterBalance - beforeBalance).to.be.equal(-(Math.floor(transferValue / 2) + fee));
+      const userL1BalanceAfter = await web3Client.getBalance(nf3User.ethereumAddress);
+      // Final L1 balance to be lesser than initial balance because of fees
+      expect(parseInt(userL1BalanceAfter, 10)).to.be.lessThan(parseInt(userL1BalanceBefore, 10));
     });
   });
 
-  describe('Instant withdrawals from L2', () => {
+  describe('Instant withdrawals', () => {
     const nf3LiquidityProvider = new Nf3(signingKeys.liquidityProvider, environment);
+    let withdrawalTxHash;
+
     before(async () => {
       await nf3LiquidityProvider.init(mnemonics.liquidityProvider);
 
@@ -318,21 +344,35 @@ describe('ERC20 tests', () => {
         nf3LiquidityProvider.shieldContractAddress,
         tokenType,
         Math.floor(transferValue / 2),
-        web3Client.getWeb3(),
+        web3,
         !!nf3LiquidityProvider.ethereumSigningKey,
       );
       if (txDataToSign) {
         await nf3LiquidityProvider.submitTransaction(txDataToSign, erc20Address, 0);
       }
 
+      await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+      await makeBlock();
+
+      await nf3User.withdraw(
+        false,
+        erc20Address,
+        tokenType,
+        Math.floor(transferValue / 2),
+        tokenId,
+        nf3User.ethereumAddress,
+        fee,
+      );
+      withdrawalTxHash = nf3User.getLatestWithdrawHash();
+
       // Liquidity provider for instant withdraws
-      const emitter = await nf3Users[0].getInstantWithdrawalRequestedEmitter();
+      const emitter = await nf3User.getInstantWithdrawalRequestedEmitter();
       emitter.on('data', async withdrawTransactionHash => {
         // approve tokens to be advanced by liquidity provider in the instant withdraw
         try {
           await nf3LiquidityProvider.advanceInstantWithdrawal(withdrawTransactionHash);
         } catch (e) {
-          console.log('ERROR Liquidity Provider: ', e);
+          console.log('ERROR Liquidity Provider');
         }
 
         logs.instantWithdraw += 1;
@@ -341,58 +381,23 @@ describe('ERC20 tests', () => {
       web3Client.subscribeTo('logs', eventLogs, { address: stateAddress });
     });
 
-    it('should allow instant withdraw of existing withdraw', async function () {
-      const startBalance = await web3Client.getBalance(nf3Users[0].ethereumAddress);
+    it('Should not allow instant withdrawal because withdrawal is not in block yet', async function () {
+      const res = await nf3User.requestInstantWithdrawal(withdrawalTxHash, fee);
+      expect(res).to.be.equal(null);
+    });
 
-      await nf3Users[0].withdraw(
-        false,
-        erc20Address,
-        tokenType,
-        Math.floor(transferValue / 2),
-        tokenId,
-        nf3Users[0].ethereumAddress,
-        fee,
-      );
+    it('Should allow instant withdraw of existing withdraw', async function () {
+      const userL1BalanceBefore = await web3Client.getBalance(nf3User.ethereumAddress);
 
-      await nf3Users[0].makeBlockNow();
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await makeBlock();
 
-      const latestWithdrawTransactionHash = nf3Users[0].getLatestWithdrawHash();
-      expect(latestWithdrawTransactionHash).to.be.a('string').and.to.include('0x');
-
-      const count = logs.instantWithdraw;
-
-      await nf3Users[0].makeBlockNow();
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-
-      // We request the instant withdraw and should wait for the liquidity provider to send the instant withdraw
-      const res = await nf3Users[0].requestInstantWithdrawal(latestWithdrawTransactionHash, fee);
-
+      const res = await nf3User.requestInstantWithdrawal(withdrawalTxHash, fee);
       expectTransaction(res);
       logger.debug(`Gas used was ${Number(res.gasUsed)}`);
 
-      await waitForTxExecution(count, 'instantWithdraw');
-
-      const endBalance = await web3Client.getBalance(nf3Users[0].ethereumAddress);
-
-      expect(parseInt(endBalance, 10)).to.be.lessThan(parseInt(startBalance, 10));
-    });
-
-    it('should not allow instant withdraw of non existing withdraw or not in block yet', async function () {
-      await nf3Users[0].withdraw(
-        false,
-        erc20Address,
-        tokenType,
-        Math.floor(transferValue / 2),
-        tokenId,
-        nf3Users[0].ethereumAddress,
-        fee,
-      );
-      const latestWithdrawTransactionHash = nf3Users[0].getLatestWithdrawHash();
-      expect(latestWithdrawTransactionHash).to.be.a('string').and.to.include('0x');
-
-      const res = await nf3Users[0].requestInstantWithdrawal(latestWithdrawTransactionHash, fee);
-      expect(res).to.be.equal(null);
+      const userL1BalanceAfter = await web3Client.getBalance(nf3User.ethereumAddress);
+      // Final L1 balance to be lesser than initial balance because of fees
+      expect(parseInt(userL1BalanceAfter, 10)).to.be.lessThan(parseInt(userL1BalanceBefore, 10));
     });
 
     after(async () => {
@@ -404,128 +409,117 @@ describe('ERC20 tests', () => {
     What is this, you wonder? We're just testing restrictions, since for an initial release phase
     we want to restrict the amount of deposits/withdraws. Take a look at #516 if you want to know more
     */
-  describe('Testing deposit and withdraw restrictions', () => {
-    let maxERC20WithdrawValue;
-    let maxERC20DepositValue;
+  describe('Deposit and withdrawal restrictions', () => {
+    const maxERC20WithdrawValue =
+      maxWithdrawValue.find(e => e.address.toLowerCase() === erc20Address)?.amount || erc20default;
+    console.log('************************maxERC20WithdrawValue', maxERC20WithdrawValue);
+    const maxERC20DepositValue = Math.floor(maxERC20WithdrawValue / 4);
+    console.log('************************maxERC20DepositValue', maxERC20DepositValue);
 
-    before(() => {
-      web3Client.subscribeTo('logs', eventLogs, { address: stateAddress });
-
-      maxERC20WithdrawValue =
-        maxWithdrawValue.find(e => e.address.toLowerCase() === erc20Address)?.amount ||
-        erc20default;
-      maxERC20DepositValue = Math.floor(maxERC20WithdrawValue / 4);
-    });
-
-    it('should restrict deposits', async () => {
-      // anything equal or above the restricted amount should fail
+    it('Should restrict deposits', async () => {
+      // Anything equal or above the restricted amount should fail
       try {
-        await nf3Users[0].deposit(erc20Address, tokenType, maxERC20DepositValue + 1, tokenId, fee);
-        expect.fail('Transaction has not been reverted by the EVM');
-      } catch (error) {
-        expect(error.message).to.satisfy(message =>
-          message.includes('Transaction has been reverted by the EVM'),
-        );
+        await nf3User.deposit(erc20Address, tokenType, maxERC20DepositValue + 1, tokenId, fee);
+        expect.fail('Throw error, deposit not restricted');
+      } catch (err) {
+        expect(err.message).to.include('Transaction has been reverted by the EVM');
       }
     });
 
-    it('should restrict withdrawals', async function () {
+    // We need to withdraw more than the max withdraw limit, but we can't deposit
+    // more than the max withdraw limit because deposit's limit is 1/4 that of withdraw
+    // limit (floor of 1/4th). So we perform 6 deposits of the max deposit value, accumulate them into
+    // one commitment with multiple transfers. Then perform withdraw with this huge commitment which
+    // will be bigger than withdraw limit. Transfers to accumulate are done in such that they can
+    // accumulate this final value
+
+    // Transfer which gives a change of 0 is not possible because these commitments won't be picked
+    // and transfer errors with no suitable commitments. Example, this is not possible
+    //                                                                          Commitment List Before [250, 250, 250, 250, 250, 250]
+    // Transfer 500 to self             Input [250, 250]   Output [500, 0]      Commitment List after [0, 250, 250, 250, 250, 500]
+
+    // Example for accumulating withdraw
+    // Max Withdraw Limit : 1000                                                 Max Deposit Limit 1000/4 = 250
+    // Need a commitment with value greater than 1000
+    // Deposit 250 6 times                                                      Commitment List [250, 250, 250, 250, 250, 250]
+    // Transfer 400 to self             Input [250, 250]   Output [400, 100]    Commitment List after [100, 250, 250, 250, 250, 400]
+    // Transfer 400 + 200 to self       Input [400, 250]   Output [600, 50]     Commitment List after [50, 100, 250, 250, 250, 600]
+    // Transfer 600 + 200 to self       Input [600, 250]   Output [800, 50]     Commitment List after [50, 50, 100, 250, 250, 800]
+    // Transfer 800 + 200 to self       Input [800, 250]   Output [800, 50]     Commitment List after [50, 50, 50, 100, 250, 1000]
+    // Transfer 1000 + 200 to self      Input [1000, 250]  Output [1200, 50]    Commitment List after [50, 50, 50, 50, 100, 1200]
+    it.skip('Should restrict withdrawals', async function () {
       const nodeInfo = await web3Client.getInfo();
-      if (nodeInfo.includes('TestRPC')) {
-        try {
-          // we need to withdraw more than the max withdraw limit, but we can't deposit
-          // more than the max withdraw limit because deposit's limit is 1/4 that of withdraw
-          // limit (floor of 1/4th). So we perform 6 deposits of the max deposit value, accumulate them into
-          // one commitment with multiple tranfers. Then perform withdraw with this huge commitment which
-          // will be bigger than withdraw limit. Transfers to accumulate are done in such that they can
-          // accumulate this final value
-
-          // Transfer which gives a change of 0 is not possible because these commitments won't be picked
-          // and transfer errors with no suitable commitments. Example, this is not possible
-          //                                                                          Commitment List Before [250, 250, 250, 250, 250, 250]
-          // Transfer 500 to self             Input [250, 250]   Output [500, 0]      Commitment List after [0, 250, 250, 250, 250, 500]
-
-          // Example for accumulating withdraw
-          // Max Withdraw Limit : 1000                                                 Max Deposit Limit 1000/4 = 250
-          // Need a commitment with value greater than 1000
-          // Deposit 250 6 times                                                      Commitment List [250, 250, 250, 250, 250, 250]
-          // Transfer 400 to self             Input [250, 250]   Output [400, 100]    Commitment List after [100, 250, 250, 250, 250, 400]
-          // Transfer 400 + 200 to self       Input [400, 250]   Output [600, 50]     Commitment List after [50, 100, 250, 250, 250, 600]
-          // Transfer 600 + 200 to self       Input [600, 250]   Output [800, 50]     Commitment List after [50, 50, 100, 250, 250, 800]
-          // Transfer 800 + 200 to self       Input [800, 250]   Output [800, 50]     Commitment List after [50, 50, 50, 100, 250, 1000]
-          // Transfer 1000 + 200 to self      Input [1000, 250]  Output [1200, 50]    Commitment List after [50, 50, 50, 50, 100, 1200]
-
-          const trnsferValue = Math.floor(maxERC20WithdrawValue / 5); // maxERC20DepositValue < trnsferValue < maxERC20WithdrawValue
-          const withdrawValue = trnsferValue * 6; // trnsferValue = ( maxERC20WithdrawValue / 5 ) * 6 > maxERC20WithdrawValue
-
-          await depositNTransactions(
-            nf3Users[0],
-            6, // at least 6 deposits of max deposit value, put together it is bigger than max withdraw value
-            erc20Address,
-            tokenType,
-            maxERC20DepositValue,
-            tokenId,
-            fee,
-          );
-
-          await waitForSufficientTransactionsMempool({ nf3User: nf3Users[0], nTransactions: 6 });
-
-          await nf3Users[0].makeBlockNow();
-          await waitForSufficientBalance({
-            nf3User: nf3Users[0],
-            value: 6 * maxERC20DepositValue,
-            ercAddress: erc20Address,
-          });
-
-          await nf3Users[0].transfer(
-            false,
-            erc20Address,
-            tokenType,
-            trnsferValue * 4,
-            tokenId,
-            nf3Users[0].zkpKeys.compressedZkpPublicKey,
-            0,
-          );
-
-          await nf3Users[0].makeBlockNow();
-
-          await waitForSufficientBalance({
-            nf3User: nf3Users[0],
-            value: 6 * maxERC20DepositValue,
-            ercAddress: erc20Address,
-          });
-
-          const rec = await nf3Users[0].withdraw(
-            false,
-            erc20Address,
-            tokenType,
-            withdrawValue,
-            tokenId,
-            nf3Users[0].ethereumAddress,
-            0,
-          );
-
-          await nf3Users[0].makeBlockNow();
-          await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-
-          await new Promise(resolve => setTimeout(resolve, 30000));
-
-          expectTransaction(rec);
-
-          const withdrawal = nf3Users[0].getLatestWithdrawHash();
-          await web3Client.timeJump(3600 * 24 * 10); // jump in time by 50 days
-          // anything equal or above the restricted amount should fail
-          await nf3Users[0].finaliseWithdrawal(withdrawal);
-
-          expect.fail('Transaction has not been reverted by the EVM');
-        } catch (error) {
-          expect(error.message).to.satisfy(message =>
-            message.includes('Transaction has been reverted by the EVM'),
-          );
-        }
-      } else {
-        console.log('Not using a time-jump capable test client so this test is skipped');
+      if (!nodeInfo.includes('TestRPC')) {
+        logger.info('Not using a time-jump capable test client so this test is skipped');
         this.skip();
+      }
+
+      try {
+        const trnsferValue = Math.floor(maxERC20WithdrawValue / 5); // maxERC20DepositValue < trnsferValue < maxERC20WithdrawValue
+        const withdrawValue = trnsferValue * 6; // trnsferValue = ( maxERC20WithdrawValue / 5 ) * 6 > maxERC20WithdrawValue
+
+        await depositNTransactions(
+          nf3User,
+          6, // at least 6 deposits of max deposit value, put together it is bigger than max withdraw value
+          erc20Address,
+          tokenType,
+          maxERC20DepositValue,
+          tokenId,
+          0,
+        );
+
+        await waitForSufficientTransactionsMempool({ nf3User, nTransactions: 6 });
+
+        await nf3Proposer.makeBlockNow();
+        await waitForSufficientBalance({
+          nf3User,
+          value: 6 * maxERC20DepositValue,
+          ercAddress: erc20Address,
+        });
+
+        await nf3User.transfer(
+          false,
+          erc20Address,
+          tokenType,
+          trnsferValue * 4,
+          tokenId,
+          nf3User.zkpKeys.compressedZkpPublicKey,
+          0,
+        );
+
+        await nf3Proposer.makeBlockNow();
+
+        await waitForSufficientBalance({
+          nf3User,
+          value: 6 * maxERC20DepositValue,
+          ercAddress: erc20Address,
+        });
+
+        const rec = await nf3User.withdraw(
+          false,
+          erc20Address,
+          tokenType,
+          withdrawValue,
+          tokenId,
+          nf3User.ethereumAddress,
+          0,
+        );
+
+        await nf3Proposer.makeBlockNow();
+        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+
+        await new Promise(resolve => setTimeout(resolve, 30000));
+
+        expectTransaction(rec);
+
+        const withdrawalTxHash = nf3User.getLatestWithdrawHash();
+        await web3Client.timeJump(3600 * 24 * 10);
+        // anything equal or above the restricted amount should fail
+        await nf3User.finaliseWithdrawal(withdrawalTxHash);
+
+        expect.fail('Throw error, withdrawal not restricted');
+      } catch (err) {
+        expect(err.message).to.include('Transaction has been reverted by the EVM');
       }
     });
   });
@@ -539,8 +533,9 @@ describe('ERC20 tests', () => {
   after(async () => {
     await nf3Proposer.deregisterProposer();
     await nf3Proposer.close();
-    await nf3Users[0].close();
-    await nf3Users[1].close();
-    await web3Client.closeWeb3();
+    await nf3User.close();
+    await nf3User2.close();
+    await nf3UserSanctioned.close();
+    web3Client.closeWeb3();
   });
 });

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -447,7 +447,7 @@ describe('ERC20 tests', () => {
     // Transfer 600 + 200 to self       Input [600, 250]   Output [800, 50]     Commitment List after [50, 50, 100, 250, 250, 800]
     // Transfer 800 + 200 to self       Input [800, 250]   Output [800, 50]     Commitment List after [50, 50, 50, 100, 250, 1000]
     // Transfer 1000 + 200 to self      Input [1000, 250]  Output [1200, 50]    Commitment List after [50, 50, 50, 50, 100, 1200]
-    it.skip('Should restrict withdrawals', async function () {
+    it('Should restrict withdrawals', async function () {
       const nodeInfo = await web3Client.getInfo();
       if (!nodeInfo.includes('TestRPC')) {
         logger.info('Not using a time-jump capable test client so this test is skipped');

--- a/test/e2e/tokens/erc721.test.mjs
+++ b/test/e2e/tokens/erc721.test.mjs
@@ -1,20 +1,27 @@
 /* eslint-disable no-await-in-loop */
 
 import chai from 'chai';
+import gen from 'general-number';
 import chaiHttp from 'chai-http';
 import chaiAsPromised from 'chai-as-promised';
 import config from 'config';
 import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
 import Nf3 from '../../../cli/lib/nf3.mjs';
-import { emptyL2, expectTransaction, Web3Client } from '../../utils.mjs';
+import {
+  expectTransaction,
+  getLayer2Balances,
+  getUserCommitments,
+  Web3Client,
+} from '../../utils.mjs';
 import { getERCInfo } from '../../../cli/lib/tokens.mjs';
 
-// so we can use require with mjs file
+const { generalise } = gen;
+
 const { expect } = chai;
 chai.use(chaiHttp);
 chai.use(chaiAsPromised);
-const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
 
+const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
 const {
   fee,
   transferValue,
@@ -23,34 +30,40 @@ const {
   signingKeys,
 } = config.TEST_OPTIONS;
 
-const nf3Users = [new Nf3(signingKeys.user1, environment), new Nf3(signingKeys.user2, environment)];
-const nf3Proposer1 = new Nf3(signingKeys.proposer1, environment);
-
 const web3Client = new Web3Client();
-
-let erc721Address;
-// why do we need an ERC20 token in an ERC721 test, you ask?
-// let me tell you I also don't know, but I guess we just want to fill some blocks?
-let erc20Address;
-let stateAddress;
+const web3 = web3Client.getWeb3();
 const eventLogs = [];
-let availableTokenIds;
 let rollbackCount = 0;
 
-/*
-  This function tries to zero the number of unprocessed transactions in the optimist node
-  that nf3 is connected to. We call it extensively on the tests, as we want to query stuff from the
-  L2 layer, which is dependent on a block being made. We also need 0 unprocessed transactions by the end
-  of the tests, otherwise the optimist will become out of sync with the L2 block count on-chain.
-*/
+const nf3User = new Nf3(signingKeys.user1, environment);
+const nf3User2 = new Nf3(signingKeys.user2, environment);
+const nf3Proposer = new Nf3(signingKeys.proposer1, environment);
+nf3Proposer.setApiKey(environment.AUTH_TOKEN);
+
+let erc721Address;
+async function getLayer2Erc721s(_nf3User) {
+  return (await _nf3User.getLayer2Balances())[erc721Address]?.length || 0;
+}
+
+async function makeBlock() {
+  await nf3Proposer.makeBlockNow();
+  await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+}
 
 describe('ERC721 tests', () => {
+  let erc20Address; // erc20 is used to cover fees
+  let stateAddress;
+  let availableTokenIds;
+
   before(async () => {
-    await nf3Proposer1.init(mnemonics.proposer);
-    await nf3Proposer1.registerProposer('http://optimist', await nf3Proposer1.getMinimumStake());
+    await nf3User.init(mnemonics.user1);
+    await nf3User2.init(mnemonics.user2);
+
+    await nf3Proposer.init(mnemonics.proposer);
+    await nf3Proposer.registerProposer('http://optimist', await nf3Proposer.getMinimumStake());
 
     // Proposer listening for incoming events
-    const newGasBlockEmitter = await nf3Proposer1.startProposer();
+    const newGasBlockEmitter = await nf3Proposer.startProposer();
     newGasBlockEmitter.on('rollback', () => {
       rollbackCount += 1;
       logger.debug(
@@ -58,217 +71,360 @@ describe('ERC721 tests', () => {
       );
     });
 
-    await nf3Users[0].init(mnemonics.user1);
-    await nf3Users[1].init(mnemonics.user2);
-    erc20Address = await nf3Users[0].getContractAddress('ERC20Mock');
-    erc721Address = await nf3Users[0].getContractAddress('ERC721Mock');
-
-    stateAddress = await nf3Users[0].stateContractAddress;
+    erc20Address = await nf3User.getContractAddress('ERC20Mock');
+    erc721Address = await nf3User.getContractAddress('ERC721Mock');
+    stateAddress = await nf3User.stateContractAddress;
     web3Client.subscribeTo('logs', eventLogs, { address: stateAddress });
 
     availableTokenIds = (
-      await getERCInfo(erc721Address, nf3Users[0].ethereumAddress, web3Client.getWeb3(), {
+      await getERCInfo(erc721Address, nf3User.ethereumAddress, web3, {
         details: true,
       })
     ).details.map(t => t.tokenId);
 
-    await nf3Users[0].deposit(erc20Address, tokenType, transferValue, tokenId, 0);
-
-    await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
+    await nf3User.deposit(erc20Address, tokenType, 10 * transferValue, tokenId, 0);
+    await makeBlock();
   });
 
-  describe('Deposit', () => {
-    it('should deposit some ERC721 crypto into a ZKP commitment', async function () {
-      const tokenToDeposit = availableTokenIds.shift();
+  describe('Deposits', () => {
+    it('Should increment user L2 balance after depositing some ERC721', async function () {
+      const userL2Erc721Before = await getLayer2Erc721s(nf3User);
+      const userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
 
-      const myPublicKey = nf3Users[0].zkpKeys.compressedZkpPublicKey;
-      const balanceBefore = (await nf3Users[0].getLayer2Balances())[erc721Address]?.length || 0;
-      const balanceL2FeeTokenBefore =
-        (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
-      const unspentCommitmentsBefore = await nf3Users[0].getLayer2Commitments(
-        [erc721Address],
-        true,
-      );
-      let nUnspentCommitmentsBefore = 0;
-      if (myPublicKey in unspentCommitmentsBefore && unspentCommitmentsBefore[myPublicKey]) {
-        nUnspentCommitmentsBefore = unspentCommitmentsBefore[myPublicKey][erc721Address].length;
-      }
-
-      // We create enough transactions to fill blocks full of deposits.
-      const res = await nf3Users[0].deposit(erc721Address, tokenTypeERC721, 0, tokenToDeposit, fee);
+      const _tokenId = availableTokenIds.shift();
+      const res = await nf3User.deposit(erc721Address, tokenTypeERC721, 0, _tokenId, fee);
       expectTransaction(res);
+      logger.debug(`Gas used was ${Number(res.gasUsed)}`);
+      await makeBlock();
 
-      await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
+      const userL2Erc721After = await getLayer2Erc721s(nf3User);
+      const userL2FeesBalanceAfter = await getLayer2Balances(nf3User, erc20Address);
 
-      const balanceAfter = (await nf3Users[0].getLayer2Balances())[erc721Address]?.length || 0;
-      const balanceL2FeeTokenAfter =
-        (await nf3Users[0].getLayer2Balances())[erc20Address]?.[0].balance || 0;
-      const unspentCommitmentsAfter = await nf3Users[0].getLayer2Commitments([erc721Address], true);
-      let nUnspentCommitmentsAfter = 0;
-      if (myPublicKey in unspentCommitmentsAfter && unspentCommitmentsAfter[myPublicKey]) {
-        nUnspentCommitmentsAfter = unspentCommitmentsAfter[myPublicKey][erc721Address].length;
-      }
-
-      expect(balanceAfter - balanceBefore).to.be.equal(1);
-      expect(balanceL2FeeTokenAfter - balanceL2FeeTokenBefore).to.be.equal(-fee);
-      expect(nUnspentCommitmentsAfter - nUnspentCommitmentsBefore).to.be.equal(1);
+      expect(userL2Erc721After - userL2Erc721Before).to.be.equal(1);
+      expect(userL2FeesBalanceAfter - userL2FeesBalanceBefore).to.be.equal(-fee);
     });
-  });
 
-  describe('Transfer', () => {
-    it('should decrement the balance after transfer ERC721 to other wallet and increment the other wallet', async function () {
-      const tokenToTransfer = availableTokenIds.shift();
+    it('Should perform a deposit in which the user specifies which commitments they want to use to pay for the fee', async function () {
+      const userL2Erc721Before = await getLayer2Erc721s(nf3User);
+      const userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
 
-      const deposit = await nf3Users[0].deposit(
+      const _tokenId = availableTokenIds.shift();
+
+      const userCommitments = await getUserCommitments(
+        environment.clientApiUrl,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+      );
+
+      const erc20Commitments = userCommitments
+        .filter(c => c.ercAddress === generalise(erc20Address).hex(32))
+        .filter(c => c.value >= generalise(fee).hex(32));
+
+      const usedCommitmentsFee = [erc20Commitments[0].commitmentHash];
+
+      const res = await nf3User.deposit(
         erc721Address,
         tokenTypeERC721,
         0,
-        tokenToTransfer,
+        _tokenId,
+        fee,
+        usedCommitmentsFee,
+      );
+      expectTransaction(res);
+      logger.debug(`Gas used was ${Number(res.gasUsed)}`);
+      await makeBlock();
+
+      const userL2Erc721After = await getLayer2Erc721s(nf3User);
+      const userL2FeesBalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+
+      expect(userL2Erc721After - userL2Erc721Before).to.be.equal(1);
+      expect(userL2FeesBalanceAfter - userL2FeesBalanceBefore).to.be.equal(-fee);
+    });
+  });
+
+  describe('Transfers', () => {
+    it('Should decrement user L2 balance after transferring some ERC721 to other wallet, and increment the other wallet balance', async function () {
+      const _tokenId = availableTokenIds.shift();
+      await nf3User.deposit(erc721Address, tokenTypeERC721, 0, _tokenId, fee);
+      await makeBlock();
+
+      const userL2Erc721Before = await getLayer2Erc721s(nf3User);
+      const user2L2Erc721Before = await getLayer2Erc721s(nf3User2);
+      const userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
+
+      const res = await nf3User.transfer(
+        false,
+        erc721Address,
+        tokenTypeERC721,
+        0,
+        _tokenId,
+        nf3User2.zkpKeys.compressedZkpPublicKey,
         fee,
       );
+      expectTransaction(res);
+      logger.debug(`Gas used was ${Number(res.gasUsed)}`);
+      await makeBlock();
+
+      const userL2Erc721After = await getLayer2Erc721s(nf3User);
+      const user2L2Erc721After = await getLayer2Erc721s(nf3User2);
+      const userL2FeesBalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+
+      // Assertions user
+      expect(userL2Erc721After - userL2Erc721Before).to.be.equal(-1);
+      expect(userL2FeesBalanceAfter - userL2FeesBalanceBefore).to.be.equal(-fee);
+      // user 2
+      expect(user2L2Erc721After - user2L2Erc721Before).to.be.equal(1);
+    });
+
+    it('should perform a transfer by specifying the commitment that provides enough value to cover value + fee', async function () {
+      const _tokenId = availableTokenIds.shift();
+
+      const deposit = await nf3User.deposit(erc721Address, tokenTypeERC721, 0, _tokenId, fee);
       expectTransaction(deposit);
-      await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
+      await makeBlock();
 
-      async function getBalances() {
-        return Promise.all([
-          await nf3Users[0].getLayer2Balances(),
-          await nf3Users[1].getLayer2Balances(),
-        ]);
-      }
+      const userL2Erc721Before = await getLayer2Erc721s(nf3User);
+      const user2L2Erc721Before = await getLayer2Erc721s(nf3User2);
+      const userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
 
-      const balancesBefore = await getBalances();
+      const userCommitments = await getUserCommitments(nf3User.zkpKeys.compressedZkpPublicKey);
 
-      const res = await nf3Users[0].transfer(
+      const erc20Commitments = userCommitments
+        .filter(c => c.ercAddress === generalise(erc20Address).hex(32))
+        .filter(c => c.value >= generalise(fee).hex(32));
+
+      const erc721Commitments = userCommitments.filter(
+        c =>
+          c.ercAddress === generalise(erc721Address).hex(32) &&
+          c.tokenId === generalise(_tokenId).hex(32),
+      );
+
+      console.log('ERC721Commitments', erc721Commitments);
+
+      const res = await nf3User.transfer(
         false,
         erc721Address,
         tokenTypeERC721,
         0,
-        tokenToTransfer,
-        nf3Users[1].zkpKeys.compressedZkpPublicKey,
+        _tokenId,
+        nf3User2.zkpKeys.compressedZkpPublicKey,
         fee,
+        [erc721Commitments[0].commitmentHash],
+        [erc20Commitments[0].commitmentHash],
       );
       expectTransaction(res);
 
-      await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
+      await makeBlock();
 
-      const balancesAfter = await getBalances();
-      expect(
-        (balancesAfter[0][erc721Address]?.length || 0) -
-          (balancesBefore[0][erc721Address]?.length || 0),
-      ).to.be.equal(-1);
-      expect(
-        (balancesAfter[1][erc721Address]?.length || 0) -
-          (balancesBefore[1][erc721Address]?.length || 0),
-      ).to.be.equal(1);
-      console.log('Balances after', balancesAfter);
-      console.log('Balances before', balancesBefore);
-      expect(
-        (balancesAfter[0][erc20Address]?.[0].balance || 0) -
-          (balancesBefore[0][erc20Address]?.[0].balance || 0),
-      ).to.be.equal(-fee);
+      const userL2Erc721After = await getLayer2Erc721s(nf3User);
+      const user2L2Erc721After = await getLayer2Erc721s(nf3User2);
+      const userL2FeesBalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+
+      // Assertions user
+      expect(userL2Erc721After - userL2Erc721Before).to.be.equal(-1);
+      expect(userL2FeesBalanceAfter - userL2FeesBalanceBefore).to.be.equal(-fee);
+      // user 2
+      expect(user2L2Erc721After - user2L2Erc721Before).to.be.equal(1);
     });
-  });
 
-  describe('Withdraw', () => {
-    it('should withdraw from L2, checking for missing commitment', async function () {
-      const tokenToWithdraw = availableTokenIds.shift();
+    it('should perform a transfer by specifying the commitment that provides enough value to cover value', async function () {
+      const _tokenId = availableTokenIds.shift();
 
-      const res = await nf3Users[0].deposit(
-        erc721Address,
-        tokenTypeERC721,
-        0,
-        tokenToWithdraw,
-        fee,
+      const deposit = await nf3User.deposit(erc721Address, tokenTypeERC721, 0, _tokenId, fee);
+      expectTransaction(deposit);
+      await makeBlock();
+
+      const userL2Erc721Before = await getLayer2Erc721s(nf3User);
+      const user2L2Erc721Before = await getLayer2Erc721s(nf3User2);
+      const userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
+
+      const userCommitments = await getUserCommitments(nf3User.zkpKeys.compressedZkpPublicKey);
+
+      const erc721Commitments = userCommitments.filter(
+        c =>
+          c.ercAddress === generalise(erc721Address).hex(32) &&
+          c.tokenId === generalise(_tokenId).hex(32),
       );
-      expectTransaction(res);
-      await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
 
-      const balancesBefore = await nf3Users[0].getLayer2Balances();
-
-      const rec = await nf3Users[0].withdraw(
+      const res = await nf3User.transfer(
         false,
         erc721Address,
         tokenTypeERC721,
         0,
-        tokenToWithdraw,
-        nf3Users[0].ethereumAddress,
+        _tokenId,
+        nf3User2.zkpKeys.compressedZkpPublicKey,
         fee,
+        [erc721Commitments[0].commitmentHash],
+        [],
       );
-      expectTransaction(rec);
-      logger.debug(`Gas used was ${Number(rec.gasUsed)}`);
+      expectTransaction(res);
 
-      await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
+      await makeBlock();
 
-      const balancesAfter = await nf3Users[0].getLayer2Balances();
-      expect(
-        (balancesAfter[erc721Address]?.length || 0) - (balancesBefore[erc721Address]?.length || 0),
-      ).to.be.equal(-1);
-      expect(
-        (balancesAfter[erc20Address]?.[0].balance || 0) -
-          (balancesBefore[erc20Address]?.[0].balance || 0),
-      ).to.be.equal(-fee);
+      const userL2Erc721After = await getLayer2Erc721s(nf3User);
+      const user2L2Erc721After = await getLayer2Erc721s(nf3User2);
+      const userL2FeesBalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+
+      // Assertions user
+      expect(userL2Erc721After - userL2Erc721Before).to.be.equal(-1);
+      expect(userL2FeesBalanceAfter - userL2FeesBalanceBefore).to.be.equal(-fee);
+      // user 2
+      expect(user2L2Erc721After - user2L2Erc721Before).to.be.equal(1);
     });
 
-    it('should withdraw from L2, checking for L1 balance (only with time-jump client)', async function () {
-      const nodeInfo = await web3Client.getInfo();
-      if (nodeInfo.includes('TestRPC')) {
-        const tokenToWithdraw = availableTokenIds.shift();
+    it('should perform a transfer by specifying the commitment that provides enough value to cover fee', async function () {
+      const _tokenId = availableTokenIds.shift();
 
-        const deposit = await nf3Users[0].deposit(
-          erc721Address,
-          tokenTypeERC721,
-          0,
-          tokenToWithdraw,
-          fee,
-        );
-        expectTransaction(deposit);
-        await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
+      const deposit = await nf3User.deposit(erc721Address, tokenTypeERC721, 0, _tokenId, fee);
+      expectTransaction(deposit);
+      await makeBlock();
 
-        const balancesBefore = await nf3Users[0].getLayer2Balances();
+      const userCommitments = await getUserCommitments(nf3User.zkpKeys.compressedZkpPublicKey);
 
-        const rec = await nf3Users[0].withdraw(
+      const erc20Commitments = userCommitments
+        .filter(c => c.ercAddress === generalise(erc20Address).hex(32))
+        .filter(c => c.value >= generalise(fee).hex(32));
+
+      const userL2Erc721Before = await getLayer2Erc721s(nf3User);
+      const user2L2Erc721Before = await getLayer2Erc721s(nf3User2);
+      const userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
+
+      const res = await nf3User.transfer(
+        false,
+        erc721Address,
+        tokenTypeERC721,
+        0,
+        _tokenId,
+        nf3User2.zkpKeys.compressedZkpPublicKey,
+        fee,
+        [],
+        [erc20Commitments[0].commitmentHash],
+      );
+      expectTransaction(res);
+
+      await makeBlock();
+
+      const userL2Erc721After = await getLayer2Erc721s(nf3User);
+      const user2L2Erc721After = await getLayer2Erc721s(nf3User2);
+      const userL2FeesBalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+
+      // Assertions user
+      expect(userL2Erc721After - userL2Erc721Before).to.be.equal(-1);
+      expect(userL2FeesBalanceAfter - userL2FeesBalanceBefore).to.be.equal(-fee);
+      // user 2
+      expect(user2L2Erc721After - user2L2Erc721Before).to.be.equal(1);
+    });
+
+    it('should fail to perform a transfer if user specifies commitments for the fee but it does not cover the whole value', async function () {
+      const _tokenId = availableTokenIds.shift();
+
+      const deposit = await nf3User.deposit(erc721Address, tokenTypeERC721, 0, _tokenId, fee);
+      expectTransaction(deposit);
+      await makeBlock();
+
+      const userCommitments = await getUserCommitments(nf3User.zkpKeys.compressedZkpPublicKey);
+
+      const erc20Commitments = userCommitments
+        .filter(c => c.ercAddress === generalise(erc20Address).hex(32))
+        .filter(c => c.value >= generalise(fee).hex(32));
+
+      try {
+        const res = await nf3User.transfer(
           false,
           erc721Address,
           tokenTypeERC721,
           0,
-          tokenToWithdraw,
-          nf3Users[0].ethereumAddress,
-          fee,
+          _tokenId,
+          nf3User2.zkpKeys.compressedZkpPublicKey,
+          Number(generalise(erc20Commitments[0].value).bigInt + 1n),
+          [],
+          [erc20Commitments[0].commitmentHash],
         );
-        expectTransaction(rec);
-        await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
-
-        const withdrawal = nf3Users[0].getLatestWithdrawHash();
-
-        const balancesAfter = await nf3Users[0].getLayer2Balances();
-
-        await web3Client.timeJump(3600 * 24 * 10); // jump in time by 10 days
-
-        const commitments = await nf3Users[0].getPendingWithdraws();
-        expect(
-          commitments[nf3Users[0].zkpKeys.compressedZkpPublicKey][erc721Address].length,
-        ).to.be.greaterThan(0);
-        expect(
-          commitments[nf3Users[0].zkpKeys.compressedZkpPublicKey][erc721Address].filter(
-            c => c.valid === true,
-          ).length,
-        ).to.be.greaterThan(0);
-
-        const res = await nf3Users[0].finaliseWithdrawal(withdrawal);
         expectTransaction(res);
+      } catch (err) {
+        expect(err.message).to.be.equal('provided commitments do not cover the fee');
+      }
+    });
 
-        expect(
-          (balancesAfter[erc721Address]?.length || 0) -
-            (balancesBefore[erc721Address]?.length || 0),
-        ).to.be.equal(-1);
-        expect(
-          (balancesAfter[erc20Address]?.[0].balance || 0) -
-            (balancesBefore[erc20Address]?.[0].balance || 0),
-        ).to.be.equal(-fee);
-      } else {
+    it('should fail to perform a transfer if user specifies commitments and some of them are invalid', async function () {
+      const _tokenId = availableTokenIds.shift();
+
+      const deposit = await nf3User.deposit(erc721Address, tokenTypeERC721, 0, _tokenId, fee);
+      expectTransaction(deposit);
+      await makeBlock();
+
+      try {
+        const res = await nf3User.transfer(
+          false,
+          erc721Address,
+          tokenTypeERC721,
+          0,
+          _tokenId,
+          nf3User2.zkpKeys.compressedZkpPublicKey,
+          fee,
+          [],
+          [generalise(34).hex(43)],
+        );
+        expectTransaction(res);
+      } catch (err) {
+        expect(err.message).to.include('Some of the commitments provided for the fee were invalid');
+      }
+    });
+  });
+
+  describe('Withdrawals', () => {
+    let userL2Erc721Before;
+    let userL2FeesBalanceBefore;
+    let withdrawalTx;
+    let withdrawalTxHash;
+
+    before(async function () {
+      const _tokenId = availableTokenIds.shift();
+      await nf3User.deposit(erc721Address, tokenTypeERC721, 0, _tokenId, fee);
+      await makeBlock();
+
+      userL2Erc721Before = await getLayer2Erc721s(nf3User);
+      userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
+      withdrawalTx = await nf3User.withdraw(
+        false,
+        erc721Address,
+        tokenTypeERC721,
+        0,
+        _tokenId,
+        nf3User.ethereumAddress,
+        fee,
+      );
+      withdrawalTxHash = nf3User.getLatestWithdrawHash();
+    });
+
+    it('Should withdraw from L2', async function () {
+      expectTransaction(withdrawalTx);
+      logger.debug(`Gas used was ${Number(withdrawalTx.gasUsed)}`);
+      await makeBlock();
+
+      const userL2Erc721After = await getLayer2Erc721s(nf3User);
+      const userL2FeesBalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+
+      expect(userL2Erc721After - userL2Erc721Before).to.be.equal(-1);
+      expect(userL2FeesBalanceAfter - userL2FeesBalanceBefore).to.be.equal(-fee);
+    });
+
+    it('Should finalise previous withdrawal from L2 to L1 (only with time-jump client)', async function () {
+      const nodeInfo = await web3Client.getInfo();
+      if (!nodeInfo.includes('TestRPC')) {
         logger.info('Not using a time-jump capable test client so this test is skipped');
         this.skip();
       }
+
+      const userL1BalanceBefore = await web3Client.getBalance(nf3User.ethereumAddress);
+
+      await web3Client.timeJump(3600 * 24 * 10);
+      const res = await nf3User.finaliseWithdrawal(withdrawalTxHash);
+      expectTransaction(res);
+      logger.debug(`Gas used was ${Number(res.gasUsed)}`);
+
+      const userL1BalanceAfter = await web3Client.getBalance(nf3User.ethereumAddress);
+      // Final L1 balance to be lesser than initial balance because of fees
+      expect(parseInt(userL1BalanceAfter, 10)).to.be.lessThan(parseInt(userL1BalanceBefore, 10));
     });
   });
 
@@ -279,10 +435,10 @@ describe('ERC721 tests', () => {
   });
 
   after(async () => {
-    await nf3Proposer1.deregisterProposer();
-    await nf3Proposer1.close();
-    await nf3Users[0].close();
-    await nf3Users[1].close();
-    await web3Client.closeWeb3();
+    await nf3Proposer.deregisterProposer();
+    await nf3Proposer.close();
+    await nf3User.close();
+    await nf3User2.close();
+    web3Client.closeWeb3();
   });
 });

--- a/test/e2e/tokens/erc721.test.mjs
+++ b/test/e2e/tokens/erc721.test.mjs
@@ -38,7 +38,6 @@ let rollbackCount = 0;
 const nf3User = new Nf3(signingKeys.user1, environment);
 const nf3User2 = new Nf3(signingKeys.user2, environment);
 const nf3Proposer = new Nf3(signingKeys.proposer1, environment);
-nf3Proposer.setApiKey(environment.AUTH_TOKEN);
 
 let erc721Address;
 async function getLayer2Erc721s(_nf3User) {

--- a/test/e2e/tokens/erc721.test.mjs
+++ b/test/e2e/tokens/erc721.test.mjs
@@ -185,7 +185,10 @@ describe('ERC721 tests', () => {
       const user2L2Erc721Before = await getLayer2Erc721s(nf3User2);
       const userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
 
-      const userCommitments = await getUserCommitments(nf3User.zkpKeys.compressedZkpPublicKey);
+      const userCommitments = await getUserCommitments(
+        environment.clientApiUrl,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+      );
 
       const erc20Commitments = userCommitments
         .filter(c => c.ercAddress === generalise(erc20Address).hex(32))
@@ -236,7 +239,10 @@ describe('ERC721 tests', () => {
       const user2L2Erc721Before = await getLayer2Erc721s(nf3User2);
       const userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
 
-      const userCommitments = await getUserCommitments(nf3User.zkpKeys.compressedZkpPublicKey);
+      const userCommitments = await getUserCommitments(
+        environment.clientApiUrl,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+      );
 
       const erc721Commitments = userCommitments.filter(
         c =>
@@ -277,7 +283,10 @@ describe('ERC721 tests', () => {
       expectTransaction(deposit);
       await makeBlock();
 
-      const userCommitments = await getUserCommitments(nf3User.zkpKeys.compressedZkpPublicKey);
+      const userCommitments = await getUserCommitments(
+        environment.clientApiUrl,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+      );
 
       const erc20Commitments = userCommitments
         .filter(c => c.ercAddress === generalise(erc20Address).hex(32))
@@ -320,7 +329,10 @@ describe('ERC721 tests', () => {
       expectTransaction(deposit);
       await makeBlock();
 
-      const userCommitments = await getUserCommitments(nf3User.zkpKeys.compressedZkpPublicKey);
+      const userCommitments = await getUserCommitments(
+        environment.clientApiUrl,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+      );
 
       const erc20Commitments = userCommitments
         .filter(c => c.ercAddress === generalise(erc20Address).hex(32))

--- a/test/e2e/tokens/l2tokenisation.test.mjs
+++ b/test/e2e/tokens/l2tokenisation.test.mjs
@@ -149,7 +149,7 @@ describe('L2 Tokenisation tests', () => {
         beforeBalance[l2Address]?.find(e => e.tokenId === generalise(privateTokenId).hex(32))
           ?.balance || 0;
 
-      await nf3Users[0].burn(l2Address, valueBurnt, privateTokenId, [commitmentHash], 1);
+      await nf3Users[0].burn(l2Address, valueBurnt, privateTokenId, 1, [commitmentHash]);
 
       await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
 
@@ -192,7 +192,7 @@ describe('L2 Tokenisation tests', () => {
         beforeBalance[l2Address]?.find(e => e.tokenId === generalise(privateTokenId).hex(32))
           ?.balance || 0;
 
-      await nf3Users[0].burn(l2Address, value, privateTokenId, [commitmentHash], 1);
+      await nf3Users[0].burn(l2Address, value, privateTokenId, 1, [commitmentHash]);
 
       await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
 
@@ -222,7 +222,7 @@ describe('L2 Tokenisation tests', () => {
         beforeBalance[l2Address]?.find(e => e.tokenId === generalise(privateTokenId).hex(32))
           ?.balance || 0;
 
-      await nf3Users[0].burn(l2Address, valueBurnt, privateTokenId, [], 1);
+      await nf3Users[0].burn(l2Address, valueBurnt, privateTokenId, 1, []);
 
       await emptyL2({ nf3User: nf3Users[0], web3: web3Client, logs: eventLogs });
 

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -535,3 +535,24 @@ export const emptyL2 = async ({ nf3User, web3, logs }) => {
   }
   await new Promise(resolve => setTimeout(resolve, 6000));
 };
+
+export async function getLayer2Balances(_nf3User, tokenAddress) {
+  return (await _nf3User.getLayer2Balances())[tokenAddress]?.[0].balance || 0;
+}
+
+export async function getUserCommitments(clientApiUrl, compressedZkpPublicKey) {
+  const userCommitments = (
+    await axios.post(`${clientApiUrl}/commitment/compressedZkpPublicKeys`, [compressedZkpPublicKey])
+  ).data.commitmentsByListOfCompressedZkpPublicKey;
+
+  return userCommitments
+    .filter(c => c.isNullifiedOnChain === -1)
+    .map(c => {
+      return {
+        commitmentHash: c._id,
+        ercAddress: c.preimage.ercAddress,
+        tokenId: c.preimage.tokenId,
+        value: c.preimage.value,
+      };
+    });
+}

--- a/wallet/src/nightfall-browser/services/commitment-storage.js
+++ b/wallet/src/nightfall-browser/services/commitment-storage.js
@@ -867,16 +867,14 @@ export async function findUsableCommitmentsMutex(
   );
 }
 
-export async function getCommitmentsByHash(hashes, compressedZkpPublicKey, ercAddress, tokenId) {
+export async function getCommitmentsByHash(hashes, compressedZkpPublicKey) {
   const db = await connectDB();
   const vals = db.getAll(COMMITMENTS_COLLECTION);
   const commitment = vals.filter(
     v =>
       hashes.includes(v._id) &&
       v.compressedZkpPublicKey === compressedZkpPublicKey.hex(32) &&
-      v.preimage.ercAddress === generalise(ercAddress).hex(32) &&
-      v.preimage.tokenId === generalise(tokenId).hex(32) &&
-      !v.isNullified &&
+      v.isNullifiedOnChain === -1 &&
       !v.isPendingNullification,
   );
 

--- a/wallet/src/nightfall-browser/services/database.js
+++ b/wallet/src/nightfall-browser/services/database.js
@@ -183,22 +183,15 @@ find which block a transaction went into. Note, we'll save all blocks, that get
 posted to the blockchain, not just ours.
 */
 export async function saveBlock(_block) {
-  const block = { ..._block, _id: _block.blockNumberL2 };
+  const block = { _id: _block.blockNumberL2, ..._block };
   if (!block.transactionHashL1)
     throw new Error('Layer 2 blocks must be saved with a valid Layer 1 transactionHash');
   if (!block.blockNumber)
     throw new Error('Layer 2 blocks must be saved with a valid Layer 1 block number');
   const db = await connectDB();
-  const existing = await db.get(SUBMITTED_BLOCKS_COLLECTION, block._id);
-  // there are three possibilities here:
-  // 1) We're just saving a block for the first time.  This is fine
-  // 2) We're trying to save a replayed block.  This will correctly fail because the _id will be duplicated
-  // 3) We're trying to save a block that we've seen before but it was re-mined due to a chain reorg. In
-  //    this case, it's fine, we just update the layer 1 blocknumber and transactionHash to the new values
-  if (!existing || !existing.blockNumber) {
-    return db.put(SUBMITTED_BLOCKS_COLLECTION, block, block._id);
-  }
-  throw new Error('Attempted to replay existing layer 2 block');
+  const query = { _id: block._id };
+  const update = { $set: block };
+  return db.collection(SUBMITTED_BLOCKS_COLLECTION).updateOne(query, update, { upsert: true });
 }
 
 /**
@@ -273,20 +266,10 @@ export async function saveTransaction(_transaction) {
     _id: _transaction.transactionHash,
     ..._transaction,
   };
-  // there are three possibilities here:
-  // 1) We're just saving a transaction for the first time.  This is fine
-  // 2) We're trying to save a replayed transaction.  This will correctly fail because the _id will be duplicated
-  // 3) We're trying to save a transaction that we've seen before but it was re-mined due to a chain reorg. In
-  //    this case, it's fine, we just update the layer 1 blocknumber and transactionHash to the new values
   const db = await connectDB();
-  const query = await db.getAll(TRANSACTIONS_COLLECTION);
-  const existing = query.filter(q => q.transactionHash === transaction.transactionHash);
-  transaction.createdTime = _transaction?.createdTime ?? Math.floor(Date.now() / 1000);
-  if (!existing) return db.put(TRANSACTIONS_COLLECTION, transaction, transaction._id);
-  if (!existing.blockNumber) {
-    return db.put(TRANSACTIONS_COLLECTION, transaction, transaction._id);
-  }
-  throw new Error('Attempted to replay existing transaction');
+  const query = { transactionHash: transaction.transactionHash };
+  const update = { $set: transaction };
+  return db.collection(TRANSACTIONS_COLLECTION).updateOne(query, update, { upsert: true });
 }
 
 /*

--- a/wallet/src/nightfall-browser/services/deposit.js
+++ b/wallet/src/nightfall-browser/services/deposit.js
@@ -28,12 +28,13 @@ const { SHIELD_CONTRACT_NAME, BN128_GROUP_ORDER } = global.nightfallConstants;
 const { generalise } = gen;
 let circuitName = 'depositfee';
 
-async function deposit(items, shieldContractAddress) {
+async function deposit(depositParams, shieldContractAddress) {
   logger.info('Creating a deposit transaction');
   // before we do anything else, long hex strings should be generalised to make
   // subsequent manipulations easier
+  const { tokenType, providedCommitmentsFee, ...items } = depositParams;
+  const ercAddress = generalise(depositParams.ercAddress.toLowerCase());
   const { tokenId, value, fee, rootKey } = generalise(items);
-  const ercAddress = generalise(items.ercAddress.toLowerCase());
   const { compressedZkpPublicKey, nullifierKey } = new ZkpKeys(rootKey);
   const zkpPublicKey = ZkpKeys.decompressZkpPublicKey(compressedZkpPublicKey);
 
@@ -75,6 +76,7 @@ async function deposit(items, shieldContractAddress) {
         rootKey,
         maxNullifiers: VK_IDS[circuitName].numberNullifiers,
         maxNonFeeNullifiers: 0,
+        providedCommitmentsFee,
       });
     }
   } else {
@@ -110,7 +112,7 @@ async function deposit(items, shieldContractAddress) {
     fee,
     historicRootBlockNumberL2: commitmentsInfo.blockNumberL2s,
     circuitHash,
-    tokenType: items.tokenType,
+    tokenType,
     tokenId,
     value,
     ercAddress,

--- a/wallet/src/nightfall-browser/services/transfer.js
+++ b/wallet/src/nightfall-browser/services/transfer.js
@@ -38,7 +38,7 @@ const circuitName = 'transfer';
 async function transfer(transferParams, shieldContractAddress) {
   logger.info('Creating a transfer transaction');
   // let's extract the input items
-  const { providedCommitments, ...items } = transferParams;
+  const { providedCommitments, providedCommitmentsFee, ...items } = transferParams;
   const { tokenId, recipientData, rootKey, fee = generalise(0) } = generalise(items);
   const { compressedZkpPublicKey, nullifierKey } = new ZkpKeys(rootKey);
   const ercAddress = generalise(items.ercAddress.toLowerCase());
@@ -82,6 +82,7 @@ async function transfer(transferParams, shieldContractAddress) {
       rootKey,
       maxNullifiers: VK_IDS[circuitName].numberNullifiers,
       providedCommitments,
+      providedCommitmentsFee,
     });
 
     try {

--- a/wallet/src/nightfall-browser/services/withdraw.js
+++ b/wallet/src/nightfall-browser/services/withdraw.js
@@ -37,6 +37,7 @@ async function withdraw(withdrawParams, shieldContractAddress) {
     rootKey,
     fee = generalise(0),
     providedCommitments,
+    providedCommitmentsFee,
   } = generalise(withdrawParams);
   const { compressedZkpPublicKey, nullifierKey } = new ZkpKeys(rootKey);
   const ercAddress = generalise(withdrawParams.ercAddress.toLowerCase());
@@ -66,6 +67,7 @@ async function withdraw(withdrawParams, shieldContractAddress) {
     rootKey,
     maxNullifiers: VK_IDS[circuitName].numberNullifiers,
     providedCommitments,
+    providedCommitmentsFee,
   });
 
   const circuitHashData = await getStoreCircuit(`${circuitName}-hash`);

--- a/wallet/src/nightfall-browser/utils/getCommitmentInfo.ts
+++ b/wallet/src/nightfall-browser/utils/getCommitmentInfo.ts
@@ -25,6 +25,8 @@ type CommitmentsInfo = {
   roots: any[];
   nullifiers: any[];
   salts: any[];
+  hasChange: boolean;
+  hasChangeFee: boolean;
 };
 
 type TxInfo = {
@@ -38,6 +40,7 @@ type TxInfo = {
   maxNullifiers: number;
   maxNonFeeNullifiers: number | undefined;
   providedCommitments: string[];
+  providedCommitmentsFee: string[];
 };
 
 const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
@@ -50,6 +53,7 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
     tokenId = generalise(0),
     rootKey,
     providedCommitments = [],
+    providedCommitmentsFee = [],
   } = txInfo;
 
   let { maxNullifiers, maxNonFeeNullifiers = undefined } = txInfo;
@@ -61,11 +65,21 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
   const ercAddressArray = recipientZkpPublicKeysArray.map(() => ercAddress);
 
   const tokenIdArray = recipientZkpPublicKeysArray.map(() => tokenId);
+  // If ercAddress is the same as the feeAddress, we will set the fee as zero and only look for value
   const addedFee = maticAddress.hex(32) === ercAddress.hex(32) ? fee : 0n;
 
-  let value = totalValueToSend + addedFee;
-  const feeValue = fee - addedFee;
+  let value = totalValueToSend;
+  let feeValue = fee;
 
+  // If maxNonFeeNullifiers is equal to zero, it means that we are not looking for non fee commitments and so
+  // we won't use addedFee logic
+  if (maxNonFeeNullifiers === undefined || maxNonFeeNullifiers !== 0) {
+    value += addedFee;
+    feeValue -= addedFee;
+  }
+
+  // Set maxNonFeeNullifiers if undefined. If fee is higher than zero it means we will need at least 1 slot
+  // for the fee, so maximum non fee will be maxNullifiers - 1. Otherwise all slots can be used for the transfer
   if (maxNonFeeNullifiers === undefined) {
     maxNonFeeNullifiers = feeValue > 0n ? maxNullifiers - 1 : maxNullifiers;
   }
@@ -73,49 +87,132 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
   const spentCommitments = [];
   try {
     let validatedProvidedCommitments = [];
-    if (providedCommitments.length > 0) {
-      const commitmentHashes = providedCommitments.map(c => c.toString());
-      const rawCommitments = await getCommitmentsByHash(
-        commitmentHashes,
-        compressedZkpPublicKey,
-        ercAddress,
-        tokenId,
-      );
+    let validatedProvidedCommitmentsFee = [];
+    let nonFeeCommitmentsProvided = false;
+    let feeCommitmentsProvided = false;
+    let providedValue = 0n;
+    let providedValueFee = 0n;
 
-      if (rawCommitments.length < commitmentHashes.length) {
-        const invalidHashes = commitmentHashes.filter(ch => {
-          for (const rc of rawCommitments) {
-            if (rc._id === ch) return false;
-          }
-          return true;
-        });
-        throw new Error(`invalid commitment hashes: ${invalidHashes}`);
-      }
-
-      const providedValue = rawCommitments
-        .map((c: any) => generalise(c.preimage.value).bigInt)
-        .reduce((sum: bigint, c: bigint) => sum + c);
-
-      if (providedValue < totalValueToSend)
-        throw new Error('provided commitments do not cover the value');
-
-      // transform the hashes retrieved from the DB to well formed commitments
-      validatedProvidedCommitments = rawCommitments.map((ct: any) => new Commitment(ct.preimage));
-
-      if (maticAddress.hex(32) === ercAddress.hex(32)) {
-        // the user provided enough commitments to cover the value but not the fee
-        // this can only happen when the token to send is the fee token
-        // we need to set the value here instead of the feeValue
-        value = providedValue >= value ? 0n : value - providedValue;
-      } else {
-        maxNonFeeNullifiers = 0;
-      }
-
-      maxNullifiers -= validatedProvidedCommitments.length;
-      await Promise.all(validatedProvidedCommitments.map((c: Commitment) => markPending(c)));
-      spentCommitments.push(...validatedProvidedCommitments);
+    // Throw an error if more than the allowed number of max number of nullifiers are provided
+    if (providedCommitments.length + providedCommitmentsFee.length > maxNullifiers) {
+      throw new Error(`You can not provide more than ${maxNullifiers} commitments to be nullified`);
     }
 
+    // User has the ability to specify the commitments they wanna use. If that's the case, we will need to check that
+    // those commitments are valid and fulfill all the requirements. Otherwise, we will use our own algorithm to select
+    // the commitments used.
+    if (providedCommitments.length > 0) {
+      const commitmentHashes = providedCommitments.map(c => c.toString());
+
+      // Search for the commitment hashes in the DB. The commitment will be considered valid
+      // as long as it is not already nullified
+      const rawCommitments = await getCommitmentsByHash(commitmentHashes, compressedZkpPublicKey);
+
+      // Filter which of those commitments belong to the ercAddress
+      const ercAddressCommitments = rawCommitments.filter(
+        (c: any) => c.preimage.ercAddress === generalise(ercAddress).hex(32),
+      );
+
+      if (ercAddressCommitments.length < providedCommitments.length) {
+        throw new Error('Some of the commitments provided for the value were invalid');
+      }
+
+      // Calculate the total value from the ercAddress commitments
+      providedValue = ercAddressCommitments
+        .map((c: any) => generalise(c.preimage.value).bigInt)
+        .reduce((sum: bigint, c: bigint) => sum + c, 0n);
+
+      if (ercAddressCommitments.length > 0) {
+        if (providedValue < totalValueToSend) {
+          throw new Error('provided commitments do not cover the value');
+        } else {
+          nonFeeCommitmentsProvided = true;
+          validatedProvidedCommitments = ercAddressCommitments.map(
+            (ct: any) => new Commitment(ct.preimage),
+          );
+        }
+      }
+
+      // If ercAddress commitments are provided, we force maxNonFeeNullifiers to be zero so that our algorithm
+      // does not check for transfer commitments. We cannot rely on value to be zero due to ERC721 tokens
+      if (nonFeeCommitmentsProvided) {
+        maxNonFeeNullifiers = 0;
+      }
+    }
+
+    if (providedCommitmentsFee.length > 0) {
+      const commitmentHashesFee = providedCommitmentsFee.map(c => c.toString());
+
+      // Search for the commitment hashes in the DB. The commitment will be considered valid
+      // as long as it is not already nullified
+      const rawCommitmentsFee = await getCommitmentsByHash(
+        commitmentHashesFee,
+        compressedZkpPublicKey,
+      );
+
+      // Filter which of those commitments belong to the ercAddress
+      const ercAddressCommitmentsFee = rawCommitmentsFee.filter(
+        (c: any) => c.preimage.ercAddress === generalise(maticAddress).hex(32),
+      );
+
+      if (ercAddressCommitmentsFee.length < providedCommitmentsFee.length) {
+        throw new Error('Some of the commitments provided for the fee were invalid');
+      }
+
+      // Calculate the total value from the ercAddress commitments
+      providedValueFee = ercAddressCommitmentsFee
+        .map((c: any) => generalise(c.preimage.value).bigInt)
+        .reduce((sum: bigint, c: bigint) => sum + c, 0n);
+
+      if (ercAddressCommitmentsFee.length > 0) {
+        // Check if enough value is provided. Otherwise, throw an error because we assume that
+        // if the user provide the commitments he has full control of what is he spending
+        if (providedValueFee < fee) {
+          throw new Error('provided commitments do not cover the fee');
+        } else {
+          feeCommitmentsProvided = true;
+          validatedProvidedCommitmentsFee = ercAddressCommitmentsFee.map(
+            (ct: any) => new Commitment(ct.preimage),
+          );
+        }
+      }
+
+      if (feeCommitmentsProvided) {
+        // If ercAddressFee commitments are provided, we force feeValue to be zero so that our algorithm
+        // does not check for fee commitments
+        feeValue = 0n;
+      }
+    }
+
+    const validatedCommitments = [
+      ...validatedProvidedCommitments,
+      ...validatedProvidedCommitmentsFee,
+    ];
+
+    // If the user is transferring the same token as the fee, the case in which the user provided
+    // enough commitments to cover the value but not the fee is valid.
+    // If that is the case, we modify the parameters accordingly.
+    if (maticAddress.hex(32) === ercAddress.hex(32)) {
+      const totalProvidedValue = providedValue + providedValueFee;
+      if (totalProvidedValue < value) {
+        maxNonFeeNullifiers =
+          providedValue >= value ? 0 : maxNonFeeNullifiers - validatedCommitments.length;
+        value = providedValue >= value ? 0n : value - providedValue;
+      }
+    }
+
+    // Update max nullifiers so that validatedCommitments spots are not used
+    maxNullifiers -= validatedCommitments.length;
+
+    // Mark the commitments as pendingNullification
+    await Promise.all(validatedCommitments.map(c => markPending(c)));
+
+    // Store this commitments inside spentCommitment so that if anything goes wrong we can clear the pending
+    // commitments
+    spentCommitments.push(...validatedCommitments);
+
+    // Use our commitment selection algorithm to select the commitments the user is gonna use for the transfer
+    // and the fee
     const commitments = await findUsableCommitmentsMutex(
       compressedZkpPublicKey,
       ercAddress,
@@ -126,15 +223,20 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
       maxNullifiers,
       maxNonFeeNullifiers,
     );
-
     const { oldCommitments, oldCommitmentsFee } = commitments;
+
+    // Add oldcommitments and oldCommitmentsFee to spentCommitments so that if anything goes wrong we can clear the pending
     spentCommitments.push(...oldCommitments);
     spentCommitments.push(...oldCommitmentsFee);
 
+    // Add providedCommitments to oldCommitments array
     oldCommitments.push(...validatedProvidedCommitments);
+    oldCommitmentsFee.push(...validatedProvidedCommitmentsFee);
 
     // Compute the nullifiers
-    const nullifiers = spentCommitments.map(commitment => new Nullifier(commitment, nullifierKey));
+    const nullifiers = [...oldCommitments, ...oldCommitmentsFee].map(
+      commitment => new Nullifier(commitment, nullifierKey),
+    );
 
     // then the new output commitment(s)
     const totalInputCommitmentValue = oldCommitments.reduce(
@@ -143,7 +245,7 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
     );
 
     // we may need to return change to the recipient
-    const change = totalInputCommitmentValue - value;
+    const change = totalInputCommitmentValue - (totalValueToSend + addedFee);
 
     // if so, add an output commitment to do that
     if (generalise(change).bigInt !== 0n) {
@@ -160,7 +262,7 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
     );
 
     // we may need to return change to the recipient
-    const changeFee = totalInputCommitmentFeeValue - feeValue;
+    const changeFee = totalInputCommitmentFeeValue - (fee - addedFee);
 
     // if so, add an output commitment to do that
     if (generalise(changeFee).bigInt !== 0n) {
@@ -174,7 +276,6 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
       recipientZkpPublicKeysArray.map(async () => randValueLT(BN128_GROUP_ORDER)),
     );
 
-    // Generate new commitments, already truncated to u32[7]
     const newCommitments = recipientZkpPublicKeysArray.map(
       (recipientKey, i) =>
         new Commitment({
@@ -187,7 +288,9 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
     );
 
     // Commitment Tree Information
-    const commitmentTreeInfo = await Promise.all(spentCommitments.map(c => getSiblingInfo(c)));
+    const commitmentTreeInfo = await Promise.all(
+      [...oldCommitments, ...oldCommitmentsFee].map(c => getSiblingInfo(c)),
+    );
     const localSiblingPaths = commitmentTreeInfo.map(l => {
       const path = l.siblingPath.path.map((p: any) => p.value);
       return generalise([l.root].concat(path.reverse()));
@@ -197,7 +300,7 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
     const roots = commitmentTreeInfo.map(l => l.root);
 
     return {
-      oldCommitments: spentCommitments,
+      oldCommitments: [...oldCommitments, ...oldCommitmentsFee],
       nullifiers,
       newCommitments,
       localSiblingPaths,
@@ -205,6 +308,8 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
       blockNumberL2s,
       roots,
       salts,
+      hasChange: change !== 0n,
+      hasChangeFee: changeFee !== 0n,
     };
   } catch (err) {
     console.log('ERR', err);


### PR DESCRIPTION
This PR modifies the logic allowing the user to specify the commitment hashes they wanna use. With the current changes, it will work as follows:
- Users will be able to provide commitment hashes for either the fee or the value, using `providedCommitments` and `providedCommitmentsFee` respectively. 
- All commitments provided will be used. If more commitments than the number of max number of nullifiers is sent, an error will be thrown. If any of the commitments doesn't belong to the value address or the fee address, an error will be thrown. 
- If the user provide commitments for the value, they should cover the whole amount. Otherwise an error will be thrown. Same applies for the fee.

Routes have been updated to throw any error that is thrown. 

Transpilation for the adversary has been adjusted to work with this code. 

Wallet code has also been adjusted accordingly.

A bunch of new tests has been added to `e2e-erc1155`, `e2e-erc721`, `e2e-erc20` to test this new logic. This tests has also been hugely refactored using as a reference the job done by @imagobea in #1286 