### PR TITLE
trusted key bug

### DIFF
--- a/nightfall-deployer/contracts/X509.sol
+++ b/nightfall-deployer/contracts/X509.sol
@@ -419,7 +419,6 @@ contract X509 is DERParser, Whitelist, X509Interface {
         // we only check extended key usage for end-user certs; it's not really relevant for CA certs
         checkExtendedKeyUsage(tlvs, oidGroup);
         checkCertificatePolicies(tlvs, oidGroup);
-        trustedPublicKeys[subjectKeyIdentifier] = certificatePublicKey;
         checkSignature(
             addressSignature,
             abi.encodePacked(uint160(msg.sender)),


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Currently, when we validate either an intermediate CA certificate or an end-user certificate, we add their public keys to the list of keys that the smart contract trusts.  We should not be doing this for an end-user certificate because it would enable the holder of an end-user certificate to act as an intermediate CA and create their own end user certificates.
This fix stops adding end-user public keys to the trusted keys list.

## Does this close any currently open issues?

No, it's a bug-fix

## What commands can I run to test the change? 

You can run `npm run unit-test-x509`

## Any other comments?

It's an important fix.