### PR TITLE
fix: Adding listener for queues on errors

### DIFF
--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -27,10 +27,16 @@ import {
 // TODO when SDK is refactored such that these functions are split by user, proposer and challenger,
 // then there will only be one queue here. The constructor does not need to initialise clientBaseUrl
 // for proposer/liquidityProvider/challenger and optimistBaseUrl, optimistWsUrl for a user etc
-const userQueue = new Queue({ autostart: true, concurrency: 1 });
-const proposerQueue = new Queue({ autostart: true });
-const challengerQueue = new Queue({ autostart: true, concurrency: 1 });
-const liquidityProviderQueue = new Queue({ autostart: true, concurrency: 1 });
+const userQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 }));
+const proposerQueue = catchQueueError(new Queue({ autostart: true }));
+const challengerQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 }));
+const liquidityProviderQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 }));
+
+function catchQueueError(emitter) {
+  emitter.on('error', error => logger.error({ msg: 'Error caught by queue', error }));
+
+  return emitter;
+}
 
 /**
 @class

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -24,19 +24,20 @@ import {
   GAS_ESTIMATE_ENDPOINT,
 } from './constants.mjs';
 
-function catchQueueError(emitter) {
-  emitter.on('error', error => logger.error({ msg: 'Error caught by queue', error }));
+function createQueue(options) {
+  const queue = new Queue(options);
+  queue.on('error', error => logger.error({ msg: 'Error caught by queue', error }));
 
-  return emitter;
+  return queue;
 }
 
 // TODO when SDK is refactored such that these functions are split by user, proposer and challenger,
 // then there will only be one queue here. The constructor does not need to initialise clientBaseUrl
 // for proposer/liquidityProvider/challenger and optimistBaseUrl, optimistWsUrl for a user etc
-const userQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 }));
-const proposerQueue = catchQueueError(new Queue({ autostart: true }));
-const challengerQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 }));
-const liquidityProviderQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 }));
+const userQueue = createQueue({ autostart: true, concurrency: 1 });
+const proposerQueue = createQueue({ autostart: true });
+const challengerQueue = createQueue({ autostart: true, concurrency: 1 });
+const liquidityProviderQueue = createQueue({ autostart: true, concurrency: 1 });
 
 /**
 @class

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -24,6 +24,12 @@ import {
   GAS_ESTIMATE_ENDPOINT,
 } from './constants.mjs';
 
+function catchQueueError(emitter) {
+  emitter.on('error', error => logger.error({ msg: 'Error caught by queue', error }));
+
+  return emitter;
+}
+
 // TODO when SDK is refactored such that these functions are split by user, proposer and challenger,
 // then there will only be one queue here. The constructor does not need to initialise clientBaseUrl
 // for proposer/liquidityProvider/challenger and optimistBaseUrl, optimistWsUrl for a user etc
@@ -31,12 +37,6 @@ const userQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 })
 const proposerQueue = catchQueueError(new Queue({ autostart: true }));
 const challengerQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 }));
 const liquidityProviderQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 }));
-
-function catchQueueError(emitter) {
-  emitter.on('error', error => logger.error({ msg: 'Error caught by queue', error }));
-
-  return emitter;
-}
 
 /**
 @class

--- a/common-files/utils/event-queue.mjs
+++ b/common-files/utils/event-queue.mjs
@@ -24,12 +24,22 @@ import config from 'config';
 import logger from './logger.mjs';
 import { web3 } from './contract.mjs';
 
+function createQueue(options) {
+  const queue = new Queue(options);
+  queue.on('error', error => logger.error({ msg: 'Error caught by queue', error }));
+
+  return queue;
+}
+
 const { MAX_QUEUE, CONFIRMATION_POLL_TIME, CONFIRMATIONS } = config;
-const fastQueue = new Queue({ autostart: false, concurrency: 1 });
-const slowQueue = new Queue({ autostart: false, concurrency: 1 });
-const removed = {}; // singleton holding transaction hashes of any removed events
-const stopQueue = new Queue({ autostart: false, concurrency: 1 });
+
+const fastQueue = createQueue({ autostart: false, concurrency: 1 });
+const slowQueue = createQueue({ autostart: false, concurrency: 1 });
+const stopQueue = createQueue({ autostart: false, concurrency: 1 });
+
 export const queues = [fastQueue, slowQueue, stopQueue];
+
+const removed = {}; // singleton holding transaction hashes of any removed events
 
 /**
 This function will wait until all the functions currently in a queue have been

--- a/wallet/src/common-files/utils/event-queue.js
+++ b/wallet/src/common-files/utils/event-queue.js
@@ -21,9 +21,15 @@ import Queue from 'queue';
 import logger from './logger';
 
 const { MAX_QUEUE } = global.config;
-const fastQueue = new Queue({ autostart: true, concurrency: 1 });
-const slowQueue = new Queue({ autostart: true, concurrency: 1 });
+const fastQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 }));
+const slowQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 }));
 export const queues = [fastQueue, slowQueue];
+
+function catchQueueError(emitter) {
+  emitter.on('error', error => logger.error({ msg: 'Error caught by queue', error }));
+
+  return emitter;
+}
 
 /**
 This function will return a promise that resolves to true when the next highest

--- a/wallet/src/common-files/utils/event-queue.js
+++ b/wallet/src/common-files/utils/event-queue.js
@@ -20,16 +20,16 @@ and catch these removals, processing them appropriately.
 import Queue from 'queue';
 import logger from './logger';
 
-const { MAX_QUEUE } = global.config;
-const fastQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 }));
-const slowQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 }));
-export const queues = [fastQueue, slowQueue];
-
 function catchQueueError(emitter) {
   emitter.on('error', error => logger.error({ msg: 'Error caught by queue', error }));
 
   return emitter;
 }
+
+const { MAX_QUEUE } = global.config;
+const fastQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 }));
+const slowQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 }));
+export const queues = [fastQueue, slowQueue];
 
 /**
 This function will return a promise that resolves to true when the next highest

--- a/wallet/src/common-files/utils/event-queue.js
+++ b/wallet/src/common-files/utils/event-queue.js
@@ -20,15 +20,16 @@ and catch these removals, processing them appropriately.
 import Queue from 'queue';
 import logger from './logger';
 
-function catchQueueError(emitter) {
-  emitter.on('error', error => logger.error({ msg: 'Error caught by queue', error }));
+function createQueue(options) {
+  const queue = new Queue(options);
+  queue.on('error', error => logger.error({ msg: 'Error caught by queue', error }));
 
-  return emitter;
+  return queue;
 }
 
 const { MAX_QUEUE } = global.config;
-const fastQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 }));
-const slowQueue = catchQueueError(new Queue({ autostart: true, concurrency: 1 }));
+const fastQueue = createQueue({ autostart: true, concurrency: 1 });
+const slowQueue = createQueue({ autostart: true, concurrency: 1 });
 export const queues = [fastQueue, slowQueue];
 
 /**


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
This fixes an issue that can happen when errors aren't properly caught by the queues. The queues being used are emitters and when there isn't a listener for an 'error' event for that queue and an error happens, the application crashes. 

Follows the log of a test performed locally:

```
optimist_1       | [2023-01-06 14:25:49.066] DEBUG: Block Assembler - about to make a new block
optimist_1       |     correlationId: "579dd1c6-1ad5-448e-89f3-90c1173cc75c"
optimist_1       | file:///app/node_modules/@polygon-nightfall/common-files/utils/block-utils.mjs:27
optimist_1       |   const proposerPacked = generalise(proposer).hex(20).slice(2);
optimist_1       |                                              ^
optimist_1       | 
optimist_1       | TypeError: Cannot read properties of undefined (reading 'hex')
optimist_1       |     at packBlockInfo (file:///app/node_modules/@polygon-nightfall/common-files/utils/block-utils.mjs:27:46)
optimist_1       |     at calcBlockHash (file:///app/node_modules/@polygon-nightfall/common-files/utils/block-utils.mjs:45:22)
optimist_1       |     at Function.calcHash (file:///app/src/classes/block.mjs:218:12)
optimist_1       |     at Function.build (file:///app/src/classes/block.mjs:138:28)
optimist_1       |     at runMicrotasks (<anonymous>)
optimist_1       |     at processTicksAndRejections (node:internal/process/task_queues:96:5)
optimist_1       |     at async conditionalMakeBlock (file:///app/src/services/block-assembler.mjs:166:23)
optimist_1       | Emitted 'error' event on Queue instance at:
optimist_1       |     at next (/app/node_modules/queue/index.js:108:14)
optimist_1       |     at /app/node_modules/queue/index.js:150:14
optimist_1       |     at runMicrotasks (<anonymous>)
optimist_1       |     at processTicksAndRejections (node:internal/process/task_queues:96:5)
nightfall_3_optimist_1 exited with code 1
```

## Does this close any currently open issues?
No

## What commands can I run to test the change? 
The current ones in Github Actions.

## Any other comments?
No
