### PR TITLE
changeCurrentProposer log improvement

### DIFF
--- a/apps/proposer/src/proposer.mjs
+++ b/apps/proposer/src/proposer.mjs
@@ -30,18 +30,22 @@ async function checkAndChangeProposer(nf3) {
       if (currentSprint === '0') {
         let spanProposersList = [];
         for (let i = 0; i < sprintInSpan; i++) {
-          spanProposersList.push(nf3.spanProposersList(i))
+          spanProposersList.push(nf3.spanProposersList(i));
         }
         spanProposersList = await Promise.all(spanProposersList);
         logger.info(`list of next proposer: ${spanProposersList}`);
       }
-      logger.info(`Next proposer address: ${spanProposersListAtPosition} and sprint: ${currentSprint}`);
+      logger.info(
+        `Next proposer address: ${spanProposersListAtPosition} and sprint: ${currentSprint}`,
+      );
       try {
         if (spanProposersListAtPosition === nf3.ethereumAddress) {
           logger.info(`${nf3.ethereumAddress} is Calling changeCurrentProposer`);
           await nf3.changeCurrentProposer();
         } else if (currentBlock - proposerStartBlock >= rotateProposerBlocks * MAX_ROTATE_TIMES) {
-          logger.info(`${nf3.ethereumAddress} is not the next proposer and is Calling changeCurrentProposer`);
+          logger.info(
+            `${nf3.ethereumAddress} is not the next proposer and is Calling changeCurrentProposer`,
+          );
           await nf3.changeCurrentProposer();
         }
       } catch (err) {

--- a/apps/proposer/src/proposer.mjs
+++ b/apps/proposer/src/proposer.mjs
@@ -27,7 +27,7 @@ async function checkAndChangeProposer(nf3) {
 
     if (currentBlock - proposerStartBlock >= rotateProposerBlocks && numproposers > 1) {
       const spanProposersListAtPosition = await nf3.spanProposersList(currentSprint);
-      if (currentSprint === 0) {
+      if (currentSprint === '0') {
         let spanProposersList = [];
         for (let i = 0; i < sprintInSpan; i++) {
           spanProposersList.push(nf3.spanProposersList(i))

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -1562,6 +1562,16 @@ class Nf3 {
   async getNumProposers() {
     return this.stateContract.methods.getNumProposers().call();
   }
+
+  /**
+    getSprintsInSpan
+    @method
+    @async
+    @returns {uint256} A promise that resolves to the Ethereum call.
+    */
+  async getSprintsInSpan() {
+    return this.stateContract.methods.getSprintsInSpan().call();
+  }
 }
 
 export default Nf3;

--- a/test/unit/SmartContracts/state.unit.test.mjs
+++ b/test/unit/SmartContracts/state.unit.test.mjs
@@ -1258,6 +1258,13 @@ describe('State contract State functions', function () {
     await state.setStakeAccount(addr2.address, amount.mul(100000), challengeLocked);
     await state.setNumProposers(2);
 
+    const sprintInSpan = await state.getSprintsInSpan();
+    let spanProposersList = [];
+    for (let i = 0; i < sprintInSpan; i++) {
+      spanProposersList.push(state.spanProposersList(i))
+    }
+    console.log(`list of next proposer: ${await Promise.all(spanProposersList)}`);
+
     for (let i = 0; i < signers.length; i++) {
       await state.setProposer(signers[i].address, [
         signers[i].address,

--- a/test/unit/SmartContracts/state.unit.test.mjs
+++ b/test/unit/SmartContracts/state.unit.test.mjs
@@ -1259,9 +1259,9 @@ describe('State contract State functions', function () {
     await state.setNumProposers(2);
 
     const sprintInSpan = await state.getSprintsInSpan();
-    let spanProposersList = [];
+    const spanProposersList = [];
     for (let i = 0; i < sprintInSpan; i++) {
-      spanProposersList.push(state.spanProposersList(i))
+      spanProposersList.push(state.spanProposersList(i));
     }
     console.log(`list of next proposer: ${await Promise.all(spanProposersList)}`);
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
added some logs to see the list of proposers at sprint 0 and the next proposer at each sprint

## What commands can I run to test the change? 
./bin/start-multiproposer-test-env -g
docker logs -f proposer_1
docker logs -f proposer_2


