### PR TITLE
fix: add proposer host, port defaults to proposer app

### DIFF
--- a/docker/docker-compose.apps.yml
+++ b/docker/docker-compose.apps.yml
@@ -22,8 +22,8 @@ services:
       OPTIMIST_WS_PORT: ${OPTIMIST_WS_PORT:-8080}
       CLIENT_HOST: ${CLIENT_HOST:-client}
       CLIENT_PORT: ${CLIENT_PORT:-8080}
-      PROPOSER_HOST: ${PROPOSER_HOST}
-      PROPOSER_PORT: ${PROPOSER_PORT}
+      PROPOSER_HOST: ${PROPOSER_HOST:-proposer}
+      PROPOSER_PORT: ${PROPOSER_PORT:-8092}
     networks:
       - nightfall_network
     volumes:


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Client couldn't reach proposer eg when sending offchain transactions. Have added a couple of defaults to the docker compose apps file, to resolve the proposer host and port successfully.
