### PR TITLE
fix: add some wait for balances before transfer and withdraw to be sy…

### DIFF
--- a/test/ping-pong/index.mjs
+++ b/test/ping-pong/index.mjs
@@ -107,6 +107,13 @@ export async function simpleUserTest(
     const valueToTransfer = Math.floor(Math.random() * (value - fee)) + 2; // Returns a random integer from 2 to value - fee
 
     try {
+      await waitForSufficientBalance({
+        nf3User: nf3,
+        value: valueToTransfer + fee,
+        ercAddress,
+        message: `Waiting balance for transfer ${nf3.zkpKeys.compressedZkpPublicKey}.`,
+      });
+
       const res = await nf3.transfer(
         txTypes[i * 3],
         offchainTx,
@@ -188,6 +195,13 @@ export async function simpleUserTest(
     } catch (err) {
       console.warn('Error deposit', err);
     }
+
+    await waitForSufficientBalance({
+      nf3User: nf3,
+      value: valueToTransfer + fee,
+      ercAddress,
+      message: `Waiting balance for withdraw ${nf3.zkpKeys.compressedZkpPublicKey}.`,
+    });
 
     try {
       const res = await nf3.withdraw(

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -459,12 +459,12 @@ export const registerProposerOnNoProposer = async proposer => {
   function to wait for sufficient balance by waiting for pending transaction
   to be proposed
 */
-export const waitForSufficientBalance = ({ nf3User, value, ercAddress }) => {
+export const waitForSufficientBalance = ({ nf3User, value, ercAddress, message }) => {
   return new Promise(resolve => {
     async function isSufficientBalance() {
       const balance = await retrieveL2Balance(nf3User, ercAddress);
       logger.debug(
-        ` Balance needed for ${nf3User.ethereumAddress} is ${value}. Current balance ${balance}.`,
+        `${message} Balance needed for ${nf3User.ethereumAddress} is ${value}. Current balance ${balance}.`,
       );
       if (balance < value) {
         await waitForTimeout(10000);


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Fix synchronization balance before transfer and withdraw

## Does this close any currently open issues?
No

## What commands can I run to test the change? 
- In one terminal `./bin/start-multiproposer-test-env -g`
- In another terminal `npm run ping-pong`

## Any other comments?
No
