### PR TITLE
Fixing deep rollbacks

### DIFF
--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -66,7 +66,10 @@ async function blockProposedEventHandler(data, syncing) {
     let isDecrypted = false;
     // In order to check if the transaction is a transfer, we check if the compressed secrets
     // are different than zero. All other transaction types have compressedSecrets = [0,0]
-    if (transaction.compressedSecrets[0] !== ZERO || transaction.compressedSecrets[1] !== ZERO) {
+    if (
+      (transaction.compressedSecrets[0] !== ZERO || transaction.compressedSecrets[1] !== ZERO) &&
+      !countOfNonZeroCommitments
+    ) {
       const transactionDecrypted = await decryptCommitment(
         transaction,
         zkpPrivateKeys,

--- a/nightfall-client/src/services/commitment-sync.mjs
+++ b/nightfall-client/src/services/commitment-sync.mjs
@@ -54,7 +54,11 @@ export async function decryptCommitment(transaction, zkpPrivateKey, nullifierKey
     }
   });
 
-  return Promise.all(storeCommitments);
+  const commitmentsStored = await Promise.all(storeCommitments);
+  if (commitmentsStored.length > 0) {
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -67,9 +71,10 @@ export async function clientCommitmentSync(zkpPrivateKey, nullifierKey) {
     // filter out non zero commitments and nullifiers
     const nonZeroCommitments = transactions[i].commitments.filter(n => n !== ZERO);
     // In order to check if the transaction is a transfer, we check if the compressed secrets
-    // are different than zero. All other transaction types have compressedSecrets = [0,0]
+    // are different than zero. All other transaction types have compressedSecrets = [ZERO,ZERO]
     if (
-      (transactions[i].compressedSecrets[0] !== 0 || transactions[i].compressedSecrets[1] !== 0) &&
+      (transactions[i].compressedSecrets[0] !== ZERO ||
+        transactions[i].compressedSecrets[1] !== ZERO) &&
       countCommitments([nonZeroCommitments[0]]) === 0
     )
       decryptCommitment(transactions[i], zkpPrivateKey, nullifierKey);

--- a/nightfall-optimist/src/event-handlers/rollback.mjs
+++ b/nightfall-optimist/src/event-handlers/rollback.mjs
@@ -64,7 +64,7 @@ async function rollbackEventHandler(data) {
     );
     logger.info({
       msg: 'Rollback - blockTransactions to check:',
-      blockTransactions,
+      blockTransactions: blockTransactions.map(t => t.transactionHash),
     });
 
     const transactionsSortedByFee = blockTransactions.sort((tx1, tx2) =>
@@ -80,7 +80,7 @@ async function rollbackEventHandler(data) {
         await checkTransaction({
           transaction,
           checkDuplicatesInL2: true,
-          blockNumberL2: blockNumber,
+          transactionBlockNumberL2: blockNumber,
         });
 
         for (let k = 0; k < transaction.commitments.length; k++) {

--- a/nightfall-optimist/src/event-handlers/rollback.mjs
+++ b/nightfall-optimist/src/event-handlers/rollback.mjs
@@ -81,6 +81,7 @@ async function rollbackEventHandler(data) {
           transaction,
           checkDuplicatesInL2: true,
           transactionBlockNumberL2: blockNumber,
+          lastValidBlockNumberL2: blockNumberL2 - 1,
         });
 
         for (let k = 0; k < transaction.commitments.length; k++) {

--- a/nightfall-optimist/src/services/check-block.mjs
+++ b/nightfall-optimist/src/services/check-block.mjs
@@ -258,7 +258,7 @@ export async function checkBlock(block, transactions) {
       await checkTransaction({
         transaction,
         checkDuplicatesInL2: true,
-        blockNumberL2: block.blockNumberL2,
+        transactionBlockNumberL2: block.blockNumberL2,
       }); // eslint-disable-line no-await-in-loop
     }
   } catch (err) {

--- a/nightfall-optimist/src/services/transaction-checker.mjs
+++ b/nightfall-optimist/src/services/transaction-checker.mjs
@@ -157,6 +157,8 @@ async function checkHistoricRootBlockNumber(transaction, lastValidBlockNumberL2)
     latestBlockNumberL2 = Number((await stateInstance.methods.getNumberOfL2Blocks().call()) - 1);
   }
 
+  logger.debug({ msg: `Latest valid block number in L2`, latestBlockNumberL2 });
+
   transaction.historicRootBlockNumberL2.forEach((blockNumberL2, i) => {
     if (transaction.nullifiers[i] === ZERO) {
       if (Number(blockNumberL2) !== 0) {
@@ -164,10 +166,16 @@ async function checkHistoricRootBlockNumber(transaction, lastValidBlockNumberL2)
           transactionHash: transaction.transactionHash,
         });
       }
-    } else if (Number(blockNumberL2) >= latestBlockNumberL2) {
-      throw new TransactionError('Historic root has block number L2 greater than on chain', 3, {
-        transactionHash: transaction.transactionHash,
-      });
+    } else if (Number(blockNumberL2) > latestBlockNumberL2) {
+      throw new TransactionError(
+        `Historic root block number, which is ${Number(
+          blockNumberL2,
+        )}, has block number L2 greater than on chain, which is ${latestBlockNumberL2}`,
+        3,
+        {
+          transactionHash: transaction.transactionHash,
+        },
+      );
     }
   });
 }

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -204,7 +204,7 @@ describe('Testing with an adversary', () => {
     currentRollbacks = rollbackCount;
   });
 
-  describe.skip('Testing block zero challenges', async () => {
+  describe('Testing block zero challenges', async () => {
     before(async () => {
       await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
     });
@@ -233,26 +233,27 @@ describe('Testing with an adversary', () => {
   });
 
   describe('Testing optimist deep rollbacks', async () => {
+    const userL2BalanceBefore = await getLayer2BalancesBadClient(ercAddress);
+    const user2L2BalanceBefore = await getLayer2Balances(nf3User2, ercAddress);
+
     before(async () => {
-      await nf3User2.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
+      await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
       await makeBlock();
       await waitForTimeout(10000);
     });
     it('Deep rollback', async () => {
       console.log('Testing deep rollback at distance 2...');
-      const userL2BalanceBefore = await getLayer2BalancesBadClient(ercAddress);
-      const user2L2BalanceBefore = await getLayer2Balances(nf3User2, ercAddress);
 
       await enableChallenger(false);
-      await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
-      await nf3User2.transfer(
+      await nf3User2.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
+      await nf3User.transfer(
         'ValidTransaction',
         false,
         ercAddress,
         tokenType,
         transferValue / 2,
         tokenId,
-        nf3User.zkpKeys.compressedZkpPublicKey,
+        nf3User2.zkpKeys.compressedZkpPublicKey,
         0,
       );
       await nf3User.deposit('IncorrectInput', ercAddress, tokenType, transferValue, tokenId, 0);
@@ -262,14 +263,14 @@ describe('Testing with an adversary', () => {
       });
 
       await makeBlock('IncorrectTreeRoot');
-      await nf3User.transfer(
+      await nf3User2.transfer(
         'ValidTransaction',
         false,
         ercAddress,
         tokenType,
         transferValue,
         tokenId,
-        nf3User2.zkpKeys.compressedZkpPublicKey,
+        nf3User.zkpKeys.compressedZkpPublicKey,
         0,
       );
       await makeBlock();
@@ -282,7 +283,7 @@ describe('Testing with an adversary', () => {
       const numberTxs = mempool.filter(e => e.mempool).length;
       expect(numberTxs).to.be.equal(2);
 
-      await nf3User2.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
+      await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
 
       await waitForSufficientTransactionsMempool({
         optimistBaseUrl: environment.adversarialOptimistApiUrl,

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -18,18 +18,30 @@ import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
 // eslint-disable-next-line import/no-unresolved
 import Nf3 from './adversary/adversary-cli/lib/nf3.mjs';
 
-import { clearMempool, registerProposerOnNoProposer, Web3Client } from './utils.mjs';
+import {
+  clearMempool,
+  getLayer2Balances,
+  registerProposerOnNoProposer,
+  restartOptimist,
+  waitForSufficientTransactionsMempool,
+  waitForTimeout,
+  Web3Client,
+} from './utils.mjs';
 
 chai.use(chaiHttp);
 chai.use(chaiAsPromised);
 
 const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
 
-const { fee } = config.TEST_OPTIONS;
+const {
+  fee,
+  signingKeys,
+  mnemonics,
+  tokenConfigs: { tokenType, tokenId },
+  transferValue,
+} = config.TEST_OPTIONS;
 
 const web3Client = new Web3Client();
-
-let stateAddress;
 const eventLogs = [];
 
 const challengeSelectors = {
@@ -52,41 +64,51 @@ const {
   ...others
 } = environment;
 
-async function makeBlockNow(badBlockType) {
+const nf3User = new Nf3(signingKeys.user1, {
+  ...others,
+  clientApiUrl: adversarialClientApiUrl,
+  clientWsUrl: adversarialClientWsUrl,
+});
+const nf3User2 = new Nf3(signingKeys.user2, environment);
+
+const nf3AdversarialProposer = new Nf3(signingKeys.proposer1, {
+  ...others,
+  optimistApiUrl: adversarialOptimistApiUrl,
+  optimistWsUrl: adversarialOptimistWsUrl,
+});
+
+const nf3Challenger = new Nf3(signingKeys.challenger, environment);
+
+async function makeBlock(badBlockType) {
+  logger.debug(`Make block...`);
   if (badBlockType) {
     await axios.get(`${adversarialOptimistApiUrl}/block/make-now/${badBlockType}`);
   } else {
     await axios.get(`${adversarialOptimistApiUrl}/block/make-now`);
   }
+  await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+}
+
+async function getLayer2BalancesBadClient(ercAddress) {
+  const res = await axios.get(`${adversarialClientApiUrl}/commitment/balance`, {
+    params: {
+      compressedZkpPublicKey: nf3User.zkpKeys.compressedZkpPublicKey,
+    },
+  });
+  return res.data.balance[ercAddress]?.[0].balance || 0;
+}
+
+async function enableChallenger(enable) {
+  await axios.post(`${optimistApiUrl}/challenger/enable`, { enable });
 }
 
 describe('Testing with an adversary', () => {
-  let nf3User;
-  let nf3AdversarialProposer;
   let blockProposeEmitter;
   let challengeEmitter;
   let ercAddress;
-  let nf3Challenger;
+  let stateAddress;
   let intervalId;
 
-  // this is the etherum private key for accounts[0] and so on
-  const ethereumSigningKeyUser =
-    '0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69e';
-  const ethereumSigningKeyProposer =
-    '0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69d';
-  const ethereumSigningKeyChallenger =
-    '0xd42905d0582c476c4b74757be6576ec323d715a0c7dcff231b6348b7ab0190eb';
-  const mnemonicUser =
-    'trip differ bamboo bundle bonus luxury strike mad merry muffin nose auction';
-  const mnemonicProposer =
-    'high return hold whale promote payment hat panel reduce oyster ramp mouse';
-  const mnemonicChallenger =
-    'heart bless cream into jacket purpose very sentence saddle sea bird abuse';
-  const tokenId = '0x00'; // has to be zero for ERC20
-  const tokenType = 'ERC20'; // it can be 'ERC721' or 'ERC1155'
-  // const value = 10;
-  // const value1 = 1000;
-  const value2 = 5;
   let rollbackCount = 0;
   let currentRollbacks = 0;
   let challengeSelector;
@@ -108,41 +130,24 @@ describe('Testing with an adversary', () => {
 
   before(async () => {
     console.log('ENV:\n', environment);
-    nf3User = new Nf3(ethereumSigningKeyUser, {
-      ...others,
-      clientApiUrl: adversarialClientApiUrl,
-    });
 
-    nf3AdversarialProposer = new Nf3(ethereumSigningKeyProposer, {
-      ...others,
-      optimistApiUrl: adversarialOptimistApiUrl,
-      optimistWsUrl: adversarialOptimistWsUrl,
-    });
-
-    nf3Challenger = new Nf3(ethereumSigningKeyChallenger, {
-      ...others,
-      optimistApiUrl,
-      optimistWsUrl,
-    });
-
-    // Generate a random mnemonic (uses crypto.randomBytes under the hood), defaults to 128-bits of entropy
-    await nf3User.init(mnemonicUser);
-    await nf3AdversarialProposer.init(mnemonicProposer);
-    await nf3Challenger.init(mnemonicChallenger);
+    await nf3User.init(mnemonics.user1);
+    await nf3User2.init(mnemonics.user2);
+    await nf3AdversarialProposer.init(mnemonics.proposer);
+    await nf3Challenger.init(mnemonics.challenger);
 
     if (!(await nf3User.healthcheck('client'))) throw new Error('Healthcheck failed');
+    if (!(await nf3User2.healthcheck('client'))) throw new Error('Healthcheck failed');
     if (!(await nf3AdversarialProposer.healthcheck('optimist')))
       throw new Error('Healthcheck failed');
     if (!(await nf3Challenger.healthcheck('optimist'))) throw new Error('Healthcheck failed');
-
-    // retrieve initial balance
-    ercAddress = await nf3User.getContractAddress('ERC20Mock');
 
     // Proposer registration
     await nf3AdversarialProposer.registerProposer(
       'http://optimist',
       await nf3AdversarialProposer.getMinimumStake(),
     );
+
     // Proposer listening for incoming events
     blockProposeEmitter = await nf3AdversarialProposer.startProposer();
     blockProposeEmitter
@@ -189,6 +194,8 @@ describe('Testing with an adversary', () => {
         );
       });
 
+    // retrieve initial balance
+    ercAddress = await nf3User.getContractAddress('ERC20Mock');
     stateAddress = await nf3User.stateContractAddress;
     web3Client.subscribeTo('logs', eventLogs, { address: stateAddress });
   });
@@ -199,28 +206,89 @@ describe('Testing with an adversary', () => {
 
   describe('Testing block zero challenges', async () => {
     before(async () => {
-      await nf3User.deposit('ValidTransaction', ercAddress, tokenType, value2, tokenId, 0);
+      await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
     });
 
     it('Challenging block zero for having an invalid leaf count', async () => {
       console.log('Testing incorrect leaf count in block zero...');
-      await makeBlockNow('IncorrectLeafCount');
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await makeBlock('IncorrectLeafCount');
       await waitForRollback();
       expect(challengeSelector).to.be.equal(challengeSelectors.challengeLeafCount);
     });
 
     it('Challenging block zero for having an invalid frontier hash', async () => {
       console.log('Testing incorrect frontier hash in block zero...');
-      await makeBlockNow('IncorrectFrontierHash');
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await makeBlock('IncorrectFrontierHash');
       await waitForRollback();
       expect(challengeSelector).to.be.equal(challengeSelectors.challengeFrontier);
     });
 
     after(async () => {
-      await makeBlockNow();
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await makeBlock();
+    });
+  });
+
+  describe('Testing optimist deep rollbacks', async () => {
+    before(async () => {
+      await nf3User2.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
+      await makeBlock();
+      await waitForTimeout(10000);
+    });
+    it('Deep rollback', async () => {
+      console.log('Testing deep rollback at distance 2...');
+      await enableChallenger(false);
+      await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
+      await nf3User2.transfer(
+        'ValidTransaction',
+        false,
+        ercAddress,
+        tokenType,
+        transferValue / 2,
+        tokenId,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+        0,
+      );
+      await nf3User.deposit('IncorrectInput', ercAddress, tokenType, transferValue, tokenId, 0);
+      await waitForSufficientTransactionsMempool({
+        optimistBaseUrl: environment.adversarialOptimistApiUrl,
+        nTransactions: 3,
+      });
+
+      await makeBlock('IncorrectTreeRoot');
+      await nf3User.transfer(
+        'ValidTransaction',
+        false,
+        ercAddress,
+        tokenType,
+        transferValue,
+        tokenId,
+        nf3User2.zkpKeys.compressedZkpPublicKey,
+        0,
+      );
+      await makeBlock();
+      await restartOptimist(nf3Challenger);
+      await waitForRollback();
+
+      const { result: mempool } = (
+        await axios.get(`${environment.optimistApiUrl}/proposer/mempool`)
+      ).data;
+      const numberTxs = mempool.filter(e => e.mempool).length;
+      expect(numberTxs).to.be.equal(2);
+
+      await nf3User2.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
+
+      await waitForSufficientTransactionsMempool({
+        optimistBaseUrl: environment.adversarialOptimistApiUrl,
+        nTransactions: 3,
+      });
+
+      await makeBlock();
+
+      const userL2BalanceAfter = await getLayer2BalancesBadClient(ercAddress);
+      const user2L2BalanceAfter = await getLayer2Balances(nf3User2, ercAddress);
+
+      expect(userL2BalanceAfter).to.be.equal(transferValue + transferValue / 2);
+      expect(user2L2BalanceAfter).to.be.equal(transferValue + transferValue / 2);
     });
   });
 
@@ -228,27 +296,31 @@ describe('Testing with an adversary', () => {
     describe('Deposits rollback', async () => {
       it('Test duplicate transaction deposit', async () => {
         console.log('Testing duplicate transaction deposit...');
-        await nf3User.deposit('ValidTransaction', ercAddress, tokenType, value2, tokenId, fee);
-        await makeBlockNow('DuplicateTransaction');
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await nf3User.deposit(
+          'ValidTransaction',
+          ercAddress,
+          tokenType,
+          transferValue,
+          tokenId,
+          fee,
+        );
+        await makeBlock('DuplicateTransaction');
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeCommitment);
       });
 
       it('Test failing incorrect input deposit', async () => {
         console.log('Testing incorrect input deposit...');
-        await nf3User.deposit('IncorrectInput', ercAddress, tokenType, value2, tokenId, 0);
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await nf3User.deposit('IncorrectInput', ercAddress, tokenType, transferValue, tokenId, 0);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
 
       it('Test failing incorrect proof deposit', async () => {
         console.log('Testing incorrect proof deposit...');
-        await nf3User.deposit('IncorrectProof', ercAddress, tokenType, value2, tokenId, 0);
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await nf3User.deposit('IncorrectProof', ercAddress, tokenType, transferValue, tokenId, 0);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
@@ -256,9 +328,8 @@ describe('Testing with an adversary', () => {
 
     describe('Transfers rollback', async () => {
       beforeEach(async () => {
-        await nf3User.deposit('ValidTransaction', ercAddress, tokenType, value2, tokenId, 0);
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
+        await makeBlock();
       });
 
       it('Test duplicate transaction transfer', async () => {
@@ -268,13 +339,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.zkpKeys.compressedZkpPublicKey,
           fee,
         );
-        await makeBlockNow('DuplicateTransaction');
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock('DuplicateTransaction');
         await waitForRollback();
         expect(challengeSelector).to.be.oneOf([
           challengeSelectors.challengeCommitment,
@@ -289,13 +359,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.zkpKeys.compressedZkpPublicKey,
           0,
         );
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeNullifier);
       });
@@ -307,13 +376,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.zkpKeys.compressedZkpPublicKey,
           0,
         );
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
@@ -324,13 +392,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.zkpKeys.compressedZkpPublicKey,
           0,
         );
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
@@ -342,13 +409,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.zkpKeys.compressedZkpPublicKey,
           0,
         );
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeHistoricRoot);
       });
@@ -356,9 +422,8 @@ describe('Testing with an adversary', () => {
 
     describe('Withdraw rollbacks', async () => {
       beforeEach(async () => {
-        await nf3User.deposit('ValidTransaction', ercAddress, tokenType, value2, tokenId, 0);
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
+        await makeBlock();
       });
 
       it('Test duplicate transaction withdraw', async () => {
@@ -368,13 +433,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.ethereumAddress,
           fee,
         );
-        await makeBlockNow('DuplicateTransaction');
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock('DuplicateTransaction');
         await waitForRollback();
         expect(challengeSelector).to.be.oneOf([
           challengeSelectors.challengeCommitment,
@@ -389,13 +453,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.ethereumAddress,
           0,
         );
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeNullifier);
       });
@@ -407,13 +470,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.ethereumAddress,
           0,
         );
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
@@ -425,13 +487,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.ethereumAddress,
           0,
         );
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
@@ -443,13 +504,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.ethereumAddress,
           0,
         );
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeHistoricRoot);
       });
@@ -466,36 +526,32 @@ describe('Testing with an adversary', () => {
 
   describe('Testing bad blocks', async () => {
     before(async () => {
-      await nf3User.deposit('ValidTransaction', ercAddress, tokenType, value2, tokenId, 0);
+      await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
     });
 
     it('Test incorrect leaf count', async () => {
       console.log('Testing incorrect leaf count...');
-      await makeBlockNow('IncorrectLeafCount');
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await makeBlock('IncorrectLeafCount');
       await waitForRollback();
       expect(challengeSelector).to.be.equal(challengeSelectors.challengeLeafCount);
     });
 
     it('Test incorrect tree root', async () => {
       console.log('Testing incorrect tree root...');
-      await makeBlockNow('IncorrectTreeRoot');
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await makeBlock('IncorrectTreeRoot');
       await waitForRollback();
       expect(challengeSelector).to.be.equal(challengeSelectors.challengeRoot);
     });
 
     it('Test incorrect frontier hash', async () => {
       console.log('Testing incorrect frontier hash...');
-      await makeBlockNow('IncorrectFrontierHash');
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await makeBlock('IncorrectFrontierHash');
       await waitForRollback();
       expect(challengeSelector).to.be.equal(challengeSelectors.challengeFrontier);
     });
 
     after(async () => {
-      await makeBlockNow();
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await makeBlock();
     });
   });
 

--- a/test/adversary/adversary-code/incorrectTransactions.mjs
+++ b/test/adversary/adversary-code/incorrectTransactions.mjs
@@ -25,6 +25,7 @@ if (transactionType === 'IncorrectInput') {
     transaction[selectedKey] = modifiedValue;
   }
 
+  transaction.transactionHash = Transaction.calcHash(transaction);
   logger.debug({
     msg: 'Transaction after modification',
     transaction,
@@ -32,8 +33,10 @@ if (transactionType === 'IncorrectInput') {
 } else if (transactionType === 'IncorrectProof') {
   transaction.proof[0] = generalise(Math.floor(Math.random() * 2 ** 32)).hex(32);
 
+  transaction.transactionHash = Transaction.calcHash(transaction);
   logger.debug({
     msg: 'Transaction after modification',
     transaction,
   });
+  transaction.transactionHash = Transaction.calcHash(transaction);
 }

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -468,7 +468,10 @@ describe('ERC20 tests', () => {
           0,
         );
 
-        await waitForSufficientTransactionsMempool({ nf3User, nTransactions: 6 });
+        await waitForSufficientTransactionsMempool({
+          optimistBaseUrl: environment.optimistApiUrl,
+          nTransactions: 6,
+        });
 
         await nf3Proposer.makeBlockNow();
         await waitForSufficientBalance({

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -5,6 +5,8 @@ import Web3 from 'web3';
 import chai from 'chai';
 import config from 'config';
 import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
+import compose from 'docker-compose';
+import mongo from '@polygon-nightfall/common-files/utils/mongo.mjs';
 import { rand } from '@polygon-nightfall/common-files/utils/crypto/crypto-random.mjs';
 
 const { expect } = chai;
@@ -478,10 +480,12 @@ export const waitForSufficientBalance = ({ nf3User, value, ercAddress }) => {
 /**
   function to wait for a number of transactions in the mempool before creating block
 */
-export const waitForSufficientTransactionsMempool = ({ nf3User, nTransactions }) => {
+export const waitForSufficientTransactionsMempool = ({ optimistBaseUrl, nTransactions }) => {
   return new Promise(resolve => {
     async function isSufficientTransactions() {
-      const numberTxs = await nf3User.unprocessedTransactionCount();
+      const { result: mempool } = (await axios.get(`${optimistBaseUrl}/proposer/mempool`)).data;
+      const numberTxs = mempool.filter(e => e.mempool).length;
+
       logger.debug(
         ` Waiting for ${nTransactions} to create a block. Current transactions: ${numberTxs}`,
       );
@@ -555,4 +559,77 @@ export async function getUserCommitments(clientApiUrl, compressedZkpPublicKey) {
         value: c.preimage.value,
       };
     });
+}
+
+// setup a healthcheck wait
+const healthy = async nf3Proposer => {
+  while (!(await nf3Proposer.healthcheck('optimist'))) {
+    await waitForTimeout(1000);
+  }
+
+  logger.debug('optimist is healthy');
+};
+
+const dropOptimistMongoDatabase = async () => {
+  logger.debug(`Dropping Optimist's Mongo database`);
+  let mongoConn;
+  try {
+    mongoConn = await mongo.connection('mongodb://localhost:27017');
+
+    while (!(await mongoConn.db('optimist_data').dropDatabase())) {
+      logger.debug(`Retrying dropping MongoDB`);
+      await waitForTimeout(2000);
+    }
+
+    logger.debug(`Optimist's Mongo database dropped successfuly!`);
+  } finally {
+    mongo.disconnect();
+  }
+};
+
+const dropOptimistMongoBlocksCollection = async () => {
+  logger.debug(`Dropping Optimist's Mongo collection`);
+  let mongoConn;
+  try {
+    mongoConn = await mongo.connection('mongodb://localhost:27017');
+
+    while (!(await mongoConn.db('optimist_data').collection('blocks').drop())) {
+      logger.debug(`Retrying dropping MongoDB blocks colection`);
+      await waitForTimeout(2000);
+    }
+    while (!(await mongoConn.db('optimist_data').collection('timber').drop())) {
+      logger.debug(`Retrying dropping MongoDB timber colection`);
+      await waitForTimeout(2000);
+    }
+
+    logger.debug(`Optimist's Mongo blocks dropped successfuly!`);
+  } finally {
+    mongo.disconnect();
+  }
+};
+
+export async function restartOptimist(nf3Proposer, dropDb = true) {
+  const options = {
+    config: [
+      'docker/docker-compose.yml',
+      'docker/docker-compose.dev.yml',
+      'docker/docker-compose.ganache.yml',
+    ],
+    log: process.env.LOG_LEVEL || 'silent',
+    composeOptions: [['-p', 'nightfall_3']],
+  };
+
+  await compose.stopOne('optimist', options);
+  await compose.rm(options, 'optimist');
+
+  // dropDb vs dropCollection.
+  if (dropDb) {
+    await dropOptimistMongoDatabase();
+  } else {
+    await dropOptimistMongoBlocksCollection();
+  }
+
+  await compose.upOne('optimist', options);
+
+  await healthy(nf3Proposer);
 }

--- a/wallet/src/nightfall-browser/event-handlers/block-proposed.js
+++ b/wallet/src/nightfall-browser/event-handlers/block-proposed.js
@@ -45,7 +45,7 @@ async function blockProposedEventHandler(data, zkpPrivateKeys, nullifierKeys) {
 
   const dbUpdates = transactions.map(async transaction => {
     // filter out non zero commitments and nullifiers
-    const nonZeroCommitments = transaction.commitments.filter(n => n !== ZERO);
+    const nonZeroCommitments = transaction.commitments.filter(c => c !== ZERO);
     const nonZeroNullifiers = transaction.nullifiers.filter(n => n !== ZERO);
 
     const countOfNonZeroCommitments = await countCommitments([nonZeroCommitments[0]]);
@@ -53,9 +53,9 @@ async function blockProposedEventHandler(data, zkpPrivateKeys, nullifierKeys) {
     const storeCommitments = [];
     const tempTransactionStore = [];
     // In order to check if the transaction is a transfer, we check if the compressed secrets
-    // are different than zero. All other transaction types have compressedSecrets = [0,0]
+    // are different than zero. All other transaction types have compressedSecrets = [ZERO,ZERO]
     if (
-      (transaction.compressedSecrets[0] !== 0 || transaction.compressedSecrets[1] !== 0) &&
+      (transaction.compressedSecrets[0] !== ZERO || transaction.compressedSecrets[1] !== ZERO) &&
       !countOfNonZeroCommitments
     ) {
       zkpPrivateKeys.forEach((key, i) => {
@@ -94,6 +94,7 @@ async function blockProposedEventHandler(data, zkpPrivateKeys, nullifierKeys) {
               saveTransaction({
                 transactionHashL1,
                 ...transaction,
+                isDecrypted: true,
               }),
             );
           }

--- a/wallet/src/nightfall-browser/event-handlers/subscribe.js
+++ b/wallet/src/nightfall-browser/event-handlers/subscribe.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-await-in-loop */
 
 // ignore unused exports startEventQueue
+// ignore unused exports waitForContract
 
 /**
  * Module to subscribe to blockchain events
@@ -22,7 +23,7 @@ const { RETRIES } = global.config;
  * This is useful in case nightfall-client comes up before the contract
  * is fully deployed.
  */
-async function waitForContract(contractName) {
+export async function waitForContract(contractName) {
   let errorCount = 0;
   let error;
   let instance;

--- a/wallet/src/nightfall-browser/services/database.js
+++ b/wallet/src/nightfall-browser/services/database.js
@@ -338,3 +338,23 @@ export async function setTransactionHashSiblingInfo(
   }
   return null;
 }
+
+/**
+function to find transactions with a transactionHash in the array transactionHashes.
+*/
+export async function getTransactionsByTransactionHashesByL2Block(transactionHashes, block) {
+  const db = await connectDB();
+  const res = await db.getAll(TRANSACTIONS_COLLECTION);
+  const filteredTransactions = res.filter(
+    t => t.blockNumberL2 === block.blockNumberL2 && transactionHashes.includes(t.transactionHash),
+  );
+  // Create a dictionary where we will store the correct position ordering
+  const positions = {};
+  // Use the ordering of txHashes in the block to fill the dictionary-indexed by txHash
+  // eslint-disable-next-line no-return-assign
+  transactionHashes.forEach((t, index) => (positions[t] = index));
+  const transactions = filteredTransactions.sort(
+    (a, b) => positions[a.transactionHash] - positions[b.transactionHash],
+  );
+  return transactions;
+}


### PR DESCRIPTION
This PR fixes deep rollbacks in both, optimist and client. We can assume that a deep rollbacks are any rollbacks that doesn't take place just after the bad block was introduced but a few blocks after.

When a deep rollback happens, we will consider the following:
- Bad transactions are removed (for obvious reasons)
- If all nullifiers are commitments that were added prior to the rollback, the transaction is considered valid. Otherwise, the transaction is removed from the mempool.

In order to fix deep rollbacks in the optimist, the check for historic root block number has been modified. So, instead of relying on the database, it will rely on the blockchain to get the latest valid block number.

The rollback in the client has been completely rewritten to work with this new logic. Some other minor errors found in the code, such as considering that the return of an `await Promise.all` is truthy, has been fixed.

Client is only keeping track of their own commitments and transactions. When doing a rollback, the client assumes that all his transactions are valid as long as the historic root condition mentioned above holds. However, the client can not assume the validity of transfer transactions that has been sent to him. Therefore, when decrypting a transaction this is specified in the DB and if a rollback happens this transaction (and the commitment decrypted) are deleted. This is fine since, if the transaction was valid, an optimist will kept it in the mempool and when is put in a new block the client will store it back again.

A test has been created to make sure that both, optimist and client, are handling the rollback properly. One can test it by running the adversary tests.

I've tried to also implement the changes to the wallet, but I have not tested it since right now is not a priority


