### PR TITLE
fix: registerProposer

### DIFF
--- a/nightfall-deployer/contracts/Proposers.sol
+++ b/nightfall-deployer/contracts/Proposers.sol
@@ -43,7 +43,6 @@ contract Proposers is Stateful, Config, ReentrancyGuardUpgradeable {
             currentProposer = LinkedAddress(msg.sender, msg.sender, msg.sender, url, fee, false, 0);
             state.setProposer(msg.sender, currentProposer);
             state.setProposerStartBlock(block.number);
-            state.setNumProposers(1);
             emit NewCurrentProposer(currentProposer.thisAddress);
         } else {
             // only if it's not a proposer yet
@@ -78,10 +77,10 @@ contract Proposers is Stateful, Config, ReentrancyGuardUpgradeable {
                 }
                 state.setProposer(proposersCurrent.thisAddress, proposersCurrent);
                 state.setProposer(msg.sender, proposer);
-                state.setNumProposers(state.numProposers() + 1);
             }
         }
         state.setCurrentProposer(currentProposer.thisAddress);
+        state.setNumProposers(state.numProposers() + 1);
     }
 
     // Proposers are allowed to deregister themselves at any point (even if they are the current proposer)


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
solves the problem that occurred when two proposers were registered, but the `spanProposersList` that was built contained only 1 proposer instead of 2. this was due to the fact that the `numproposer` was incremented before the `currentProposer` was set

## What commands can I run to test the change? 
`./bin/start-multiproposer-test-env -g`
then: 
`docker logs -f proposer_1`
from the logs it will be possible to see the printed `spanProposersList` containing both the proposers

