### PR TITLE
periodic payment cron job for proposer and challenger

### DIFF
--- a/.github/workflows/on-pull-request-master.yml
+++ b/.github/workflows/on-pull-request-master.yml
@@ -722,6 +722,19 @@ jobs:
       - name: Build adversary
         run: npm run build-adversary
 
+      - name: Perform npm link
+        run: |
+          cd common-files
+          npm link
+          cd ..
+          npm link @polygon-nightfall/common-files
+          cd cli
+          npm link @polygon-nightfall/common-files
+          cd ..
+          cd test/adversary/adversary-cli
+          npm link @polygon-nightfall/common-files
+          cd .. && cd .. && cd ..
+
       - name: Start Containers
         run: |
           ./bin/setup-nightfall
@@ -770,6 +783,9 @@ jobs:
         with:
           node-version: '16.17.0'
 
+      - name: Build adversary
+        run: npm run build-adversary
+
       - name: Perform npm link
         run: |
           cd common-files
@@ -779,9 +795,9 @@ jobs:
           cd cli
           npm link @polygon-nightfall/common-files
           cd ..
-
-      - name: Build adversary
-        run: npm run build-adversary
+          cd test/adversary/adversary-cli
+          npm link @polygon-nightfall/common-files
+          cd .. && cd .. && cd ..
 
       - name: Start Containers
         run: |
@@ -970,3 +986,60 @@ jobs:
         with:
           name: test-apps-logs
           path: ./test-apps.log
+
+  periodic-payment-test:
+    env:
+      CONFIRMATIONS: 1
+      NF_SERVICES_TO_START: blockchain,client,deployer,mongodb,optimist,rabbitmq,worker
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '16.17.0'
+
+      - name: Perform npm link
+        run: |
+          cd common-files
+          npm link
+          cd ..
+          npm link @polygon-nightfall/common-files
+          cd cli
+          npm link @polygon-nightfall/common-files
+          cd ..
+
+      - name: Start Containers
+        run: |
+          ./bin/setup-nightfall
+          ./bin/start-nightfall -g -d &> periodic-payment-test.log &disown
+
+      - name: Wait for images to be ready
+        uses: Wandalen/wretry.action@v1.0.11
+        with:
+          command: |
+            docker wait nightfall_3_deployer_1
+          attempt_limit: 100
+          attempt_delay: 20000
+
+      - name: Debug logs - after image builds
+        if: always()
+        run: cat periodic-payment-test.log
+
+      - name: Run integration test
+        run: |
+          npm run test-periodic-payment
+
+      - name: Debug logs - after integration test run
+        if: always()
+        run: cat periodic-payment-test.log
+
+      - name: If integration test failed, shutdown the Containers
+        if: failure()
+        run: npm run nightfall-down
+
+      - name: If integration test failed, upload logs files as artifacts
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: periodic-payment-test-logs
+          path: ./periodic-payment-test.log

--- a/cli/lib/constants.mjs
+++ b/cli/lib/constants.mjs
@@ -21,4 +21,9 @@ export const GAS_MULTIPLIER = Number(process.env.GAS_MULTIPLIER) || 2;
 export const GAS_PRICE_MULTIPLIER = Number(process.env.GAS_PRICE_MULTIPLIER) || 2;
 export const GAS = process.env.GAS || 4000000;
 export const GAS_PRICE = process.env.GAS_PRICE || '10000000000';
-export const { GAS_ESTIMATE_ENDPOINT } = process.env;
+export const GAS_ESTIMATE_ENDPOINT =
+  process.env.GAS_ESTIMATE_ENDPOINT ||
+  'https://vqxy02tr5e.execute-api.us-east-2.amazonaws.com/production/estimateGas';
+
+export const DEFAULT_MIN_L1_WITHDRAW = 1; // minimum l1 balance in wei required for withdraw from State contract
+export const DEFAULT_MIN_L2_WITHDRAW = 1; // minimum l2 erc20 token balance required for withdraw from State contract

--- a/cli/lib/constants.mjs
+++ b/cli/lib/constants.mjs
@@ -21,9 +21,6 @@ export const GAS_MULTIPLIER = Number(process.env.GAS_MULTIPLIER) || 2;
 export const GAS_PRICE_MULTIPLIER = Number(process.env.GAS_PRICE_MULTIPLIER) || 2;
 export const GAS = process.env.GAS || 4000000;
 export const GAS_PRICE = process.env.GAS_PRICE || '10000000000';
-export const GAS_ESTIMATE_ENDPOINT =
-  process.env.GAS_ESTIMATE_ENDPOINT ||
-  'https://vqxy02tr5e.execute-api.us-east-2.amazonaws.com/production/estimateGas';
-
+export const { GAS_ESTIMATE_ENDPOINT } = process.env;
 export const DEFAULT_MIN_L1_WITHDRAW = 1; // minimum l1 balance in wei required for withdraw from State contract
 export const DEFAULT_MIN_L2_WITHDRAW = 1; // minimum l2 erc20 token balance required for withdraw from State contract

--- a/cli/lib/jobScheduler.mjs
+++ b/cli/lib/jobScheduler.mjs
@@ -1,0 +1,15 @@
+/**
+ * This is cron library to create scheduler
+ * for any given job
+ */
+import cron from 'node-cron';
+
+export default function createJob(cronExp, job) {
+  if (!cron.validate(cronExp)) {
+    throw Error('Invalid cron expression string');
+  }
+  if (!(job instanceof Function)) {
+    throw Error('No valid Job');
+  }
+  return cron.schedule(cronExp, job);
+}

--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -15,6 +15,7 @@ import { approve } from './tokens.mjs';
 import erc20 from './abis/ERC20.mjs';
 import erc721 from './abis/ERC721.mjs';
 import erc1155 from './abis/ERC1155.mjs';
+import createJob from './jobScheduler.mjs';
 
 import {
   DEFAULT_FEE_TOKEN_VALUE,
@@ -24,6 +25,8 @@ import {
   GAS_PRICE,
   GAS_PRICE_MULTIPLIER,
   GAS_ESTIMATE_ENDPOINT,
+  DEFAULT_MIN_L1_WITHDRAW,
+  DEFAULT_MIN_L2_WITHDRAW,
 } from './constants.mjs';
 
 function createQueue(options) {
@@ -76,6 +79,8 @@ class Nf3 {
 
   stateContract;
 
+  shieldContract;
+
   ethereumSigningKey;
 
   ethereumAddress;
@@ -97,6 +102,14 @@ class Nf3 {
   nonceMutex = new Mutex();
 
   clientAuthenticationKey;
+
+  // min fee or reward one should hold for withdaw
+  // in State contract.
+  minL1Balance = DEFAULT_MIN_L1_WITHDRAW;
+
+  minL2Balance = DEFAULT_MIN_L2_WITHDRAW;
+
+  periodicPaymentJob;
 
   constructor(
     ethereumSigningKey,
@@ -172,6 +185,7 @@ class Nf3 {
     this.challengesContractAddress = await this.contractGetter('Challenges');
     this.stateContractAddress = await this.contractGetter('State');
     this.stateContract = await this.getContractInstance('State');
+    this.shieldContract = await this.getContractInstance('Shield');
 
     // set the ethereumAddress iff we have a signing key
     if (typeof this.ethereumSigningKey === 'string') {
@@ -1202,6 +1216,11 @@ class Nf3 {
     return this.stateContract.methods.getRotateProposerBlocks().call();
   }
 
+  // used by proposers and challengers
+  async getPendingWithdrawsFromStateContract() {
+    return this.stateContract.methods.pendingWithdrawalsFees(this.ethereumAddress).call();
+  }
+
   /**
     Starts a Proposer that listens for blocks and submits block proposal
     transactions to the blockchain.
@@ -1698,6 +1717,45 @@ class Nf3 {
     */
   async getSprintsInSpan() {
     return this.stateContract.methods.getSprintsInSpan().call();
+  }
+
+  /**
+   * function start periodic payment
+   * @param cronExp {string} default is At 00:00 on every 6th day-of-week (Saturday).
+   */
+  startPeriodicPayment(cronExp = '0 0 * * */6') {
+    this.periodicPaymentJob = createJob(cronExp, async () => {
+      try {
+        logger.info(`--in cron job --- ${new Date().toLocaleString()}`);
+        const { feesL1, feesL2 } = await this.getPendingWithdrawsFromStateContract();
+        logger.info(
+          `${this.ethereumAddress} pending balance are feesL1 - ${feesL1}, and feesL2 - ${feesL2}`,
+        );
+        if (Number(feesL1) < this.minL1Balance && Number(feesL2) < this.minL2Balance) {
+          return;
+        }
+        const { txDataToSign } = (await axios.post(`${this.optimistBaseUrl}/proposer/withdraw`))
+          .data;
+        const tx = await this._signTransaction(txDataToSign, this.stateContractAddress, 0);
+        await this._sendTransaction(tx);
+      } catch (err) {
+        logger.error({
+          msg: 'Error while trying to submit withdraw tx',
+          err,
+        });
+      }
+    });
+    this.periodicPaymentJob.start();
+  }
+
+  /**
+   * This function not just stop periodic payment job
+   * but also destroys it as well
+   */
+  stopPeriodicPayment() {
+    if (!this.periodicPaymentJob) throw Error('Periodic Payment job not created yet');
+    this.periodicPaymentJob.stop();
+    this.periodicPaymentJob = undefined;
   }
 }
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -22,6 +22,7 @@
         "express": "^4.17.3",
         "figlet": "^1.5.2",
         "inquirer": "^8.1.4",
+        "node-cron": "^3.0.2",
         "queue": "^6.0.2",
         "reconnecting-websocket": "^4.4.0",
         "web3": "^1.7.5",
@@ -6591,6 +6592,17 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.2.tgz",
+      "integrity": "sha512-iP8l0yGlNpE0e6q1o185yOApANRe47UPbLf4YxfbiNHt/RU5eBcGB/e0oudruheSf+LQeDMezqC5BVAb5wwRcQ==",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -14029,6 +14041,14 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
+    "node-cron": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.2.tgz",
+      "integrity": "sha512-iP8l0yGlNpE0e6q1o185yOApANRe47UPbLf4YxfbiNHt/RU5eBcGB/e0oudruheSf+LQeDMezqC5BVAb5wwRcQ==",
+      "requires": {
+        "uuid": "8.3.2"
+      }
     },
     "node-fetch": {
       "version": "2.6.7",

--- a/cli/package.json
+++ b/cli/package.json
@@ -21,6 +21,7 @@
     "express": "^4.17.3",
     "figlet": "^1.5.2",
     "inquirer": "^8.1.4",
+    "node-cron": "^3.0.2",
     "queue": "^6.0.2",
     "reconnecting-websocket": "^4.4.0",
     "web3": "^1.7.5",

--- a/nightfall-deployer/contracts/State.sol
+++ b/nightfall-deployer/contracts/State.sol
@@ -346,7 +346,8 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Key_Registry, Config {
             'State: Not authorised to call this function'
         );
 
-        pendingWithdrawalsFees[addr] = FeeTokens(feesL1, feesL2);
+        if (feesL1 > 0) pendingWithdrawalsFees[addr].feesL1 += feesL1;
+        if (feesL2 > 0) pendingWithdrawalsFees[addr].feesL2 += feesL2;
     }
 
     function withdraw() external nonReentrant whenNotPaused {
@@ -360,11 +361,7 @@ contract State is ReentrancyGuardUpgradeable, Pausable, Key_Registry, Config {
         }
         if (amountL2Token > 0) {
             pendingWithdrawalsFees[msg.sender].feesL2 = 0;
-            IERC20Upgradeable(super.getFeeL2TokenAddress()).safeTransferFrom(
-                address(this),
-                msg.sender,
-                amountL2Token
-            );
+            IERC20Upgradeable(super.getFeeL2TokenAddress()).safeTransfer(msg.sender, amountL2Token);
         }
     }
 

--- a/nightfall-deployer/migrations/2_deploy_upgradeable.js
+++ b/nightfall-deployer/migrations/2_deploy_upgradeable.js
@@ -89,8 +89,7 @@ module.exports = async function (deployer) {
   const challengers = await Challenges.deployed();
   const shield = await Shield.deployed();
   const x509 = await X509.deployed();
-
-  await State.deployed();
+  const state = await State.deployed();
 
   const { bootProposer, bootChallenger } = addresses;
 
@@ -121,7 +120,8 @@ module.exports = async function (deployer) {
   const feeL2TokenAddress = RESTRICTIONS.tokens[process.env.ETH_NETWORK].find(
     token => token.name === FEE_L2_TOKEN_ID,
   ).address;
-  await shield.setFeeL2TokenAddress(feeL2TokenAddress.toLowerCase());
+  await shield.setFeeL2TokenAddress(feeL2TokenAddress);
+  await state.setFeeL2TokenAddress(feeL2TokenAddress);
 
   console.log('Whitelisting is enabled unless it says "disable" here:', process.env.WHITELISTING);
   if (process.env.WHITELISTING === 'disable') {

--- a/nightfall-deployer/migrations/3_test_tokens_migration.js
+++ b/nightfall-deployer/migrations/3_test_tokens_migration.js
@@ -7,6 +7,7 @@ const {
 const { DEPLOY_MOCK_TOKENS = true } = process.env;
 
 const Shield = artifacts.require('Shield.sol');
+const State = artifacts.require('State.sol');
 
 const ERC20Mock = artifacts.require('ERC20Mock.sol');
 const ERC721Mock = artifacts.require('ERC721Mock.sol');
@@ -17,6 +18,7 @@ const nERC721 = 35;
 module.exports = function (deployer, _, accounts) {
   deployer.then(async () => {
     const shield = await Shield.deployed();
+    const state = await State.deployed();
 
     if (DEPLOY_MOCK_TOKENS === 'false') return;
 
@@ -52,7 +54,8 @@ module.exports = function (deployer, _, accounts) {
 
     if (!config.ETH_ADDRESS) {
       //modify the fee token address to be ERCMock for tests
-      await shield.setFeeL2TokenAddress(ERC20deployed.address.toLowerCase());
+      await shield.setFeeL2TokenAddress(ERC20deployed.address);
+      await state.setFeeL2TokenAddress(ERC20deployed.address);
 
       // indicates we're running a wallet test that uses hardcoded addresses
       // For e2e tests

--- a/nightfall-deployer/migrations/4_upgrade_upgradeable.js
+++ b/nightfall-deployer/migrations/4_upgrade_upgradeable.js
@@ -62,6 +62,7 @@ module.exports = async function (deployer) {
   const proposers = await Proposers.deployed();
   const challengers = await Challenges.deployed();
   const shield = await Shield.deployed();
+  const state = await State.deployed();
 
   const { bootProposer, bootChallenger } = addresses;
   console.log(`Setting boot proposer ${bootProposer}...`);
@@ -89,5 +90,6 @@ module.exports = async function (deployer) {
   const feeL2TokenAddress = RESTRICTIONS.tokens[process.env.ETH_NETWORK].find(
     token => token.name === 'MATIC',
   ).address;
-  await shield.setFeeL2TokenAddress(feeL2TokenAddress.toLowerCase());
+  await shield.setFeeL2TokenAddress(feeL2TokenAddress);
+  await state.setFeeL2TokenAddress(feeL2TokenAddress);
 };

--- a/nightfall-optimist/src/routes/proposer.mjs
+++ b/nightfall-optimist/src/routes/proposer.mjs
@@ -191,7 +191,7 @@ router.get('/pending-payments', async (req, res, next) => {
   const pendingPayments = [];
   // get blocks by proposer
   try {
-    const blocks = await findBlocksByProposer(proposerAddress);
+    const blocks = await findBlocksByProposer(proposerAddress.toLowerCase());
     const shieldContractInstance = await getContractInstance(SHIELD_CONTRACT_NAME);
 
     for (let i = 0; i < blocks.length; i++) {
@@ -251,11 +251,10 @@ router.get('/stake', async (req, res, next) => {
  * Through a successful challenge or proposing state updates. This just
  * provides the tx data, the user will need to call the blockchain client.
  */
-router.get('/withdraw', async (req, res, next) => {
+router.post('/withdraw', async (req, res, next) => {
   try {
-    const proposersContractInstance = await getContractInstance(PROPOSERS_CONTRACT_NAME);
-    const txDataToSign = await proposersContractInstance.methods.withdraw().encodeABI();
-
+    const stateContractInstance = await getContractInstance(STATE_CONTRACT_NAME);
+    const txDataToSign = await stateContractInstance.methods.withdraw().encodeABI();
     res.json({ txDataToSign });
   } catch (err) {
     next(err);
@@ -273,7 +272,7 @@ router.post('/payment', async (req, res, next) => {
     const block = await getBlockByBlockHash(blockHash);
     const shieldContractInstance = await getContractInstance(SHIELD_CONTRACT_NAME);
     const txDataToSign = await shieldContractInstance.methods
-      .requestBlockPayment(block)
+      .requestBlockPayment(Block.buildSolidityStruct(block))
       .encodeABI();
 
     res.json({ txDataToSign });

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test-adversary": "npx hardhat test --no-compile --bail test/adversary.test.mjs",
     "test-general-stuff": "npx hardhat test --bail --no-compile test/kem-dem.test.mjs test/timber.test.mjs",
     "test-x509": "LOG_LEVEL=debug npx hardhat test --bail --no-compile test/x509.test.mjs",
+    "test-periodic-payment": "npx hardhat test --bail --no-compile test/fee-and-reward-periodic-payment.test.mjs",
     "unit-test": "npx hardhat test --bail test/unit/SmartContracts/*",
     "unit-test-whitelist": "npx hardhat test --bail test/unit/SmartContracts/whitelist.unit.test.mjs",
     "unit-test-x509": "npx hardhat test --bail test/unit/SmartContracts/x509.unit.test.mjs",

--- a/test/fee-and-reward-periodic-payment.test.mjs
+++ b/test/fee-and-reward-periodic-payment.test.mjs
@@ -163,11 +163,6 @@ describe('Periodic Payment', () => {
         await nf3Proposer.requestBlockPayment(
           (await nf3Proposer.getProposerPendingPayments()).map(rec => rec.blockHash)[0],
         );
-        logger.info(
-          `-- in test file -- ${JSON.stringify(
-            await nf3Proposer.getPendingWithdrawsFromStateContract(),
-          )}`,
-        );
         await new Promise(reslove => setTimeout(reslove, 300000)); // wait till cron job trigger next and does it job
         const { feesL2 } = await nf3Proposer.getPendingWithdrawsFromStateContract();
         expect(Number(feesL2)).to.be.equal(0);
@@ -202,11 +197,6 @@ describe('Periodic Payment', () => {
       for (const blockHash of blockHashs) {
         await nf3Proposer.requestBlockPayment(blockHash);
       }
-      logger.info(
-        `-- in test file -- ${JSON.stringify(
-          await nf3Proposer.getPendingWithdrawsFromStateContract(),
-        )}`,
-      );
       await new Promise(reslove => setTimeout(reslove, 600000)); // wait till cron job trigger next and does it job (if cron job exist)
       const { feesL2 } = await nf3Proposer.getPendingWithdrawsFromStateContract();
       expect(Number(feesL2)).to.be.equal(2);
@@ -224,11 +214,6 @@ describe('Periodic Payment', () => {
 
     it('Start periodic payment job', async () => {
       nf3Proposer.startPeriodicPayment('*/01 * * * *'); // At every minute
-      logger.info(
-        `-- in test file -- ${JSON.stringify(
-          await nf3Proposer.getPendingWithdrawsFromStateContract(),
-        )}`,
-      );
       await new Promise(reslove => setTimeout(reslove, 100000)); // wait till cron job trigger next and does it job
       const { feesL1, feesL2 } = await nf3Proposer.getPendingWithdrawsFromStateContract();
       expect(Number(feesL1)).to.be.equal(0);

--- a/test/fee-and-reward-periodic-payment.test.mjs
+++ b/test/fee-and-reward-periodic-payment.test.mjs
@@ -1,0 +1,245 @@
+/* eslint no-await-in-loop: "off" */
+
+/**
+ * this test suits mainly test periodic payment
+ * cron job in context to proposer, but successful
+ * execution this test suits also imply that logic
+ * will work for challenger as well for withdrawing
+ * reward from Pendging L1 withdraw
+ */
+import chai from 'chai';
+import config from 'config';
+import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
+import Nf3 from '../cli/lib/nf3.mjs';
+
+import { getLayer2Balances, Web3Client } from './utils.mjs';
+
+const { expect } = chai;
+
+const environment = config.ENVIRONMENTS[process.env.ENVIRONMENT] || config.ENVIRONMENTS.localhost;
+const {
+  fee,
+  transferValue,
+  tokenConfigs: { tokenType, tokenId },
+  mnemonics,
+  signingKeys,
+} = config.TEST_OPTIONS;
+
+const web3Client = new Web3Client();
+const eventLogs = [];
+
+const nf3User = new Nf3(signingKeys.user1, environment);
+const nf3Proposer = new Nf3(signingKeys.proposer1, environment);
+
+async function makeBlock() {
+  logger.debug(`Make block...`);
+  await nf3Proposer.makeBlockNow();
+  await web3Client.waitForEvent(eventLogs, ['blockProposed']);
+}
+
+async function logProposerStats() {
+  logger.info(`proposer stake: ${JSON.stringify(await nf3Proposer.getProposerStake())}`);
+  const web3 = nf3Proposer.getWeb3Provider();
+  logger.info(
+    `-- proposer account balance ---
+    ${await web3.eth.getBalance(nf3Proposer.ethereumAddress)}`,
+  );
+}
+
+describe('Periodic Payment', () => {
+  let erc20Address;
+
+  before(async () => {
+    await nf3User.init(mnemonics.user1);
+    await nf3Proposer.init(mnemonics.proposer);
+    await nf3Proposer.setWeb3Provider();
+    const web3 = nf3Proposer.getWeb3Provider();
+    logger.info(
+      `-- proposer account balance before registration ---
+      ${await web3.eth.getBalance(nf3Proposer.ethereumAddress)}`,
+    );
+    await nf3Proposer.registerProposer('http://optimist', await nf3Proposer.getMinimumStake());
+    await nf3Proposer.startProposer();
+
+    erc20Address = await nf3User.getContractAddress('ERC20Mock');
+    const stateAddress = await nf3User.stateContractAddress;
+    web3Client.subscribeTo('logs', eventLogs, { address: stateAddress });
+    logProposerStats();
+  });
+
+  afterEach(async () => logProposerStats());
+
+  it('Do 2 Deposit and make 2 blocks', async function () {
+    const userL2BalanceBefore = await getLayer2Balances(nf3User, erc20Address);
+
+    await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+    await makeBlock();
+    await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+    await makeBlock();
+
+    const userL2BalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+    expect(userL2BalanceAfter - userL2BalanceBefore).to.be.equal(transferValue * 2 - fee * 2);
+  });
+
+  it('Should do request for payment for two blocks', async () => {
+    const blockHashs = (await nf3Proposer.getProposerPendingPayments()).map(rec => rec.blockHash);
+    await web3Client.timeJump(3600 * 24 * 10);
+    for (const blockHash of blockHashs) {
+      await nf3Proposer.requestBlockPayment(blockHash);
+    }
+    const { feesL2 } = await nf3Proposer.getPendingWithdrawsFromStateContract();
+    expect(Number(feesL2)).to.be.equal(2);
+  });
+
+  it('Start periodic payment job', async () => {
+    nf3Proposer.startPeriodicPayment('*/03 * * * *'); // At every 3rd minute
+    await new Promise(reslove => setTimeout(reslove, 300000)); // wait till cron job trigger next and does it job
+    const { feesL2 } = await nf3Proposer.getPendingWithdrawsFromStateContract();
+    expect(Number(feesL2)).to.be.equal(0);
+  });
+
+  context('While cron job runing', () => {
+    it('Do 2 Deposit and make 2 blocks', async function () {
+      const userL2BalanceBefore = await getLayer2Balances(nf3User, erc20Address);
+
+      await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+      await makeBlock();
+      await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+      await makeBlock();
+
+      const userL2BalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+      expect(userL2BalanceAfter - userL2BalanceBefore).to.be.equal(transferValue * 2 - fee * 2);
+    });
+
+    it('Should do request for block payment and succesful withdraw', async () => {
+      const blockHashs = (await nf3Proposer.getProposerPendingPayments()).map(rec => rec.blockHash);
+      await web3Client.timeJump(3600 * 24 * 10);
+      for (const blockHash of blockHashs) {
+        await nf3Proposer.requestBlockPayment(blockHash);
+      }
+      await new Promise(reslove => setTimeout(reslove, 300000)); // wait till cron job trigger next and does it job
+      const { feesL2 } = await nf3Proposer.getPendingWithdrawsFromStateContract();
+      expect(Number(feesL2)).to.be.equal(0);
+    });
+  });
+
+  context(
+    'Update - minimum l2 erc20 token balance required for withdraw from State contract',
+    () => {
+      before(() => {
+        nf3Proposer.minL2Balance = 3; // changing l2 withdraw limit
+      });
+
+      it('Do 2 Deposit and make 2 blocks', async function () {
+        const userL2BalanceBefore = await getLayer2Balances(nf3User, erc20Address);
+
+        await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+        await makeBlock();
+        await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+        await makeBlock();
+
+        const userL2BalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+        expect(userL2BalanceAfter - userL2BalanceBefore).to.be.equal(transferValue * 2 - fee * 2);
+      });
+
+      it('Should do request for block payment and unsuccesful withdraw', async () => {
+        const blockHashs = (await nf3Proposer.getProposerPendingPayments()).map(
+          rec => rec.blockHash,
+        );
+        await web3Client.timeJump(3600 * 24 * 10);
+        for (const blockHash of blockHashs) {
+          await nf3Proposer.requestBlockPayment(blockHash);
+        }
+        await new Promise(reslove => setTimeout(reslove, 300000)); // wait till cron job trigger next and does it job
+        const { feesL2 } = await nf3Proposer.getPendingWithdrawsFromStateContract();
+        expect(Number(feesL2)).to.be.equal(2); // could not withdraw because limit is 3 now
+      });
+
+      // this test satisfy changed withdraw limit from before block
+      it('Do one more deposit to make periodic payment cron job work', async () => {
+        await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+        await makeBlock();
+        await web3Client.timeJump(3600 * 24 * 10);
+        await nf3Proposer.requestBlockPayment(
+          (await nf3Proposer.getProposerPendingPayments()).map(rec => rec.blockHash)[0],
+        );
+        logger.info(
+          `-- in test file -- ${JSON.stringify(
+            await nf3Proposer.getPendingWithdrawsFromStateContract(),
+          )}`,
+        );
+        await new Promise(reslove => setTimeout(reslove, 300000)); // wait till cron job trigger next and does it job
+        const { feesL2 } = await nf3Proposer.getPendingWithdrawsFromStateContract();
+        expect(Number(feesL2)).to.be.equal(0);
+      });
+    },
+  );
+
+  context('While there is not active cron job runing', () => {
+    before(() => {
+      nf3Proposer.minL2Balance = 1; // chang l2 withdraw limit back to 1
+    });
+    it('Stop periodic payment job', () => {
+      nf3Proposer.stopPeriodicPayment();
+      expect(nf3Proposer.periodicPaymentJob).to.be.equal(undefined);
+    });
+
+    it('Do 2 Deposit and make 2 blocks', async function () {
+      const userL2BalanceBefore = await getLayer2Balances(nf3User, erc20Address);
+
+      await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+      await makeBlock();
+      await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, fee);
+      await makeBlock();
+
+      const userL2BalanceAfter = await getLayer2Balances(nf3User, erc20Address);
+      expect(userL2BalanceAfter - userL2BalanceBefore).to.be.equal(transferValue * 2 - fee * 2);
+    });
+
+    it('Should do request for block payment and then add in pendingWithdraw', async () => {
+      const blockHashs = (await nf3Proposer.getProposerPendingPayments()).map(rec => rec.blockHash);
+      await web3Client.timeJump(3600 * 24 * 10);
+      for (const blockHash of blockHashs) {
+        await nf3Proposer.requestBlockPayment(blockHash);
+      }
+      logger.info(
+        `-- in test file -- ${JSON.stringify(
+          await nf3Proposer.getPendingWithdrawsFromStateContract(),
+        )}`,
+      );
+      await new Promise(reslove => setTimeout(reslove, 600000)); // wait till cron job trigger next and does it job (if cron job exist)
+      const { feesL2 } = await nf3Proposer.getPendingWithdrawsFromStateContract();
+      expect(Number(feesL2)).to.be.equal(2);
+    });
+  });
+
+  context('Test L1 withdraw with periodic payment cron job', () => {
+    it('Should withdraw proposer stake', async () => {
+      await nf3Proposer.deregisterProposer();
+      await web3Client.timeJump(3600 * 24 * 10);
+      await nf3Proposer.withdrawStake();
+      const { feesL1 } = await nf3Proposer.getPendingWithdrawsFromStateContract();
+      expect(Number(feesL1)).to.be.equal(1000000);
+    });
+
+    it('Start periodic payment job', async () => {
+      nf3Proposer.startPeriodicPayment('*/01 * * * *'); // At every minute
+      logger.info(
+        `-- in test file -- ${JSON.stringify(
+          await nf3Proposer.getPendingWithdrawsFromStateContract(),
+        )}`,
+      );
+      await new Promise(reslove => setTimeout(reslove, 100000)); // wait till cron job trigger next and does it job
+      const { feesL1, feesL2 } = await nf3Proposer.getPendingWithdrawsFromStateContract();
+      expect(Number(feesL1)).to.be.equal(0);
+      expect(Number(feesL2)).to.be.equal(0);
+    });
+  });
+
+  after(async () => {
+    nf3Proposer.stopPeriodicPayment();
+    await nf3Proposer.close();
+    await nf3User.close();
+    web3Client.closeWeb3();
+  });
+});


### PR DESCRIPTION
This PR implement a feature to `cli` SDK for proposer and challenger to start a cron job which withdraw their pending withdraw from state contract.
as part of the implementation it fixes few existing bugs:-
1.  fix state contract addPendingWithdrawal function - not to override existing added pendingWithdraw for an address
2. update `nightfall_deployer` migration files to do `state.setFeeL2TokenAddress` function
3. fix optimist router.get('/pending-payments') api to work with address not passed in lower case. As in our optimist DB we save EOA address in lowercase unlike  in ethereum where address in case sensitive
4. fix optimist router.get('/withdraw') api:- to  router.post('/withdraw') also correct logic to call withdraw function from state contract, before api had logic to call non-existing withdraw from proposer contract
5. fix optimist router.post('/payment')

## Does this close any currently open issues?
https://github.com/EYBlockchain/nightfall_3/issues/1237


