### PR TITLE
refactor: optimize db calls to memepol cleanup

### DIFF
--- a/common-files/utils/mongo.mjs
+++ b/common-files/utils/mongo.mjs
@@ -24,9 +24,6 @@ export default {
       const client = await new MongoClient(url, {
         useUnifiedTopology: true,
         connectTimeoutMS: 40000,
-        // keepAlive: true,
-        // serverSelectionTimeoutMS: 30000,
-        // socketTimeoutMS: 360000,
       });
       connection[url] = await client.connect();
     }

--- a/nightfall-optimist/src/event-handlers/block-proposed.mjs
+++ b/nightfall-optimist/src/event-handlers/block-proposed.mjs
@@ -13,8 +13,7 @@ import {
   getLatestTree,
   saveTree,
   saveInvalidBlock,
-  deleteDuplicateCommitmentsFromMemPool,
-  deleteDuplicateNullifiersFromMemPool,
+  deleteDuplicateCommitmentsAndNullifiersFromMemPool,
   saveTransaction,
 } from '../services/database.mjs';
 import { getProposeBlockCalldata } from '../services/process-calldata.mjs';
@@ -84,8 +83,12 @@ async function blockProposedEventHandler(data) {
     const blockNullifiers = transactions
       .map(t => t.nullifiers.filter(c => c !== ZERO))
       .flat(Infinity);
-    await deleteDuplicateCommitmentsFromMemPool(blockCommitments, block.transactionHashes);
-    await deleteDuplicateNullifiersFromMemPool(blockNullifiers, block.transactionHashes);
+
+    await deleteDuplicateCommitmentsAndNullifiersFromMemPool(
+      blockCommitments,
+      blockNullifiers,
+      block.transactionHashes,
+    );
 
     const latestTree = await getLatestTree();
     const updatedTimber = Timber.statelessUpdate(

--- a/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
+++ b/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
@@ -5,8 +5,7 @@ import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
 import constants from '@polygon-nightfall/common-files/constants/index.mjs';
 import { waitForContract } from '@polygon-nightfall/common-files/utils/contract.mjs';
 import {
-  deleteDuplicateCommitmentsFromMemPool,
-  deleteDuplicateNullifiersFromMemPool,
+  deleteDuplicateCommitmentsAndNullifiersFromMemPool,
   saveTransaction,
 } from '../services/database.mjs';
 import { checkTransaction } from '../services/transaction-checker.mjs';
@@ -56,13 +55,14 @@ async function transactionSubmittedEventHandler(eventParams) {
       checkDuplicatesInL2: true,
       checkDuplicatesInMempool: true,
     });
-    logger.info({ msg: 'Transaction checks passed' });
 
     const transactionCommitments = transaction.commitments.filter(c => c !== ZERO);
     const transactionNullifiers = transaction.nullifiers.filter(n => n !== ZERO);
 
-    await deleteDuplicateCommitmentsFromMemPool(transactionCommitments);
-    await deleteDuplicateNullifiersFromMemPool(transactionNullifiers);
+    await deleteDuplicateCommitmentsAndNullifiersFromMemPool(
+      transactionCommitments,
+      transactionNullifiers,
+    );
 
     await saveTransaction({ ...transaction });
   } catch (err) {

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -94,13 +94,6 @@ export async function getBlockByTransactionHashL1(transactionHashL1) {
   return db.collection(SUBMITTED_BLOCKS_COLLECTION).findOne(query);
 }
 
-// export async function numberOfBlockWithTransactionHash(transactionHash) {
-//   const connection = await mongo.connection(MONGO_URL);
-//   const db = connection.db(OPTIMIST_DB);
-//   const query = { transactionHashes: transactionHash };
-//   return db.collection(SUBMITTED_BLOCKS_COLLECTION).countDocuments(query);
-// }
-
 /**
 function to get a block by blockHash, if you know the hash of the block. This
 is useful for rolling back Timber.
@@ -342,29 +335,18 @@ export async function removeTransactionsFromMemPool(
 }
 
 /**
-Function to remove a set of commitments from the layer 2 mempool once they've
-been processed into an L2 block
+Function to remove a set of commitments and nullifiers from the layer 2 mempool
+once they've been processed into an L2 block
 */
-export async function deleteDuplicateCommitmentsFromMemPool(commitments, transactionHashes = []) {
+export async function deleteDuplicateCommitmentsAndNullifiersFromMemPool(
+  commitments,
+  nullifiers,
+  transactionHashes = [],
+) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   const query = {
-    commitments: { $in: commitments },
-    transactionHash: { $nin: transactionHashes },
-    mempool: true,
-  };
-  return db.collection(TRANSACTIONS_COLLECTION).deleteMany(query);
-}
-
-/**
-Function to remove a set of nullifiers from the layer 2 mempool once they've
-been processed into an L2 block
-*/
-export async function deleteDuplicateNullifiersFromMemPool(nullifiers, transactionHashes = []) {
-  const connection = await mongo.connection(MONGO_URL);
-  const db = connection.db(OPTIMIST_DB);
-  const query = {
-    nullifiers: { $in: nullifiers },
+    $or: [{ commitments: { $in: commitments } }, { nullifiers: { $in: nullifiers } }],
     transactionHash: { $nin: transactionHashes },
     mempool: true,
   };


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Reduces number of DB calls. Instead of blocking execution context twice for `deleteDuplicateCommitmentsFromMemPool` and `deleteDuplicateNullifiersFromMemPool` it performs the same operation using just one call to `deleteDuplicateCommitmentsAndNullifiersFromMemPool` and blocks the execution just once.