### PR TITLE
Fix: Handle re-deployed contracts on wallet

### DIFF
--- a/wallet/src/hooks/User/index.jsx
+++ b/wallet/src/hooks/User/index.jsx
@@ -140,6 +140,8 @@ export const UserProvider = ({ children }) => {
             console.log(
               `Last local block number is ${parsedEvent.numberBlockNext}, emitting sync event to fetch next block.`,
             );
+            setLastBlock(parsedEvent.historicalData[parsedEvent.historicalData.length - 1].block);
+
             socket.send(
               JSON.stringify({
                 type: 'sync',

--- a/wallet/src/nightfall-browser/services/database.js
+++ b/wallet/src/nightfall-browser/services/database.js
@@ -239,6 +239,13 @@ export async function getMaxBlock() {
   return maxKey;
 }
 
+export async function getNthBlockRoot(index) {
+  const db = await connectDB();
+  const timbers = await db.getAll(TIMBER_COLLECTION);
+  if (!timbers.length || index === null) return null;
+  return timbers.find(t => t.blockNumberL2 === index).root;
+}
+
 /**
 Transaction Collection
 */


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

It handles a scenario where contracts were redeployed. Instead of of only checking for block number accuracy, it also makes sure the block hashes match.

## Does this close any currently open issues?

Maybe.

## What commands can I run to test the change?

Re-snc wallet on the env where contracts where redeployed.

## Any other comments?

It assumes that the enhancement to sync block Lambda are merged.