### PR TITLE
Fixing Rollbacks edge case for deposits

### DIFF
--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -574,7 +574,8 @@ class Nf3 {
     value,
     tokenId,
     fee = this.defaultFeeTokenValue,
-    providedCommitmentsFee,
+    providedCommitmentsFee = [],
+    salt = undefined,
   ) {
     let txDataToSign;
     try {
@@ -605,6 +606,7 @@ class Nf3 {
       rootKey: this.zkpKeys.rootKey,
       fee,
       providedCommitmentsFee,
+      salt,
     });
 
     if (res.data.error) {

--- a/docker/docker-compose.ganache.yml
+++ b/docker/docker-compose.ganache.yml
@@ -9,7 +9,7 @@ services:
       - 8546:8546
     command:
       ganache-cli --accounts=10 --defaultBalanceEther=1000 --gasLimit=0x3B9ACA00 --deterministic -i
-      1337 -p 8546 -b 1
+      1337 -p 8546 -b 1 -q
       --account="0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69e,10000000000000000000000"
       --account="0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69d,10000000000000000000000"
       --account="0xd42905d0582c476c4b74757be6576ec323d715a0c7dcff231b6348b7ab0190eb,10000000000000000000000"

--- a/docker/docker-compose.ganache.yml
+++ b/docker/docker-compose.ganache.yml
@@ -9,7 +9,7 @@ services:
       - 8546:8546
     command:
       ganache-cli --accounts=10 --defaultBalanceEther=1000 --gasLimit=0x3B9ACA00 --deterministic -i
-      1337 -p 8546 -b 1 -q
+      1337 -p 8546 -b 1
       --account="0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69e,10000000000000000000000"
       --account="0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69d,10000000000000000000000"
       --account="0xd42905d0582c476c4b74757be6576ec323d715a0c7dcff231b6348b7ab0190eb,10000000000000000000000"

--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -66,7 +66,10 @@ async function blockProposedEventHandler(data, syncing) {
     let isDecrypted = false;
     // In order to check if the transaction is a transfer, we check if the compressed secrets
     // are different than zero. All other transaction types have compressedSecrets = [0,0]
-    if (transaction.compressedSecrets[0] !== ZERO || transaction.compressedSecrets[1] !== ZERO) {
+    if (
+      (transaction.compressedSecrets[0] !== ZERO || transaction.compressedSecrets[1] !== ZERO) &&
+      !countOfNonZeroCommitments
+    ) {
       const transactionDecrypted = await decryptCommitment(
         transaction,
         zkpPrivateKeys,

--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -106,17 +106,10 @@ async function blockProposedEventHandler(data, syncing) {
 
     return Promise.all([
       saveTxToDb,
-      markOnChain(
-        nonZeroCommitments,
-        block.blockNumberL2,
-        transaction.transactionHash,
-        data.blockNumber,
-        data.transactionHash,
-      ),
+      markOnChain(nonZeroCommitments, block.blockNumberL2, data.blockNumber, data.transactionHash),
       markNullifiedOnChain(
         nonZeroNullifiers,
         block.blockNumberL2,
-        transaction.transactionHash,
         data.blockNumber,
         data.transactionHash,
       ),

--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -106,10 +106,17 @@ async function blockProposedEventHandler(data, syncing) {
 
     return Promise.all([
       saveTxToDb,
-      markOnChain(nonZeroCommitments, block.blockNumberL2, data.blockNumber, data.transactionHash),
+      markOnChain(
+        nonZeroCommitments,
+        block.blockNumberL2,
+        transaction.transactionHash,
+        data.blockNumber,
+        data.transactionHash,
+      ),
       markNullifiedOnChain(
         nonZeroNullifiers,
         block.blockNumberL2,
+        transaction.transactionHash,
         data.blockNumber,
         data.transactionHash,
       ),

--- a/nightfall-client/src/event-handlers/rollback.mjs
+++ b/nightfall-client/src/event-handlers/rollback.mjs
@@ -50,7 +50,6 @@ async function rollbackEventHandler(data) {
   logger.info({ msg: 'Rollback - rollback layer 2 blocks', blocksToBeDeleted });
 
   const validTransactions = [];
-  const validCommitments = [];
 
   const invalidTransactions = [];
   const invalidNullifiers = [];
@@ -101,7 +100,6 @@ async function rollbackEventHandler(data) {
       }
 
       validTransactions.push(transaction.transactionHash);
-      validCommitments.push(...commitments);
     }
   }
 
@@ -112,8 +110,7 @@ async function rollbackEventHandler(data) {
   });
 
   logger.debug({
-    msg: 'Updating commitments && nullifiers',
-    validCommitments,
+    msg: 'Invalid commitments && nullifiers',
     invalidCommitments,
     invalidNullifiers,
   });
@@ -122,9 +119,9 @@ async function rollbackEventHandler(data) {
     deleteTreeByBlockNumberL2(Number(blockNumberL2)),
     deleteBlocksByBlockNumberL2(Number(blockNumberL2)),
     clearNullifiedOnChain(Number(blockNumberL2)),
+    clearOnChain(Number(blockNumberL2)),
     clearNullifiers(invalidNullifiers),
     deleteCommitments(invalidCommitments),
-    clearOnChain(validCommitments),
     deleteTransactionsByTransactionHashes(invalidTransactions),
   ]);
 }

--- a/nightfall-client/src/routes/commitment.mjs
+++ b/nightfall-client/src/routes/commitment.mjs
@@ -17,6 +17,7 @@ import {
   getCommitmentsByCompressedZkpPublicKeyList,
   insertCommitmentsAndResync,
   getCommitmentsByCircuitHash,
+  getCommitmentsDepositedRollbacked,
 } from '../services/commitment-storage.mjs';
 
 const router = express.Router();
@@ -131,6 +132,16 @@ router.get('/withdraws', async (req, res, next) => {
 
     const commitments = await getCommitmentsByCircuitHash(withdrawCircuitHash);
     res.json({ commitments });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/commitmentsRollbacked', async (req, res, next) => {
+  try {
+    const { compressedZkpPublicKey } = req.query;
+    const commitmentsRollbacked = await getCommitmentsDepositedRollbacked(compressedZkpPublicKey);
+    res.json({ commitmentsRollbacked });
   } catch (err) {
     next(err);
   }

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -1076,13 +1076,6 @@ export async function getCommitmentsDepositedRollbacked(compressedZkpPublicKey) 
     isOnChain: -1,
     isDeposited: true,
   };
-  console.log('DEBUG 0 ', await db.collection(COMMITMENTS_COLLECTION).find(query).toArray());
-  console.log(
-    'DEBUG 1',
-    await db
-      .collection(COMMITMENTS_COLLECTION)
-      .find({ compressedZkpPublicKey, isOnChain: -1, isDeposited: true })
-      .toArray(),
-  );
+
   return db.collection(COMMITMENTS_COLLECTION).find(query).toArray();
 }

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -1066,3 +1066,23 @@ export async function getCommitments() {
   const allCommitments = await db.collection(COMMITMENTS_COLLECTION).find().toArray();
   return allCommitments;
 }
+
+export async function getCommitmentsDepositedRollbacked(compressedZkpPublicKey) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(COMMITMENTS_DB);
+  const query = {
+    compressedZkpPublicKey,
+    commitmentTransactionHash: null,
+    isOnChain: -1,
+    isDeposited: true,
+  };
+  console.log('DEBUG 0 ', await db.collection(COMMITMENTS_COLLECTION).find(query).toArray());
+  console.log(
+    'DEBUG 1',
+    await db
+      .collection(COMMITMENTS_COLLECTION)
+      .find({ compressedZkpPublicKey, isOnChain: -1, isDeposited: true })
+      .toArray(),
+  );
+  return db.collection(COMMITMENTS_COLLECTION).find(query).toArray();
+}

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -360,7 +360,12 @@ export async function getWalletPendingDepositBalance(compressedZkpPublicKey, erc
   ercAddressList = ercAddressList.map(e => e.toUpperCase());
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(COMMITMENTS_DB);
-  const query = { isDeposited: true, isNullified: false, isOnChain: { $eq: -1 } };
+  const query = {
+    isDeposited: true,
+    isNullified: false,
+    isOnChain: { $eq: -1 },
+    isCommitmentInTransaction: true,
+  };
   const options = {
     compressedZkpPublicKey: 1,
     'preimage.ercAddress': 1,

--- a/nightfall-client/src/services/commitment-sync.mjs
+++ b/nightfall-client/src/services/commitment-sync.mjs
@@ -54,7 +54,11 @@ export async function decryptCommitment(transaction, zkpPrivateKey, nullifierKey
     }
   });
 
-  return Promise.all(storeCommitments);
+  const commitmentsStored = await Promise.all(storeCommitments);
+  if (commitmentsStored.length > 0) {
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -67,9 +71,10 @@ export async function clientCommitmentSync(zkpPrivateKey, nullifierKey) {
     // filter out non zero commitments and nullifiers
     const nonZeroCommitments = transactions[i].commitments.filter(n => n !== ZERO);
     // In order to check if the transaction is a transfer, we check if the compressed secrets
-    // are different than zero. All other transaction types have compressedSecrets = [0,0]
+    // are different than zero. All other transaction types have compressedSecrets = [ZERO,ZERO]
     if (
-      (transactions[i].compressedSecrets[0] !== 0 || transactions[i].compressedSecrets[1] !== 0) &&
+      (transactions[i].compressedSecrets[0] !== ZERO ||
+        transactions[i].compressedSecrets[1] !== ZERO) &&
       countCommitments([nonZeroCommitments[0]]) === 0
     )
       decryptCommitment(transactions[i], zkpPrivateKey, nullifierKey);

--- a/nightfall-client/src/services/commitment-sync.mjs
+++ b/nightfall-client/src/services/commitment-sync.mjs
@@ -50,9 +50,7 @@ export async function decryptCommitment(transaction, zkpPrivateKey, nullifierKey
           commitment,
           transactionHash: transaction.transactionHash,
         });
-        storeCommitments.push(
-          storeCommitment(commitment, nullifierKey[j], transaction.transactionHash),
-        );
+        storeCommitments.push(storeCommitment(commitment, nullifierKey[j]));
       }
     } catch (err) {
       // This error will be caught regularly if the commitment isn't for us

--- a/nightfall-client/src/services/commitment-sync.mjs
+++ b/nightfall-client/src/services/commitment-sync.mjs
@@ -45,8 +45,14 @@ export async function decryptCommitment(transaction, zkpPrivateKey, nullifierKey
         salt: plainTexts[3].bigInt,
       });
       if (commitment.hash.hex(32) === nonZeroCommitments[0]) {
-        logger.info('Successfully decrypted commitment for this recipient');
-        storeCommitments.push(storeCommitment(commitment, nullifierKey[j]));
+        logger.info({
+          msg: 'Commitment successfully decrypted for this recipient',
+          commitment,
+          transactionHash: transaction.transactionHash,
+        });
+        storeCommitments.push(
+          storeCommitment(commitment, nullifierKey[j], transaction.transactionHash),
+        );
       }
     } catch (err) {
       // This error will be caught regularly if the commitment isn't for us

--- a/nightfall-client/src/services/deposit.mjs
+++ b/nightfall-client/src/services/deposit.mjs
@@ -109,10 +109,7 @@ async function deposit(depositParams) {
 
   const commitmentDB = await getCommitmentByHash(commitment);
 
-  console.log('COMMITMENT DB', commitmentDB);
-
   if (commitmentDB) {
-    logger.info({ msg: 'ON CHAIN', onChain: commitmentDB.isOnChain });
     if (commitmentDB.isOnChain !== -1) {
       throw new Error('You can not re-send a commitment that is already on-chain');
     } else {

--- a/nightfall-client/src/utils/getCommitmentInfo.mjs
+++ b/nightfall-client/src/utils/getCommitmentInfo.mjs
@@ -8,7 +8,7 @@ import {
   markPending,
   findUsableCommitmentsMutex,
   getSiblingInfo,
-  getCommitmentsByHash,
+  getCommitmentsAvailableByHash,
 } from '../services/commitment-storage.mjs';
 import Commitment from '../classes/commitment.mjs';
 import { ZkpKeys } from '../services/keys.mjs';
@@ -86,7 +86,10 @@ export const getCommitmentInfo = async txInfo => {
 
       // Search for the commitment hashes in the DB. The commitment will be considered valid
       // as long as it is not already nullified
-      const rawCommitments = await getCommitmentsByHash(commitmentHashes, compressedZkpPublicKey);
+      const rawCommitments = await getCommitmentsAvailableByHash(
+        commitmentHashes,
+        compressedZkpPublicKey,
+      );
 
       // Filter which of those commitments belong to the ercAddress
       const ercAddressCommitments = rawCommitments.filter(
@@ -140,7 +143,7 @@ export const getCommitmentInfo = async txInfo => {
 
       // Search for the commitment hashes in the DB. The commitment will be considered valid
       // as long as it is not already nullified
-      const rawCommitmentsFee = await getCommitmentsByHash(
+      const rawCommitmentsFee = await getCommitmentsAvailableByHash(
         commitmentHashesFee,
         compressedZkpPublicKey,
       );

--- a/nightfall-client/src/utils/submitTransaction.mjs
+++ b/nightfall-client/src/utils/submitTransaction.mjs
@@ -20,7 +20,7 @@ export const submitTransaction = async (
   logger.debug({ msg: 'storing commitments', commitments: commitmentsInfo.newCommitments });
   const storeNewCommitments = commitmentsInfo.newCommitments
     .filter(c => c.compressedZkpPublicKey.hex(32) === compressedZkpPublicKey.hex(32))
-    .map(c => storeCommitment(c, nullifierKey));
+    .map(c => storeCommitment(c, nullifierKey, transaction.transactionHash));
 
   logger.debug({ msg: 'nullifying commitments', commitments: commitmentsInfo.oldCommitments });
   const nullifyOldCommitments = commitmentsInfo.oldCommitments.map(c =>

--- a/nightfall-client/src/utils/submitTransaction.mjs
+++ b/nightfall-client/src/utils/submitTransaction.mjs
@@ -20,7 +20,7 @@ export const submitTransaction = async (
   logger.debug({ msg: 'storing commitments', commitments: commitmentsInfo.newCommitments });
   const storeNewCommitments = commitmentsInfo.newCommitments
     .filter(c => c.compressedZkpPublicKey.hex(32) === compressedZkpPublicKey.hex(32))
-    .map(c => storeCommitment(c, nullifierKey, transaction.transactionHash));
+    .map(c => storeCommitment(c, nullifierKey));
 
   logger.debug({ msg: 'nullifying commitments', commitments: commitmentsInfo.oldCommitments });
   const nullifyOldCommitments = commitmentsInfo.oldCommitments.map(c =>

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -60,8 +60,7 @@ contract Shield is Stateful, Config, ReentrancyGuardUpgradeable, Pausable {
 
         (, bool isEscrowRequired) = state.circuitInfo(Utils.getCircuitHash(t.packedInfo));
         if (isEscrowRequired) {
-            bytes32 transactionHash = Utils.hashTransaction(t);
-            state.setTransactionInfo(transactionHash, isEscrowRequired);
+            state.setCommitmentEscrowed(t.commitments[0]);
             payIn(t);
         }
     }

--- a/nightfall-deployer/contracts/Shield.sol
+++ b/nightfall-deployer/contracts/Shield.sol
@@ -60,8 +60,12 @@ contract Shield is Stateful, Config, ReentrancyGuardUpgradeable, Pausable {
 
         (, bool isEscrowRequired) = state.circuitInfo(Utils.getCircuitHash(t.packedInfo));
         if (isEscrowRequired) {
-            state.setCommitmentEscrowed(t.commitments[0]);
-            payIn(t);
+            // We need to check if the commitment is already escrowed so the user doesn't
+            // escrow the funds twice
+            if (!state.getCommitmentEscrowed(t.commitments[0])) {
+                state.setCommitmentEscrowed(t.commitments[0]);
+                payIn(t);
+            }
         }
     }
 

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -14,7 +14,6 @@ import './Utils.sol';
 import './Config.sol';
 import './Pausable.sol';
 import './Key_Registry.sol';
-import 'hardhat/console.sol';
 
 contract State is ReentrancyGuardUpgradeable, Pausable, Key_Registry, Config {
     using SafeERC20Upgradeable for IERC20Upgradeable;
@@ -202,15 +201,10 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Key_Registry, Config {
                 let isEscrowRequired := shr(8, sload(keccak256(x, mul(0x20, 2))))
 
                 if isEscrowRequired {
-                    let commitment := calldataload(
+                    let commitment := mload(
                         add(
-                            add(t.offset, add(mul(0x20, t.length), 0x20)),
-                            calldataload(
-                                add(
-                                    t.offset,
-                                    add(calldataload(add(t.offset, mul(0x20, i))), mul(0x20, 5))
-                                )
-                            )
+                            0x20,
+                            add(transactionPos, add(mload(add(transactionPos, mul(0x20, 6))), 0x20))
                         )
                     )
 

--- a/nightfall-deployer/contracts/Structures.sol
+++ b/nightfall-deployer/contracts/Structures.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.0;
 
 contract Structures {
     error InvalidTransactionHash();
-    error DepositNotEscrowed(bytes32 depositHash);
+    error CommitmentNotEscrowed(bytes32 commitmentHash);
     error InvalidBlockSize();
     error InvalidTransactionSize();
 
@@ -114,11 +114,6 @@ contract Structures {
         address currentOwner;
         uint88 advanceFee;
         bool isWithdrawn;
-    }
-
-    struct TransactionInfo {
-        uint248 ethFee;
-        bool isEscrowed;
     }
 
     struct BlockInfo {

--- a/nightfall-deployer/migrations/3_test_tokens_migration.js
+++ b/nightfall-deployer/migrations/3_test_tokens_migration.js
@@ -70,7 +70,15 @@ module.exports = function (deployer, _, accounts) {
         accounts[0],
         addresses.user1,
         [0, 1, 2, 3, 4],
-        [100000, 200000, 10, 50, 80000],
+        [50000, 100000, 5, 25, 40000],
+        [],
+      );
+
+      await ERC1155deployed.safeBatchTransferFrom(
+        accounts[0],
+        addresses.user2,
+        [0, 1, 2, 3, 4],
+        [50000, 100000, 5, 25, 40000],
         [],
       );
     }

--- a/nightfall-optimist/src/event-handlers/rollback.mjs
+++ b/nightfall-optimist/src/event-handlers/rollback.mjs
@@ -64,7 +64,7 @@ async function rollbackEventHandler(data) {
     );
     logger.info({
       msg: 'Rollback - blockTransactions to check:',
-      blockTransactions,
+      blockTransactions: blockTransactions.map(t => t.transactionHash),
     });
 
     const transactionsSortedByFee = blockTransactions.sort((tx1, tx2) =>
@@ -80,7 +80,7 @@ async function rollbackEventHandler(data) {
         await checkTransaction({
           transaction,
           checkDuplicatesInL2: true,
-          blockNumberL2: blockNumber,
+          transactionBlockNumberL2: blockNumber,
         });
 
         for (let k = 0; k < transaction.commitments.length; k++) {

--- a/nightfall-optimist/src/event-handlers/rollback.mjs
+++ b/nightfall-optimist/src/event-handlers/rollback.mjs
@@ -81,6 +81,7 @@ async function rollbackEventHandler(data) {
           transaction,
           checkDuplicatesInL2: true,
           transactionBlockNumberL2: blockNumber,
+          lastValidBlockNumberL2: blockNumberL2 - 1,
         });
 
         for (let k = 0; k < transaction.commitments.length; k++) {

--- a/nightfall-optimist/src/routes/challenger.mjs
+++ b/nightfall-optimist/src/routes/challenger.mjs
@@ -17,7 +17,7 @@ router.post('/enable', async (req, res, next) => {
       logger.info('After enabling challenges back, no challenges remain unresolved');
     } else {
       logger.info(
-        `After enabling challenges backn, there were ${queues[2].length} unresolved challenges.  Running them now.`,
+        `After enabling challenges back, there were ${queues[2].length} unresolved challenges.  Running them now.`,
       );
 
       // start queue[2] and await all the unresolved challenges being run

--- a/nightfall-optimist/src/routes/challenger.mjs
+++ b/nightfall-optimist/src/routes/challenger.mjs
@@ -2,7 +2,8 @@
 Routes for setting and removing valid challenger addresses.
 */
 import express from 'express';
-import { emptyQueue } from '@polygon-nightfall/common-files/utils/event-queue.mjs';
+import { flushQueue, queues } from '@polygon-nightfall/common-files/utils/event-queue.mjs';
+import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
 import { startMakingChallenges, stopMakingChallenges } from '../services/challenges.mjs';
 
 const router = express.Router();
@@ -10,9 +11,21 @@ const router = express.Router();
 router.post('/enable', async (req, res, next) => {
   try {
     const { enable } = req.body;
-    const result =
-      enable === true ? (emptyQueue(2), startMakingChallenges()) : stopMakingChallenges();
+    const result = enable === true ? startMakingChallenges() : stopMakingChallenges();
     res.json(result);
+    if (queues[2].length === 0) {
+      logger.info('After enabling challenges back, no challenges remain unresolved');
+    } else {
+      logger.info(
+        `After enabling challenges backn, there were ${queues[2].length} unresolved challenges.  Running them now.`,
+      );
+
+      // start queue[2] and await all the unresolved challenges being run
+      const p = flushQueue(2);
+      queues[2].start();
+      await p;
+      logger.debug('All challenges in the stop queue have now been made.');
+    }
   } catch (err) {
     next(err);
   }

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -175,11 +175,6 @@ export async function conditionalMakeBlock(proposer) {
           blockSize,
         });
 
-        logger.info({
-          transaction: transactions.map(t => Transaction.buildSolidityStruct(t)),
-          block: Block.buildSolidityStruct(block),
-        });
-
         // propose this block to the Shield contract here
         const unsignedProposeBlockTransaction = await (
           await waitForContract(STATE_CONTRACT_NAME)

--- a/nightfall-optimist/src/services/block-assembler.mjs
+++ b/nightfall-optimist/src/services/block-assembler.mjs
@@ -175,6 +175,11 @@ export async function conditionalMakeBlock(proposer) {
           blockSize,
         });
 
+        logger.info({
+          transaction: transactions.map(t => Transaction.buildSolidityStruct(t)),
+          block: Block.buildSolidityStruct(block),
+        });
+
         // propose this block to the Shield contract here
         const unsignedProposeBlockTransaction = await (
           await waitForContract(STATE_CONTRACT_NAME)

--- a/nightfall-optimist/src/services/challenges.mjs
+++ b/nightfall-optimist/src/services/challenges.mjs
@@ -47,8 +47,9 @@ export async function signalRollbackCompleted(data) {
 }
 
 export function startMakingChallenges() {
-  if (process.env.IS_CHALLENGER !== 'true')
-    throw Error('Connot start challenger as this optimist never intend to be a challenger');
+  if (process.env.IS_CHALLENGER !== 'true') {
+    throw new Error('Cannot start challenger as this optimist never intend to be a challenger');
+  }
   logger.info(`Challenges ON`);
   makeChallenges = true;
 }

--- a/nightfall-optimist/src/services/check-block.mjs
+++ b/nightfall-optimist/src/services/check-block.mjs
@@ -258,7 +258,7 @@ export async function checkBlock(block, transactions) {
       await checkTransaction({
         transaction,
         checkDuplicatesInL2: true,
-        blockNumberL2: block.blockNumberL2,
+        transactionBlockNumberL2: block.blockNumberL2,
       }); // eslint-disable-line no-await-in-loop
     }
   } catch (err) {

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -469,8 +469,8 @@ export async function getTransactionMempoolByCommitment(commitmentHash, transact
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   const query = {
-    commitments: commitmentHash,
-    fee: { $gt: Number(transactionFee) },
+    commitments: { $in: [commitmentHash] },
+    fee: { $gt: transactionFee },
     mempool: true,
   };
   return db.collection(TRANSACTIONS_COLLECTION).findOne(query);
@@ -480,7 +480,7 @@ export async function getTransactionL2ByCommitment(commitmentHash, blockNumberL2
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   const query = {
-    commitments: commitmentHash,
+    commitments: { $in: [commitmentHash] },
     blockNumberL2: { $gt: -1, $ne: blockNumberL2OfTx },
   };
   return db.collection(TRANSACTIONS_COLLECTION).findOne(query);
@@ -489,7 +489,11 @@ export async function getTransactionL2ByCommitment(commitmentHash, blockNumberL2
 export async function getTransactionMempoolByNullifier(nullifierHash, transactionFee) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
-  const query = { nullifiers: nullifierHash, fee: { $gt: Number(transactionFee) }, mempool: true };
+  const query = {
+    nullifiers: { $in: [nullifierHash] },
+    fee: { $gt: transactionFee },
+    mempool: true,
+  };
   return db.collection(TRANSACTIONS_COLLECTION).findOne(query);
 }
 
@@ -497,7 +501,7 @@ export async function getTransactionL2ByNullifier(nullifierHash, blockNumberL2Of
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   const query = {
-    nullifiers: nullifierHash,
+    nullifiers: { $in: [nullifierHash] },
     blockNumberL2: { $gt: -1, $ne: blockNumberL2OfTx },
   };
   return db.collection(TRANSACTIONS_COLLECTION).findOne(query);

--- a/nightfall-optimist/src/services/state-sync.mjs
+++ b/nightfall-optimist/src/services/state-sync.mjs
@@ -144,7 +144,7 @@ export default async proposer => {
   if (!latestBlockLocally || missingBlocks[0] !== latestBlockLocally.blockNumber + 1) {
     // The latest block stored locally does not match the last on-chain block
     // or we have detected a gap in the L2 blockchain
-    await stopMakingChallenges();
+    stopMakingChallenges();
     for (let i = 0; i < missingBlocks.length; i++) {
       const [fromBlock, toBlock] = missingBlocks[i];
       // Sync the state inbetween these blocks

--- a/nightfall-optimist/src/services/transaction-checker.mjs
+++ b/nightfall-optimist/src/services/transaction-checker.mjs
@@ -46,6 +46,11 @@ async function checkDuplicateCommitment({
           transaction.fee,
         );
 
+        logger.debug({
+          msg: 'Duplicate mempool commitment with higher fee: ',
+          transactionMempoolHigherFee,
+        });
+
         if (transactionMempoolHigherFee !== null) {
           throw new TransactionError(
             `The transaction has a duplicate commitment ${commitment} in the mempool with a higher fee`,
@@ -104,6 +109,11 @@ async function checkDuplicateNullifier({
           nullifier,
           transaction.fee,
         );
+
+        logger.debug({
+          msg: 'Duplicate mempool nullifier with higher fee: ',
+          transactionMempoolHigherFee,
+        });
 
         if (transactionMempoolHigherFee !== null) {
           throw new TransactionError(

--- a/nightfall-optimist/src/services/transaction-checker.mjs
+++ b/nightfall-optimist/src/services/transaction-checker.mjs
@@ -157,6 +157,8 @@ async function checkHistoricRootBlockNumber(transaction, lastValidBlockNumberL2)
     latestBlockNumberL2 = Number((await stateInstance.methods.getNumberOfL2Blocks().call()) - 1);
   }
 
+  logger.debug({ msg: `Latest valid block number in L2`, latestBlockNumberL2 });
+
   transaction.historicRootBlockNumberL2.forEach((blockNumberL2, i) => {
     if (transaction.nullifiers[i] === ZERO) {
       if (Number(blockNumberL2) !== 0) {
@@ -164,10 +166,16 @@ async function checkHistoricRootBlockNumber(transaction, lastValidBlockNumberL2)
           transactionHash: transaction.transactionHash,
         });
       }
-    } else if (Number(blockNumberL2) >= latestBlockNumberL2) {
-      throw new TransactionError('Historic root has block number L2 greater than on chain', 3, {
-        transactionHash: transaction.transactionHash,
-      });
+    } else if (Number(blockNumberL2) > latestBlockNumberL2) {
+      throw new TransactionError(
+        `Historic root block number, which is ${Number(
+          blockNumberL2,
+        )}, has block number L2 greater than on chain, which is ${latestBlockNumberL2}`,
+        3,
+        {
+          transactionHash: transaction.transactionHash,
+        },
+      );
     }
   });
 }

--- a/nightfall-optimist/src/services/transaction-checker.mjs
+++ b/nightfall-optimist/src/services/transaction-checker.mjs
@@ -46,12 +46,11 @@ async function checkDuplicateCommitment({
           transaction.fee,
         );
 
-        logger.debug({
-          msg: 'Duplicate mempool commitment with higher fee: ',
-          transactionMempoolHigherFee,
-        });
-
         if (transactionMempoolHigherFee !== null) {
+          logger.debug({
+            msg: 'Duplicate mempool commitment with higher fee: ',
+            transactionMempoolHigherFee,
+          });
           throw new TransactionError(
             `The transaction has a duplicate commitment ${commitment} in the mempool with a higher fee`,
             0,
@@ -110,12 +109,11 @@ async function checkDuplicateNullifier({
           transaction.fee,
         );
 
-        logger.debug({
-          msg: 'Duplicate mempool nullifier with higher fee: ',
-          transactionMempoolHigherFee,
-        });
-
         if (transactionMempoolHigherFee !== null) {
+          logger.debug({
+            msg: 'Duplicate mempool nullifier with higher fee: ',
+            transactionMempoolHigherFee,
+          });
           throw new TransactionError(
             `The transaction has a duplicate commitment ${nullifier} in the mempool with a higher fee`,
             1,

--- a/nightfall-optimist/src/services/transaction-checker.mjs
+++ b/nightfall-optimist/src/services/transaction-checker.mjs
@@ -206,9 +206,11 @@ async function verifyProof(transaction) {
     }),
   );
 
-  logger.debug({
-    msg: 'The historic roots are the following',
-    historicRoots: historicRoots.map(h => h.root),
+  logger.info({
+    msg: 'Constructing proof with blockNumberL2s and roots',
+    transaction: transaction.transactionHash,
+    blockNumberL2s: transaction.historicRootBlockNumberL2.map(r => Number(r)),
+    roots: historicRoots.map(h => h.root),
   });
 
   const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -23,7 +23,6 @@ import {
   clearMempool,
   getLayer2Balances,
   registerProposerOnNoProposer,
-  restartOptimist,
   waitForSufficientTransactionsMempool,
   Web3Client,
 } from './utils.mjs';
@@ -258,6 +257,7 @@ describe('Testing with an adversary', () => {
     let user2L2Erc1155BalanceBefore;
 
     before(async () => {
+      await enableChallenger(false);
       userL2BalanceBefore = await getLayer2BalancesBadClient(erc20Address);
       user2L2BalanceBefore = await getLayer2Balances(nf3User2, erc20Address);
       user2L2Erc1155BalanceBefore = await getLayer2Erc1155Balance(
@@ -271,7 +271,6 @@ describe('Testing with an adversary', () => {
     it('Deep rollback', async () => {
       console.log('Testing deep rollback at distance 2...');
 
-      await enableChallenger(false);
       await nf3User2.deposit(
         'ValidTransaction',
         erc20Address,
@@ -306,7 +305,7 @@ describe('Testing with an adversary', () => {
         fee,
       );
       await makeBlock();
-      await restartOptimist(nf3Challenger);
+      await enableChallenger(true);
       await waitForRollback();
 
       const { result: mempool } = (

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -204,7 +204,7 @@ describe('Testing with an adversary', () => {
     currentRollbacks = rollbackCount;
   });
 
-  describe.skip('Testing block zero challenges', async () => {
+  describe('Testing block zero challenges', async () => {
     before(async () => {
       await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
     });
@@ -233,26 +233,27 @@ describe('Testing with an adversary', () => {
   });
 
   describe('Testing optimist deep rollbacks', async () => {
+    const userL2BalanceBefore = await getLayer2BalancesBadClient(ercAddress);
+    const user2L2BalanceBefore = await getLayer2Balances(nf3User2, ercAddress);
+
     before(async () => {
-      await nf3User2.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
+      await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
       await makeBlock();
       await waitForTimeout(10000);
     });
     it('Deep rollback', async () => {
       console.log('Testing deep rollback at distance 2...');
-      const userL2BalanceBefore = await getLayer2BalancesBadClient(ercAddress);
-      const user2L2BalanceBefore = await getLayer2Balances(nf3User2, ercAddress);
 
       await enableChallenger(false);
-      await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
-      await nf3User2.transfer(
+      await nf3User2.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
+      await nf3User.transfer(
         'ValidTransaction',
         false,
         ercAddress,
         tokenType,
         transferValue / 2,
         tokenId,
-        nf3User.zkpKeys.compressedZkpPublicKey,
+        nf3User2.zkpKeys.compressedZkpPublicKey,
         0,
       );
       await nf3User.deposit('IncorrectInput', ercAddress, tokenType, transferValue, tokenId, 0);
@@ -262,14 +263,14 @@ describe('Testing with an adversary', () => {
       });
 
       await makeBlock('IncorrectTreeRoot');
-      await nf3User.transfer(
+      await nf3User2.transfer(
         'ValidTransaction',
         false,
         ercAddress,
         tokenType,
         transferValue,
         tokenId,
-        nf3User2.zkpKeys.compressedZkpPublicKey,
+        nf3User.zkpKeys.compressedZkpPublicKey,
         0,
       );
       await makeBlock();
@@ -282,7 +283,7 @@ describe('Testing with an adversary', () => {
       const numberTxs = mempool.filter(e => e.mempool).length;
       expect(numberTxs).to.be.equal(2);
 
-      await nf3User2.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
+      await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
 
       await waitForSufficientTransactionsMempool({
         optimistBaseUrl: environment.adversarialOptimistApiUrl,

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -18,18 +18,30 @@ import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
 // eslint-disable-next-line import/no-unresolved
 import Nf3 from './adversary/adversary-cli/lib/nf3.mjs';
 
-import { clearMempool, registerProposerOnNoProposer, Web3Client } from './utils.mjs';
+import {
+  clearMempool,
+  getLayer2Balances,
+  registerProposerOnNoProposer,
+  restartOptimist,
+  waitForSufficientTransactionsMempool,
+  waitForTimeout,
+  Web3Client,
+} from './utils.mjs';
 
 chai.use(chaiHttp);
 chai.use(chaiAsPromised);
 
 const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
 
-const { fee } = config.TEST_OPTIONS;
+const {
+  fee,
+  signingKeys,
+  mnemonics,
+  tokenConfigs: { tokenType, tokenId },
+  transferValue,
+} = config.TEST_OPTIONS;
 
 const web3Client = new Web3Client();
-
-let stateAddress;
 const eventLogs = [];
 
 const challengeSelectors = {
@@ -52,41 +64,51 @@ const {
   ...others
 } = environment;
 
-async function makeBlockNow(badBlockType) {
+const nf3User = new Nf3(signingKeys.user1, {
+  ...others,
+  clientApiUrl: adversarialClientApiUrl,
+  clientWsUrl: adversarialClientWsUrl,
+});
+const nf3User2 = new Nf3(signingKeys.user2, environment);
+
+const nf3AdversarialProposer = new Nf3(signingKeys.proposer1, {
+  ...others,
+  optimistApiUrl: adversarialOptimistApiUrl,
+  optimistWsUrl: adversarialOptimistWsUrl,
+});
+
+const nf3Challenger = new Nf3(signingKeys.challenger, environment);
+
+async function makeBlock(badBlockType) {
+  logger.debug(`Make block...`);
   if (badBlockType) {
     await axios.get(`${adversarialOptimistApiUrl}/block/make-now/${badBlockType}`);
   } else {
     await axios.get(`${adversarialOptimistApiUrl}/block/make-now`);
   }
+  await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+}
+
+async function getLayer2BalancesBadClient(ercAddress) {
+  const res = await axios.get(`${adversarialClientApiUrl}/commitment/balance`, {
+    params: {
+      compressedZkpPublicKey: nf3User.zkpKeys.compressedZkpPublicKey,
+    },
+  });
+  return res.data.balance[ercAddress]?.[0].balance || 0;
+}
+
+async function enableChallenger(enable) {
+  await axios.post(`${optimistApiUrl}/challenger/enable`, { enable });
 }
 
 describe('Testing with an adversary', () => {
-  let nf3User;
-  let nf3AdversarialProposer;
   let blockProposeEmitter;
   let challengeEmitter;
   let ercAddress;
-  let nf3Challenger;
+  let stateAddress;
   let intervalId;
 
-  // this is the etherum private key for accounts[0] and so on
-  const ethereumSigningKeyUser =
-    '0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69e';
-  const ethereumSigningKeyProposer =
-    '0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69d';
-  const ethereumSigningKeyChallenger =
-    '0xd42905d0582c476c4b74757be6576ec323d715a0c7dcff231b6348b7ab0190eb';
-  const mnemonicUser =
-    'trip differ bamboo bundle bonus luxury strike mad merry muffin nose auction';
-  const mnemonicProposer =
-    'high return hold whale promote payment hat panel reduce oyster ramp mouse';
-  const mnemonicChallenger =
-    'heart bless cream into jacket purpose very sentence saddle sea bird abuse';
-  const tokenId = '0x00'; // has to be zero for ERC20
-  const tokenType = 'ERC20'; // it can be 'ERC721' or 'ERC1155'
-  // const value = 10;
-  // const value1 = 1000;
-  const value2 = 5;
   let rollbackCount = 0;
   let currentRollbacks = 0;
   let challengeSelector;
@@ -108,41 +130,24 @@ describe('Testing with an adversary', () => {
 
   before(async () => {
     console.log('ENV:\n', environment);
-    nf3User = new Nf3(ethereumSigningKeyUser, {
-      ...others,
-      clientApiUrl: adversarialClientApiUrl,
-    });
 
-    nf3AdversarialProposer = new Nf3(ethereumSigningKeyProposer, {
-      ...others,
-      optimistApiUrl: adversarialOptimistApiUrl,
-      optimistWsUrl: adversarialOptimistWsUrl,
-    });
-
-    nf3Challenger = new Nf3(ethereumSigningKeyChallenger, {
-      ...others,
-      optimistApiUrl,
-      optimistWsUrl,
-    });
-
-    // Generate a random mnemonic (uses crypto.randomBytes under the hood), defaults to 128-bits of entropy
-    await nf3User.init(mnemonicUser);
-    await nf3AdversarialProposer.init(mnemonicProposer);
-    await nf3Challenger.init(mnemonicChallenger);
+    await nf3User.init(mnemonics.user1);
+    await nf3User2.init(mnemonics.user2);
+    await nf3AdversarialProposer.init(mnemonics.proposer);
+    await nf3Challenger.init(mnemonics.challenger);
 
     if (!(await nf3User.healthcheck('client'))) throw new Error('Healthcheck failed');
+    if (!(await nf3User2.healthcheck('client'))) throw new Error('Healthcheck failed');
     if (!(await nf3AdversarialProposer.healthcheck('optimist')))
       throw new Error('Healthcheck failed');
     if (!(await nf3Challenger.healthcheck('optimist'))) throw new Error('Healthcheck failed');
-
-    // retrieve initial balance
-    ercAddress = await nf3User.getContractAddress('ERC20Mock');
 
     // Proposer registration
     await nf3AdversarialProposer.registerProposer(
       'http://optimist',
       await nf3AdversarialProposer.getMinimumStake(),
     );
+
     // Proposer listening for incoming events
     blockProposeEmitter = await nf3AdversarialProposer.startProposer();
     blockProposeEmitter
@@ -189,6 +194,8 @@ describe('Testing with an adversary', () => {
         );
       });
 
+    // retrieve initial balance
+    ercAddress = await nf3User.getContractAddress('ERC20Mock');
     stateAddress = await nf3User.stateContractAddress;
     web3Client.subscribeTo('logs', eventLogs, { address: stateAddress });
   });
@@ -199,28 +206,89 @@ describe('Testing with an adversary', () => {
 
   describe('Testing block zero challenges', async () => {
     before(async () => {
-      await nf3User.deposit('ValidTransaction', ercAddress, tokenType, value2, tokenId, 0);
+      await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
     });
 
     it('Challenging block zero for having an invalid leaf count', async () => {
       console.log('Testing incorrect leaf count in block zero...');
-      await makeBlockNow('IncorrectLeafCount');
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await makeBlock('IncorrectLeafCount');
       await waitForRollback();
       expect(challengeSelector).to.be.equal(challengeSelectors.challengeLeafCount);
     });
 
     it('Challenging block zero for having an invalid frontier hash', async () => {
       console.log('Testing incorrect frontier hash in block zero...');
-      await makeBlockNow('IncorrectFrontierHash');
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await makeBlock('IncorrectFrontierHash');
       await waitForRollback();
       expect(challengeSelector).to.be.equal(challengeSelectors.challengeFrontier);
     });
 
     after(async () => {
-      await makeBlockNow();
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await makeBlock();
+    });
+  });
+
+  describe('Testing optimist deep rollbacks', async () => {
+    before(async () => {
+      await nf3User2.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
+      await makeBlock();
+      await waitForTimeout(10000);
+    });
+    it('Deep rollback', async () => {
+      console.log('Testing deep rollback at distance 2...');
+      await enableChallenger(false);
+      await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
+      await nf3User2.transfer(
+        'ValidTransaction',
+        false,
+        ercAddress,
+        tokenType,
+        transferValue / 2,
+        tokenId,
+        nf3User.zkpKeys.compressedZkpPublicKey,
+        0,
+      );
+      await nf3User.deposit('IncorrectInput', ercAddress, tokenType, transferValue, tokenId, 0);
+      await waitForSufficientTransactionsMempool({
+        optimistBaseUrl: environment.adversarialOptimistApiUrl,
+        nTransactions: 3,
+      });
+
+      await makeBlock('IncorrectTreeRoot');
+      await nf3User.transfer(
+        'ValidTransaction',
+        false,
+        ercAddress,
+        tokenType,
+        transferValue,
+        tokenId,
+        nf3User2.zkpKeys.compressedZkpPublicKey,
+        0,
+      );
+      await makeBlock();
+      await restartOptimist(nf3Challenger);
+      await waitForRollback();
+
+      const { result: mempool } = (
+        await axios.get(`${environment.optimistApiUrl}/proposer/mempool`)
+      ).data;
+      const numberTxs = mempool.filter(e => e.mempool).length;
+      expect(numberTxs).to.be.equal(2);
+
+      await nf3User2.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
+
+      await waitForSufficientTransactionsMempool({
+        optimistBaseUrl: environment.adversarialOptimistApiUrl,
+        nTransactions: 3,
+      });
+
+      await makeBlock();
+
+      const userL2BalanceAfter = await getLayer2BalancesBadClient(ercAddress);
+      const user2L2BalanceAfter = await getLayer2Balances(nf3User2, ercAddress);
+
+      expect(userL2BalanceAfter).to.be.equal(transferValue + transferValue / 2);
+      expect(user2L2BalanceAfter).to.be.equal(transferValue + transferValue / 2);
     });
   });
 
@@ -228,27 +296,31 @@ describe('Testing with an adversary', () => {
     describe('Deposits rollback', async () => {
       it('Test duplicate transaction deposit', async () => {
         console.log('Testing duplicate transaction deposit...');
-        await nf3User.deposit('ValidTransaction', ercAddress, tokenType, value2, tokenId, fee);
-        await makeBlockNow('DuplicateTransaction');
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await nf3User.deposit(
+          'ValidTransaction',
+          ercAddress,
+          tokenType,
+          transferValue,
+          tokenId,
+          fee,
+        );
+        await makeBlock('DuplicateTransaction');
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeCommitment);
       });
 
       it('Test failing incorrect input deposit', async () => {
         console.log('Testing incorrect input deposit...');
-        await nf3User.deposit('IncorrectInput', ercAddress, tokenType, value2, tokenId, 0);
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await nf3User.deposit('IncorrectInput', ercAddress, tokenType, transferValue, tokenId, 0);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
 
       it('Test failing incorrect proof deposit', async () => {
         console.log('Testing incorrect proof deposit...');
-        await nf3User.deposit('IncorrectProof', ercAddress, tokenType, value2, tokenId, 0);
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await nf3User.deposit('IncorrectProof', ercAddress, tokenType, transferValue, tokenId, 0);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
@@ -256,9 +328,8 @@ describe('Testing with an adversary', () => {
 
     describe('Transfers rollback', async () => {
       beforeEach(async () => {
-        await nf3User.deposit('ValidTransaction', ercAddress, tokenType, value2, tokenId, 0);
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
+        await makeBlock();
       });
 
       it('Test duplicate transaction transfer', async () => {
@@ -268,13 +339,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.zkpKeys.compressedZkpPublicKey,
           fee,
         );
-        await makeBlockNow('DuplicateTransaction');
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock('DuplicateTransaction');
         await waitForRollback();
         expect(challengeSelector).to.be.oneOf([
           challengeSelectors.challengeCommitment,
@@ -289,13 +359,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.zkpKeys.compressedZkpPublicKey,
           0,
         );
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeNullifier);
       });
@@ -307,13 +376,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.zkpKeys.compressedZkpPublicKey,
           0,
         );
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
@@ -324,13 +392,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.zkpKeys.compressedZkpPublicKey,
           0,
         );
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
@@ -342,13 +409,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.zkpKeys.compressedZkpPublicKey,
           0,
         );
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeHistoricRoot);
       });
@@ -356,9 +422,8 @@ describe('Testing with an adversary', () => {
 
     describe('Withdraw rollbacks', async () => {
       beforeEach(async () => {
-        await nf3User.deposit('ValidTransaction', ercAddress, tokenType, value2, tokenId, 0);
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
+        await makeBlock();
       });
 
       it('Test duplicate transaction withdraw', async () => {
@@ -368,13 +433,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.ethereumAddress,
           fee,
         );
-        await makeBlockNow('DuplicateTransaction');
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock('DuplicateTransaction');
         await waitForRollback();
         expect(challengeSelector).to.be.oneOf([
           challengeSelectors.challengeCommitment,
@@ -389,13 +453,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.ethereumAddress,
           0,
         );
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeNullifier);
       });
@@ -407,13 +470,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.ethereumAddress,
           0,
         );
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
@@ -425,13 +487,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.ethereumAddress,
           0,
         );
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeProofVerification);
       });
@@ -443,13 +504,12 @@ describe('Testing with an adversary', () => {
           false,
           ercAddress,
           tokenType,
-          value2,
+          transferValue,
           tokenId,
           nf3User.ethereumAddress,
           0,
         );
-        await makeBlockNow();
-        await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+        await makeBlock();
         await waitForRollback();
         expect(challengeSelector).to.be.equal(challengeSelectors.challengeHistoricRoot);
       });
@@ -466,36 +526,32 @@ describe('Testing with an adversary', () => {
 
   describe('Testing bad blocks', async () => {
     before(async () => {
-      await nf3User.deposit('ValidTransaction', ercAddress, tokenType, value2, tokenId, 0);
+      await nf3User.deposit('ValidTransaction', ercAddress, tokenType, transferValue, tokenId, 0);
     });
 
     it('Test incorrect leaf count', async () => {
       console.log('Testing incorrect leaf count...');
-      await makeBlockNow('IncorrectLeafCount');
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await makeBlock('IncorrectLeafCount');
       await waitForRollback();
       expect(challengeSelector).to.be.equal(challengeSelectors.challengeLeafCount);
     });
 
     it('Test incorrect tree root', async () => {
       console.log('Testing incorrect tree root...');
-      await makeBlockNow('IncorrectTreeRoot');
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await makeBlock('IncorrectTreeRoot');
       await waitForRollback();
       expect(challengeSelector).to.be.equal(challengeSelectors.challengeRoot);
     });
 
     it('Test incorrect frontier hash', async () => {
       console.log('Testing incorrect frontier hash...');
-      await makeBlockNow('IncorrectFrontierHash');
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await makeBlock('IncorrectFrontierHash');
       await waitForRollback();
       expect(challengeSelector).to.be.equal(challengeSelectors.challengeFrontier);
     });
 
     after(async () => {
-      await makeBlockNow();
-      await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+      await makeBlock();
     });
   });
 

--- a/test/adversary/adversary-code/commitment-storage.mjs
+++ b/test/adversary/adversary-code/commitment-storage.mjs
@@ -3,7 +3,7 @@
 /* eslint-disable no-undef */
 
 // ignore unused exports
-export async function getCommitmentsByHashFaulty(hashes, compressedZkpPublicKey) {
+export async function getCommitmentsAvailableByHashFaulty(hashes, compressedZkpPublicKey) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(COMMITMENTS_DB);
   const query = {

--- a/test/adversary/adversary-code/incorrectTransactions.mjs
+++ b/test/adversary/adversary-code/incorrectTransactions.mjs
@@ -25,6 +25,7 @@ if (transactionType === 'IncorrectInput') {
     transaction[selectedKey] = modifiedValue;
   }
 
+  transaction.transactionHash = Transaction.calcHash(transaction);
   logger.debug({
     msg: 'Transaction after modification',
     transaction,
@@ -32,8 +33,10 @@ if (transactionType === 'IncorrectInput') {
 } else if (transactionType === 'IncorrectProof') {
   transaction.proof[0] = generalise(Math.floor(Math.random() * 2 ** 32)).hex(32);
 
+  transaction.transactionHash = Transaction.calcHash(transaction);
   logger.debug({
     msg: 'Transaction after modification',
     transaction,
   });
+  transaction.transactionHash = Transaction.calcHash(transaction);
 }

--- a/test/adversary/transpile-client-adversary.mjs
+++ b/test/adversary/transpile-client-adversary.mjs
@@ -68,10 +68,10 @@ const transpileGetCommitmentInfo = _pathToSrc => {
     transactionType,`;
   srcFile = srcFile.replace(regexPassTransactionTypeParam, rePassTransactionTypeParam);
 
-  // Modify getCommitmentsByHash logic in order to call faulty function if transaction type is
+  // Modify getCommitmentsAvailableByHash logic in order to call faulty function if transaction type is
   // duplicateNulifier
-  const regexModifyGetCommitmentsCall = /getCommitmentsByHash/g;
-  const reModifyGetCommitmentsCall = `getCommitmentsByHashFaulty`;
+  const regexModifyGetCommitmentsCall = /getCommitmentsAvailableByHash/g;
+  const reModifyGetCommitmentsCall = `getCommitmentsAvailableByHashFaulty`;
   srcFile = srcFile.replace(regexModifyGetCommitmentsCall, reModifyGetCommitmentsCall);
 
   // Add incorrect Historic Block Number code, which modifies the blockNumberL2s array,

--- a/test/e2e/tokens/erc1155.test.mjs
+++ b/test/e2e/tokens/erc1155.test.mjs
@@ -102,7 +102,7 @@ describe('ERC1155 tests', () => {
   });
 
   describe('Deposits', () => {
-    it.skip('Should increment user L2 balance after depositing some ERC1155', async function () {
+    it('Should increment user L2 balance after depositing some ERC1155', async function () {
       const userL2Erc1155BeforeBalance = await getLayer2Erc1155Balance(nf3User);
       const userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
       const res = await nf3User.deposit(

--- a/test/e2e/tokens/erc1155.test.mjs
+++ b/test/e2e/tokens/erc1155.test.mjs
@@ -102,7 +102,7 @@ describe('ERC1155 tests', () => {
   });
 
   describe('Deposits', () => {
-    it('Should increment user L2 balance after depositing some ERC1155', async function () {
+    it.skip('Should increment user L2 balance after depositing some ERC1155', async function () {
       const userL2Erc1155BeforeBalance = await getLayer2Erc1155Balance(nf3User);
       const userL2FeesBalanceBefore = await getLayer2Balances(nf3User, erc20Address);
       const res = await nf3User.deposit(

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -468,7 +468,10 @@ describe('ERC20 tests', () => {
           0,
         );
 
-        await waitForSufficientTransactionsMempool({ nf3User, nTransactions: 6 });
+        await waitForSufficientTransactionsMempool({
+          optimistBaseUrl: environment.optimistApiUrl,
+          nTransactions: 6,
+        });
 
         await nf3Proposer.makeBlockNow();
         await waitForSufficientBalance({

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -5,6 +5,7 @@ import chaiHttp from 'chai-http';
 import chaiAsPromised from 'chai-as-promised';
 import config from 'config';
 import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
+import { randValueLT } from '@polygon-nightfall/common-files/utils/crypto/crypto-random.mjs';
 import Nf3 from '../../../cli/lib/nf3.mjs';
 import {
   depositNTransactions,
@@ -16,6 +17,7 @@ import {
   getUserCommitments,
 } from '../../utils.mjs';
 import { approve } from '../../../cli/lib/tokens.mjs';
+import constants from '../../../common-files/constants/index.mjs';
 
 const { expect } = chai;
 chai.use(chaiHttp);
@@ -36,6 +38,8 @@ const {
     tokens: { blockchain: maxWithdrawValue },
   },
 } = config;
+
+const { BN128_GROUP_ORDER } = constants;
 
 const web3Client = new Web3Client();
 const web3 = web3Client.getWeb3();
@@ -102,6 +106,25 @@ describe('ERC20 tests', () => {
         expect.fail('Throw error, deposit did not fail');
       } catch (err) {
         expect(err.message).to.include('Transaction has been reverted by the EVM');
+      }
+    });
+
+    it('Should fail to send a deposit if commitment is already on chain', async function () {
+      const salt = (await randValueLT(BN128_GROUP_ORDER)).hex();
+      await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, fee, [], salt);
+      await makeBlock();
+      try {
+        await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, fee, [], salt);
+      } catch (err) {
+        expect(err.message).to.include('You can not re-send a commitment that is already on-chain');
+      }
+    });
+
+    it('Should fail to send a deposit if fee is higher or equal than the value', async function () {
+      try {
+        await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, transferValue);
+      } catch (err) {
+        expect(err.message).to.include('Value deposited needs to be bigger than the fee');
       }
     });
   });

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -344,6 +344,15 @@ describe('ERC20 tests', () => {
       const userL1BalanceBefore = await web3Client.getBalance(nf3User.ethereumAddress);
 
       await web3Client.timeJump(3600 * 24 * 10);
+      const commitments = await nf3User.getPendingWithdraws();
+      expect(
+        commitments[nf3User.zkpKeys.compressedZkpPublicKey][erc20Address].length,
+      ).to.be.greaterThan(0);
+      expect(
+        commitments[nf3User.zkpKeys.compressedZkpPublicKey][erc20Address].filter(
+          c => c.valid === true,
+        ).length,
+      ).to.be.greaterThan(0);
       const res = await nf3User.finaliseWithdrawal(withdrawalTxHash);
       expectTransaction(res);
       logger.debug(`Gas used was ${Number(res.gasUsed)}`);

--- a/test/gas.test.mjs
+++ b/test/gas.test.mjs
@@ -9,7 +9,6 @@ import {
   transferNTransactions,
   withdrawNTransactions,
   Web3Client,
-  expectTransaction,
   waitForTimeout,
 } from './utils.mjs';
 
@@ -195,35 +194,6 @@ describe('Gas test', () => {
 
       await nf3Users[0].makeBlockNow();
       await web3Client.waitForEvent(eventLogs, ['blockProposed']);
-    });
-  });
-
-  describe('Finalise withdraws', () => {
-    it('should withdraw from L2, checking for L1 balance (only with time-jump client)', async function () {
-      const nodeInfo = await web3Client.getInfo();
-      if (nodeInfo.includes('TestRPC')) {
-        waitForTimeout(10000);
-        const startBalance = await web3Client.getBalance(nf3Users[0].ethereumAddress);
-        const withdrawal = await nf3Users[0].getLatestWithdrawHash();
-        await web3Client.timeJump(3600 * 24 * 10); // jump in time by 10 days
-        const commitments = await nf3Users[0].getPendingWithdraws();
-        expect(
-          commitments[nf3Users[0].zkpKeys.compressedZkpPublicKey][erc20Address].length,
-        ).to.be.greaterThan(0);
-        expect(
-          commitments[nf3Users[0].zkpKeys.compressedZkpPublicKey][erc20Address].filter(
-            c => c.valid === true,
-          ).length,
-        ).to.be.greaterThan(0);
-        const res = await nf3Users[0].finaliseWithdrawal(withdrawal);
-        expectTransaction(res);
-        const endBalance = await web3Client.getBalance(nf3Users[0].ethereumAddress);
-        expect(parseInt(endBalance, 10)).to.be.lessThan(parseInt(startBalance, 10));
-        console.log('The gas used for finalise withdraw, back to L1, was', res.gasUsed);
-      } else {
-        console.log('Not using a time-jump capable test client so this test is skipped');
-        this.skip();
-      }
     });
   });
 

--- a/test/unit/SmartContracts/challenges.unit.test.mjs
+++ b/test/unit/SmartContracts/challenges.unit.test.mjs
@@ -6,7 +6,7 @@ import {
   calculateBlockHash,
   createBlockAndTransactions,
 } from '../utils/utils.mjs';
-import { setTransactionInfo } from '../utils/stateStorage.mjs';
+import { setCommitmentHashEscrowed } from '../utils/stateStorage.mjs';
 import { unpackBlockInfo } from '../../../common-files/utils/block-utils.mjs';
 
 const { ethers, upgrades } = hardhat;
@@ -136,17 +136,9 @@ describe('Challenges contract Challenges functions', function () {
     ]);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -199,16 +191,9 @@ describe('Challenges contract Challenges functions', function () {
     ]);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -266,16 +251,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -334,17 +312,9 @@ describe('Challenges contract Challenges functions', function () {
       await state.setNumProposers(1);
       await state.setCurrentProposer(addr1.address);
       await state.setStakeAccount(addr1.address, amount, challengeLocked);
-      await setTransactionInfo(
-        shield.address,
-        calculateTransactionHash(transactionsCreated.withdrawTransaction),
-        true,
-        0,
-      );
-      await setTransactionInfo(
-        shield.address,
-        calculateTransactionHash(transactionsCreated.depositTransaction),
-        true,
-        0,
+      await setCommitmentHashEscrowed(
+        state.address,
+        transactionsCreated.depositTransaction.commitments,
       );
       await state.proposeBlock(
         transactionsCreated.block,
@@ -407,17 +377,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -475,17 +437,9 @@ describe('Challenges contract Challenges functions', function () {
     ]);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -532,17 +486,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -614,17 +560,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -689,17 +627,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -779,17 +709,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -881,17 +803,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -983,17 +897,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -1073,17 +979,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -1151,17 +1049,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -1253,17 +1143,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -1331,17 +1213,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -1412,17 +1286,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -1489,17 +1355,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -1569,17 +1427,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -1644,17 +1494,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -1715,17 +1557,9 @@ describe('Challenges contract Challenges functions', function () {
     await state.setNumProposers(1);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      0,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,

--- a/test/unit/SmartContracts/shield.unit.test.mjs
+++ b/test/unit/SmartContracts/shield.unit.test.mjs
@@ -185,7 +185,14 @@ describe('Testing Shield Contract', function () {
 
       const tx = await ShieldInstance.submitTransaction(depositTransaction);
 
-      expect(await StateInstance.isTransactionEscrowed(depositTransactionHash)).to.equal(true);
+      for (let i = 0; i < depositTransaction.commitments.length; ++i) {
+        if (Number(depositTransaction.commitments[i]) !== 0) {
+          expect(
+            // eslint-disable-next-line no-await-in-loop
+            await StateInstance.isCommitmentEscrowed(depositTransaction.commitments[i]),
+          ).to.equal(true);
+        }
+      }
       await expect(tx).to.emit(ShieldInstance, 'TransactionSubmitted').withArgs();
     });
 
@@ -246,11 +253,14 @@ describe('Testing Shield Contract', function () {
         ],
       };
       const tx = await ShieldInstance.submitTransaction(depositTransactionERC721);
-      expect(
-        await StateInstance.isTransactionEscrowed(
-          calculateTransactionHash(depositTransactionERC721),
-        ),
-      ).to.equal(true);
+      for (let i = 0; i < depositTransactionERC721.commitments.length; ++i) {
+        if (Number(depositTransactionERC721.commitments[i]) !== 0) {
+          expect(
+            // eslint-disable-next-line no-await-in-loop
+            await StateInstance.isCommitmentEscrowed(depositTransactionERC721.commitments[i]),
+          ).to.equal(true);
+        }
+      }
       expect(
         await Erc721MockInstance.ownerOf(
           '28948022309329048855892746252171976963317496166410141009864396001978282409986',
@@ -302,11 +312,14 @@ describe('Testing Shield Contract', function () {
         ],
       };
       const tx = await ShieldInstance.submitTransaction(depositTransactionERC1155);
-      expect(
-        await StateInstance.isTransactionEscrowed(
-          calculateTransactionHash(depositTransactionERC1155),
-        ),
-      ).to.equal(true);
+      for (let i = 0; i < depositTransactionERC1155.commitments.length; ++i) {
+        if (Number(depositTransactionERC1155.commitments[i]) !== 0) {
+          expect(
+            // eslint-disable-next-line no-await-in-loop
+            await StateInstance.isCommitmentEscrowed(depositTransactionERC1155.commitments[i]),
+          ).to.equal(true);
+        }
+      }
       expect(await Erc1155MockInstance.balanceOf(await owner[0].address, 0)).to.equal(1099995);
       expect(await Erc1155MockInstance.balanceOf(shieldAddress, 0)).to.equal(5);
       await expect(tx).to.emit(ShieldInstance, 'TransactionSubmitted').withArgs();
@@ -314,7 +327,14 @@ describe('Testing Shield Contract', function () {
 
     it('succeeds for a non deposit transaction', async function () {
       const tx = await ShieldInstance.submitTransaction(withdrawTransaction);
-      expect(await StateInstance.isTransactionEscrowed(withdrawTransactionHash)).to.equal(false);
+      for (let i = 0; i < withdrawTransaction.commitments.length; ++i) {
+        if (Number(withdrawTransaction.commitments[i]) !== 0) {
+          expect(
+            // eslint-disable-next-line no-await-in-loop
+            await StateInstance.isCommitmentEscrowed(withdrawTransaction.commitments[i]),
+          ).to.equal(false);
+        }
+      }
       await expect(tx).to.emit(ShieldInstance, 'TransactionSubmitted').withArgs();
     });
 
@@ -425,7 +445,14 @@ describe('Testing Shield Contract', function () {
 
       const tx = await ShieldInstance.submitTransaction(depositTransaction);
 
-      expect(await StateInstance.isTransactionEscrowed(depositTransactionHash)).to.equal(true);
+      for (let i = 0; i < depositTransaction.commitments.length; ++i) {
+        if (Number(depositTransaction.commitments[i]) !== 0) {
+          expect(
+            // eslint-disable-next-line no-await-in-loop
+            await StateInstance.isCommitmentEscrowed(depositTransaction.commitments[i]),
+          ).to.equal(true);
+        }
+      }
       await expect(tx).to.emit(ShieldInstance, 'TransactionSubmitted').withArgs();
     });
 

--- a/test/unit/SmartContracts/state.unit.test.mjs
+++ b/test/unit/SmartContracts/state.unit.test.mjs
@@ -6,7 +6,7 @@ import {
   calculateTransactionHash,
   createBlockAndTransactions,
 } from '../utils/utils.mjs';
-import { setTransactionInfo } from '../utils/stateStorage.mjs';
+import { setCommitmentHashEscrowed } from '../utils/stateStorage.mjs';
 import {
   packHistoricRoots,
   packTransactionInfo,
@@ -659,17 +659,9 @@ describe('State contract State functions', function () {
           { value: 10 },
         ),
     ).to.be.revertedWith('State: Only current proposer authorised');
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.withdrawTransaction),
-      false,
-    );
-
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      10,
+      transactionsCreated.depositTransaction.commitments,
     );
 
     await state.proposeBlock(
@@ -721,18 +713,13 @@ describe('State contract State functions', function () {
           { value: 10 },
         ),
     ).to.be.revertedWith('State: Only current proposer authorised');
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.withdrawTransaction),
-      false,
-    );
     await expect(
       state.proposeBlock(
         transactionsCreated.block,
         [transactionsCreated.withdrawTransaction, transactionsCreated.depositTransaction],
         { value: 10 },
       ),
-    ).to.be.revertedWithCustomError(state, 'DepositNotEscrowed');
+    ).to.be.revertedWithCustomError(state, 'CommitmentNotEscrowed');
   });
 
   it('should not proposeBlock: transaction hashes root', async function () {
@@ -762,16 +749,9 @@ describe('State contract State functions', function () {
         ),
     ).to.be.revertedWith('State: Only current proposer authorised');
     transactionsCreated.block.transactionHashesRoot = ethers.constants.HashZero;
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.withdrawTransaction),
-      false,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      34,
+      transactionsCreated.depositTransaction.commitments,
     );
     await expect(
       state.proposeBlock(
@@ -804,16 +784,9 @@ describe('State contract State functions', function () {
       '0x0000000000000000000000000000000000000000000000000000000000000000',
     );
 
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.withdrawTransaction),
-      false,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      34,
+      transactionsCreated.depositTransaction.commitments,
     );
     await expect(
       state.proposeBlock(transactionsCreated.block, [transactionsCreated.withdrawTransaction], {
@@ -839,16 +812,9 @@ describe('State contract State functions', function () {
     ]);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.withdrawTransaction),
-      false,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      10,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -897,16 +863,9 @@ describe('State contract State functions', function () {
     ]);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.withdrawTransaction),
-      false,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      34,
+      transactionsCreated.depositTransaction.commitments,
     );
     await expect(
       state.proposeBlock(
@@ -934,16 +893,9 @@ describe('State contract State functions', function () {
     ]);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.withdrawTransaction),
-      false,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      34,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -1030,16 +982,9 @@ describe('State contract State functions', function () {
     ]);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.withdrawTransaction),
-      false,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      34,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -1080,16 +1025,9 @@ describe('State contract State functions', function () {
     ]);
     await state.setCurrentProposer(addr1.address);
     await state.setStakeAccount(addr1.address, amount, challengeLocked);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.withdrawTransaction),
-      false,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      34,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,
@@ -1132,16 +1070,9 @@ describe('State contract State functions', function () {
 
     await state.setCurrentProposer(addr1.address);
     await state.setNumProposers(2);
-    await setTransactionInfo(
+    await setCommitmentHashEscrowed(
       state.address,
-      calculateTransactionHash(transactionsCreated.withdrawTransaction),
-      false,
-    );
-    await setTransactionInfo(
-      state.address,
-      calculateTransactionHash(transactionsCreated.depositTransaction),
-      true,
-      34,
+      transactionsCreated.depositTransaction.commitments,
     );
     await state.proposeBlock(
       transactionsCreated.block,

--- a/test/unit/utils/stateStorage.mjs
+++ b/test/unit/utils/stateStorage.mjs
@@ -5,30 +5,19 @@ import { setStorageAt, time } from '@nomicfoundation/hardhat-network-helpers';
 
 const { ethers } = hardhat;
 
-const txInfoSlot = 163;
+const commitmentEscrowedSlot = 163;
 const blockHashesSlot = 164;
 const stakeAccountsSlot = 167;
 const blockInfoSlot = 168;
 
-export async function setTransactionInfo(
-  stateAddress,
-  transactionHash,
-  isEscrowed = false,
-  ethFee = 0,
-) {
+export async function setCommitmentHashEscrowed(stateAddress, commitments) {
   const index = ethers.utils.solidityKeccak256(
     ['uint256', 'uint256'],
-    [transactionHash, txInfoSlot],
+    [commitments[0], commitmentEscrowedSlot],
   );
-
-  const txInfoStruct = ethers.utils.hexlify(
-    ethers.utils.concat([
-      ethers.utils.hexlify(Number(isEscrowed)),
-      ethers.utils.hexZeroPad(ethers.utils.hexlify(ethFee), 31),
-    ]),
-  );
-
-  await setStorageAt(stateAddress, index, txInfoStruct);
+  const commitmentEscrowed = ethers.utils.hexZeroPad(ethers.utils.hexlify(Number(true)), 14);
+  // eslint-disable-next-line no-await-in-loop
+  await setStorageAt(stateAddress, index, commitmentEscrowed);
 }
 
 export async function setBlockInfo(

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -5,6 +5,8 @@ import Web3 from 'web3';
 import chai from 'chai';
 import config from 'config';
 import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
+import compose from 'docker-compose';
+import mongo from '@polygon-nightfall/common-files/utils/mongo.mjs';
 import { rand } from '@polygon-nightfall/common-files/utils/crypto/crypto-random.mjs';
 
 const { expect } = chai;
@@ -478,10 +480,12 @@ export const waitForSufficientBalance = ({ nf3User, value, ercAddress }) => {
 /**
   function to wait for a number of transactions in the mempool before creating block
 */
-export const waitForSufficientTransactionsMempool = ({ nf3User, nTransactions }) => {
+export const waitForSufficientTransactionsMempool = ({ optimistBaseUrl, nTransactions }) => {
   return new Promise(resolve => {
     async function isSufficientTransactions() {
-      const numberTxs = await nf3User.unprocessedTransactionCount();
+      const { result: mempool } = (await axios.get(`${optimistBaseUrl}/proposer/mempool`)).data;
+      const numberTxs = mempool.filter(e => e.mempool).length;
+
       logger.debug(
         ` Waiting for ${nTransactions} to create a block. Current transactions: ${numberTxs}`,
       );
@@ -555,4 +559,77 @@ export async function getUserCommitments(clientApiUrl, compressedZkpPublicKey) {
         value: c.preimage.value,
       };
     });
+}
+
+// setup a healthcheck wait
+const healthy = async nf3Proposer => {
+  while (!(await nf3Proposer.healthcheck('optimist'))) {
+    await waitForTimeout(1000);
+  }
+
+  logger.debug('optimist is healthy');
+};
+
+const dropOptimistMongoDatabase = async () => {
+  logger.debug(`Dropping Optimist's Mongo database`);
+  let mongoConn;
+  try {
+    mongoConn = await mongo.connection('mongodb://localhost:27017');
+
+    while (!(await mongoConn.db('optimist_data').dropDatabase())) {
+      logger.debug(`Retrying dropping MongoDB`);
+      await waitForTimeout(2000);
+    }
+
+    logger.debug(`Optimist's Mongo database dropped successfuly!`);
+  } finally {
+    mongo.disconnect();
+  }
+};
+
+const dropOptimistMongoBlocksCollection = async () => {
+  logger.debug(`Dropping Optimist's Mongo collection`);
+  let mongoConn;
+  try {
+    mongoConn = await mongo.connection('mongodb://localhost:27017');
+
+    while (!(await mongoConn.db('optimist_data').collection('blocks').drop())) {
+      logger.debug(`Retrying dropping MongoDB blocks colection`);
+      await waitForTimeout(2000);
+    }
+    while (!(await mongoConn.db('optimist_data').collection('timber').drop())) {
+      logger.debug(`Retrying dropping MongoDB timber colection`);
+      await waitForTimeout(2000);
+    }
+
+    logger.debug(`Optimist's Mongo blocks dropped successfuly!`);
+  } finally {
+    mongo.disconnect();
+  }
+};
+
+export async function restartOptimist(nf3Proposer, dropDb = true) {
+  const options = {
+    config: [
+      'docker/docker-compose.yml',
+      'docker/docker-compose.dev.yml',
+      'docker/docker-compose.ganache.yml',
+    ],
+    log: process.env.LOG_LEVEL || 'silent',
+    composeOptions: [['-p', 'nightfall_3']],
+  };
+
+  await compose.stopOne('optimist', options);
+  await compose.rm(options, 'optimist');
+
+  // dropDb vs dropCollection.
+  if (dropDb) {
+    await dropOptimistMongoDatabase();
+  } else {
+    await dropOptimistMongoBlocksCollection();
+  }
+
+  await compose.upOne('optimist', options);
+
+  await healthy(nf3Proposer);
 }

--- a/wallet/src/contract-abis/Shield.json
+++ b/wallet/src/contract-abis/Shield.json
@@ -3,11 +3,11 @@
     "inputs": [
       {
         "internalType": "bytes32",
-        "name": "depositHash",
+        "name": "commitmentHash",
         "type": "bytes32"
       }
     ],
-    "name": "DepositNotEscrowed",
+    "name": "CommitmentNotEscrowed",
     "type": "error"
   },
   {

--- a/wallet/src/contract-abis/Shield.json
+++ b/wallet/src/contract-abis/Shield.json
@@ -1297,7 +1297,7 @@
     ],
     "name": "submitTransaction",
     "outputs": [],
-    "stateMutability": "payable",
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/wallet/src/nightfall-browser/event-handlers/block-proposed.js
+++ b/wallet/src/nightfall-browser/event-handlers/block-proposed.js
@@ -45,7 +45,7 @@ async function blockProposedEventHandler(data, zkpPrivateKeys, nullifierKeys) {
 
   const dbUpdates = transactions.map(async transaction => {
     // filter out non zero commitments and nullifiers
-    const nonZeroCommitments = transaction.commitments.filter(n => n !== ZERO);
+    const nonZeroCommitments = transaction.commitments.filter(c => c !== ZERO);
     const nonZeroNullifiers = transaction.nullifiers.filter(n => n !== ZERO);
 
     const countOfNonZeroCommitments = await countCommitments([nonZeroCommitments[0]]);
@@ -53,9 +53,9 @@ async function blockProposedEventHandler(data, zkpPrivateKeys, nullifierKeys) {
     const storeCommitments = [];
     const tempTransactionStore = [];
     // In order to check if the transaction is a transfer, we check if the compressed secrets
-    // are different than zero. All other transaction types have compressedSecrets = [0,0]
+    // are different than zero. All other transaction types have compressedSecrets = [ZERO,ZERO]
     if (
-      (transaction.compressedSecrets[0] !== 0 || transaction.compressedSecrets[1] !== 0) &&
+      (transaction.compressedSecrets[0] !== ZERO || transaction.compressedSecrets[1] !== ZERO) &&
       !countOfNonZeroCommitments
     ) {
       zkpPrivateKeys.forEach((key, i) => {
@@ -94,6 +94,7 @@ async function blockProposedEventHandler(data, zkpPrivateKeys, nullifierKeys) {
               saveTransaction({
                 transactionHashL1,
                 ...transaction,
+                isDecrypted: true,
               }),
             );
           }

--- a/wallet/src/nightfall-browser/event-handlers/subscribe.js
+++ b/wallet/src/nightfall-browser/event-handlers/subscribe.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-await-in-loop */
 
 // ignore unused exports startEventQueue
+// ignore unused exports waitForContract
 
 /**
  * Module to subscribe to blockchain events
@@ -22,7 +23,7 @@ const { RETRIES } = global.config;
  * This is useful in case nightfall-client comes up before the contract
  * is fully deployed.
  */
-async function waitForContract(contractName) {
+export async function waitForContract(contractName) {
   let errorCount = 0;
   let error;
   let instance;

--- a/wallet/src/nightfall-browser/services/commitment-storage.js
+++ b/wallet/src/nightfall-browser/services/commitment-storage.js
@@ -398,7 +398,9 @@ export async function getWalletPendingDepositBalance() {
   const vals = await db.getAll(COMMITMENTS_COLLECTION);
   const wallet =
     Object.keys(vals).length > 0
-      ? vals.filter(v => v.isDeposited && !v.isNullified && v.isOnChain === -1)
+      ? vals.filter(
+          v => v.isDeposited && !v.isNullified && v.isOnChain === -1 && v.isCommitmentInTransaction,
+        )
       : [];
   // the below is a little complex.  First we extract the ercAddress, tokenId and value
   // from the preimage.  Then we format them nicely. We don't care about the value of the

--- a/wallet/src/nightfall-browser/services/commitment-storage.js
+++ b/wallet/src/nightfall-browser/services/commitment-storage.js
@@ -891,7 +891,7 @@ export async function findUsableCommitmentsMutex(
   );
 }
 
-export async function getCommitmentsByHash(hashes, compressedZkpPublicKey) {
+export async function getCommitmentsAvailableByHash(hashes, compressedZkpPublicKey) {
   const db = await connectDB();
   const vals = db.getAll(COMMITMENTS_COLLECTION);
   const commitment = vals.filter(

--- a/wallet/src/nightfall-browser/services/database.js
+++ b/wallet/src/nightfall-browser/services/database.js
@@ -338,3 +338,23 @@ export async function setTransactionHashSiblingInfo(
   }
   return null;
 }
+
+/**
+function to find transactions with a transactionHash in the array transactionHashes.
+*/
+export async function getTransactionsByTransactionHashesByL2Block(transactionHashes, block) {
+  const db = await connectDB();
+  const res = await db.getAll(TRANSACTIONS_COLLECTION);
+  const filteredTransactions = res.filter(
+    t => t.blockNumberL2 === block.blockNumberL2 && transactionHashes.includes(t.transactionHash),
+  );
+  // Create a dictionary where we will store the correct position ordering
+  const positions = {};
+  // Use the ordering of txHashes in the block to fill the dictionary-indexed by txHash
+  // eslint-disable-next-line no-return-assign
+  transactionHashes.forEach((t, index) => (positions[t] = index));
+  const transactions = filteredTransactions.sort(
+    (a, b) => positions[a.transactionHash] - positions[b.transactionHash],
+  );
+  return transactions;
+}

--- a/wallet/src/nightfall-browser/utils/getCommitmentInfo.ts
+++ b/wallet/src/nightfall-browser/utils/getCommitmentInfo.ts
@@ -5,7 +5,7 @@ import Nullifier from '../classes/nullifier';
 import {
   clearPending,
   findUsableCommitmentsMutex,
-  getCommitmentsByHash,
+  getCommitmentsAvailableByHash,
   getSiblingInfo,
   markPending,
 } from '../services/commitment-storage';
@@ -106,7 +106,10 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
 
       // Search for the commitment hashes in the DB. The commitment will be considered valid
       // as long as it is not already nullified
-      const rawCommitments = await getCommitmentsByHash(commitmentHashes, compressedZkpPublicKey);
+      const rawCommitments = await getCommitmentsAvailableByHash(
+        commitmentHashes,
+        compressedZkpPublicKey,
+      );
 
       // Filter which of those commitments belong to the ercAddress
       const ercAddressCommitments = rawCommitments.filter(
@@ -145,7 +148,7 @@ const getCommitmentInfo = async (txInfo: TxInfo): Promise<CommitmentsInfo> => {
 
       // Search for the commitment hashes in the DB. The commitment will be considered valid
       // as long as it is not already nullified
-      const rawCommitmentsFee = await getCommitmentsByHash(
+      const rawCommitmentsFee = await getCommitmentsAvailableByHash(
         commitmentHashesFee,
         compressedZkpPublicKey,
       );


### PR DESCRIPTION
This PR should go after #1324.

With the current code base, a user could do a deposit of an NFT paying the fee and after a rollback that commitment could be rollbacked. Since when depositing to L2 we are "escrowing" the funds, we need to make sure that even if there's a rollback the user can still deposit that commitment. 
To accomplish this, instead of storing the transactionHash when submitting the transaction, we will be storing the commitmentHash that is related to the funds escrowed, which basically is the `commitment[0]` of a deposit transaction. 
The node code has been adjusted so that the user can specify the `salt `when creating a deposit, which would allow them to send a commitment again. 
There's no mechanism that automatically creates the deposit again for the client after a rollback if needed. However, a new parameter called `isCommitmentInTransaction` is stored along with the commitment, which is a boolean that tells if the commitment is already in a transaction. As soon as the commitment is stored, it will be set to true. If a rollback happens and the commitment's transaction is removed from the optimist, not only `isOnChain` will be reset but also this new parameter will be set to false. Therefore, the user will be able to check their DB and look for commitments that are related to funds escrowed by looking for commitments that are `isOnChain = -1` and `isCommitmentInTransaction: false`. 

The test deep rollback in the `adversary-test` has been modified so that it covers this scenario.

In the `Shield` contract, the function `submitTransaction` has been modified so if a deposit with the same commitment is sent via on-chain, the funds are not escrowed twice. 

In the optimist, `transaction-submitted` has been modified so that the optimist doesn't accept a deposit if not escrowed.

This PR also modifies the behaviour of `queues[2]` so that, if a challenger is disabled an enabled after a while and the queue isn't empty, the challenges will be sent again.
