### PR TITLE
fix: on-chain root calculation

### DIFF
--- a/nightfall-deployer/contracts/MerkleTree_Stateless.sol
+++ b/nightfall-deployer/contracts/MerkleTree_Stateless.sol
@@ -59,11 +59,11 @@ library MerkleTree_Stateless {
     /**
     @notice Insert multiple leaves into the Merkle Tree, and then update the root, The user must update and persistently stored the new frontier.
     @param _frontier - the current Frontier value
-    @param _lastLeafIndex - the index of the last leave inserted
+    @param _leafCount - the number of leaves
     */
     function calculateRoot(
         bytes32[33] memory _frontier,
-        uint256 _lastLeafIndex
+        uint256 _leafCount
     )
         public 
         returns (bytes32 root)
@@ -99,8 +99,14 @@ library MerkleTree_Stateless {
                 }
             }
 
-            slot := getFrontierSlot(_lastLeafIndex)
-            nodeValue := mload(add(_frontier, mul(0x20, sub(slot, 1))))
+            slot := getFrontierSlot(sub(_leafCount, 1)) 
+            nodeValue := mload(add(_frontier, mul(0x20, slot)))
+
+            nodeIndex := add(sub(_leafCount, 1), sub(exp(2,32), 1))
+
+            if gt(slot, 0) {
+                nodeIndex := sub(div(nodeIndex, exp(2, slot)), 1)
+            }
 
             // So far we've added all leaves, and hashed up to a particular level of the tree. We now need to continue hashing from that level until the root:
             for { let level := add(slot, 1)} lt(level, 33) { level := add(level, 1) } {

--- a/nightfall-deployer/contracts/mocks/MerkleTree_StatelessMock.sol
+++ b/nightfall-deployer/contracts/mocks/MerkleTree_StatelessMock.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.8.0;
+
+import '../MerkleTree_Stateless.sol';
+
+contract MerkleTree_StatelessMock {
+    function calculateRoot(
+        bytes32[33] memory _frontier,
+        uint256 leafCount // it's not the last leaf count it's actually the leaf count.
+    ) public returns (bytes32 root) {
+        root = MerkleTree_Stateless.calculateRoot(_frontier, leafCount);
+        return root;
+    }
+
+    function updateFrontier(
+        bytes32[] calldata leafValues,
+        bytes32[33] memory _frontier,
+        uint256 _leafCountBefore
+    ) public returns (bytes32[33] memory frontier) {
+        frontier = MerkleTree_Stateless.updateFrontier(leafValues, _frontier, _leafCountBefore);
+        return frontier;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20926,7 +20926,7 @@
           "dev": true,
           "requires": {
             "@types/node": "^12.12.6",
-            "got": "11.8.5",
+            "got": "9.6.0",
             "swarm-js": "^0.1.40"
           }
         },
@@ -22902,7 +22902,7 @@
       "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
       "dev": true,
       "requires": {
-        "colors": "1.4.0",
+        "colors": "^1.1.2",
         "object-assign": "^4.1.0",
         "string-width": "^2.1.1"
       }
@@ -24756,7 +24756,7 @@
             "which": "1.3.1",
             "wide-align": "1.1.3",
             "yargs": "13.3.2",
-            "yargs-parser": "5.0.1",
+            "yargs-parser": "13.1.2",
             "yargs-unparser": "1.6.0"
           }
         },
@@ -24888,7 +24888,7 @@
             "string-width": "^3.0.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
-            "yargs-parser": "5.0.1"
+            "yargs-parser": "^13.1.2"
           }
         },
         "yargs-unparser": {
@@ -29861,7 +29861,7 @@
             "which-module": "^1.0.0",
             "window-size": "^0.2.0",
             "y18n": "^3.2.1",
-            "yargs-parser": "5.0.1"
+            "yargs-parser": "^2.4.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "unit-test-state": "npx hardhat test --bail test/unit/SmartContracts/state.unit.test.mjs",
     "unit-test-proposers": "npx hardhat test --bail test/unit/SmartContracts/proposers.unit.test.mjs",
     "unit-test-challenges": "npx hardhat test --bail test/unit/SmartContracts/challenges.unit.test.mjs",
+    "unit-test-merkle_tree": "npx hardhat test --bail test/unit/SmartContracts/merkleTree.unit.test.mjs",
     "unit-test-verifier": "npx hardhat test --bail test/unit/SmartContracts/verifier.unit.test.mjs",
     "unit-test-compression": "npx hardhat test --bail test/unit/SmartContracts/compression.unit.test.mjs",
     "unit-test-circuits": "npx hardhat test --bail --no-compile test/unit/circuits/common/**/*.test.mjs test/unit/circuits/common/verifiers/**/*.test.mjs test/unit/circuits/*.test.mjs",

--- a/test/unit/SmartContracts/challenges.unit.test.mjs
+++ b/test/unit/SmartContracts/challenges.unit.test.mjs
@@ -1576,7 +1576,7 @@ describe('Challenges contract Challenges functions', function () {
       calculateBlockHash(transactionsCreated.block),
       1,
       '0x11cf76de9bb2b1efc8270e7e2380417daaa4c016456b43cfa831cea32b7840ba',
-      '0x280ecad231c91daad4cb1a97aba0c0d6b5278ed845aee0a46c3d426541498801',
+      '0x14cabaad7afba02a5d7f3a1813cb154975bc46212d29420dfe15fd263f19d770',
     );
     await state.proposeBlock(newTx.block, [newTx.withdrawTransaction, newTx.depositTransaction], {
       value: 10,

--- a/test/unit/SmartContracts/merkleTree.unit.test.mjs
+++ b/test/unit/SmartContracts/merkleTree.unit.test.mjs
@@ -1,0 +1,200 @@
+import config from 'config';
+import { expect } from 'chai';
+import hardhat from 'hardhat';
+import Timber from '@polygon-nightfall/common-files/classes/timber.mjs';
+import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
+import poseidonHash from '@polygon-nightfall/common-files/utils/crypto/poseidon/poseidon.mjs';
+import { generalise } from 'general-number';
+
+const { ethers } = hardhat;
+
+const { TIMBER_HEIGHT, HASH_TYPE } = config;
+
+describe('Challenges contract Challenges functions', function () {
+  let merkleTree;
+  let merkleTreeMock;
+
+  async function calculateAndVerifyRoot(leaves) {
+    const emptyTree = new Timber({
+      root: 0,
+      frontier: [],
+      leafCount: 0,
+      tree: undefined,
+      hashType: HASH_TYPE,
+      height: TIMBER_HEIGHT,
+    });
+    const updatedTimber = Timber.statelessUpdate(emptyTree, leaves, HASH_TYPE, TIMBER_HEIGHT);
+    const { frontier, root, leafCount } = updatedTimber;
+    const frontierAfterBlock = frontier.concat(
+      Array(33 - frontier.length).fill(ethers.constants.HashZero),
+    );
+    const merkleRoot = await merkleTreeMock.callStatic.calculateRoot(frontierAfterBlock, leafCount);
+    try {
+      expect(merkleRoot).to.equal(root);
+    } catch {
+      logger.error({
+        msg: 'calculate root failed',
+        leaves,
+        leafCount: leaves.length,
+        rootCalculatedOffChain: root,
+        rootCalculatedOnChain: merkleRoot,
+      });
+      expect.fail();
+    }
+  }
+
+  function generateRandomLeaves(length) {
+    return Array.from({ length }, () =>
+      poseidonHash([generalise(Math.round(Math.random() * 2 ** 32))]).hex(32),
+    );
+  }
+
+  async function updateAndVerifyFrontier(oldLeaves, newLeaves) {
+    const emptyTree = new Timber({
+      root: 0,
+      frontier: [],
+      leafCount: 0,
+      tree: undefined,
+      hashType: HASH_TYPE,
+      height: TIMBER_HEIGHT,
+    });
+    let updatedTimber = Timber.statelessUpdate(emptyTree, oldLeaves, HASH_TYPE, TIMBER_HEIGHT);
+    const { frontier: oldFrontier, leafCount: oldLeafCount } = updatedTimber;
+    const frontierBeforeBlocks = oldFrontier.concat(
+      Array(33 - oldFrontier.length).fill(ethers.constants.HashZero),
+    );
+
+    updatedTimber = Timber.statelessUpdate(updatedTimber, newLeaves, HASH_TYPE, TIMBER_HEIGHT);
+    const { frontier } = updatedTimber;
+
+    const merkleFrontier = await merkleTreeMock.callStatic.updateFrontier(
+      newLeaves,
+      frontierBeforeBlocks,
+      oldLeafCount,
+    );
+
+    for (const [index, front] of merkleFrontier.entries()) {
+      if (front !== ethers.constants.HashZero) {
+        try {
+          expect(front).to.be.eq(frontier[index]);
+        } catch {
+          logger.error({
+            msg: 'update frontier failed',
+            oldLeaves,
+            newLeaves,
+            oldLeafCount: oldLeaves.length,
+            newLeafCount: newLeaves.length,
+            updatedFrontierOffChain: frontier,
+            updatedFrontierOnChain: merkleFrontier,
+            index,
+          });
+          expect.fail();
+        }
+      }
+    }
+  }
+
+  beforeEach(async () => {
+    const Poseidon = await ethers.getContractFactory('Poseidon');
+    const poseidon = await Poseidon.deploy();
+    await poseidon.deployed();
+
+    const MerkleTree = await ethers.getContractFactory('MerkleTree_Stateless', {
+      libraries: {
+        Poseidon: poseidon.address,
+      },
+    });
+    merkleTree = await MerkleTree.deploy();
+    await merkleTree.deployed();
+    const MerkleTreeMock = await ethers.getContractFactory('MerkleTree_StatelessMock', {
+      libraries: {
+        MerkleTree_Stateless: merkleTree.address,
+      },
+    });
+    merkleTreeMock = await MerkleTreeMock.deploy();
+    await merkleTreeMock.deployed();
+  });
+
+  afterEach(async () => {
+    // clear down the test network after each test
+    await hardhat.network.provider.send('hardhat_reset');
+  });
+
+  it('calculate root of a tree with one leaf', async () => {
+    const leaves = generateRandomLeaves(1);
+    await calculateAndVerifyRoot(leaves);
+  });
+
+  it('calculate root of a tree with two leaves', async () => {
+    const leaves = generateRandomLeaves(2);
+    await calculateAndVerifyRoot(leaves);
+  });
+
+  it('calculate root of a tree with three leaves', async () => {
+    const leaves = generateRandomLeaves(3);
+    await calculateAndVerifyRoot(leaves);
+  });
+
+  it('calculate root of a tree with four leaves', async () => {
+    const leaves = generateRandomLeaves(4);
+    await calculateAndVerifyRoot(leaves);
+  });
+  it('calculate root of a tree with five leaves', async () => {
+    const leaves = generateRandomLeaves(5);
+    await calculateAndVerifyRoot(leaves);
+  });
+  it('calculate root of a tree with six leaves', async () => {
+    const leaves = generateRandomLeaves(6);
+    await calculateAndVerifyRoot(leaves);
+  });
+  it('calculate root of a tree with seven leaves', async () => {
+    const leaves = generateRandomLeaves(7);
+    await calculateAndVerifyRoot(leaves);
+  });
+
+  it('calculate root of with random amount of leaves', async () => {
+    const leafCount1 = Math.round(Math.random() * 2 ** 12);
+    const leaves1 = generateRandomLeaves(leafCount1);
+    await calculateAndVerifyRoot(leaves1);
+
+    const leafCount2 = Math.round(Math.random() * 2 ** 12);
+    const leaves2 = generateRandomLeaves(leafCount2);
+    await calculateAndVerifyRoot(leaves2);
+
+    const leafCount3 = Math.round(Math.random() * 2 ** 12);
+    const leaves3 = generateRandomLeaves(leafCount3);
+    await calculateAndVerifyRoot(leaves3);
+  });
+
+  it('update frontier with one oldLeaf and no newLeaves', async () => {
+    const oldLeaves = generateRandomLeaves(1);
+    const newLeaves = generateRandomLeaves(0);
+    await updateAndVerifyFrontier(oldLeaves, newLeaves);
+  });
+
+  it('update frontier with no oldLeaf and one newLeaves', async () => {
+    const oldLeaves = generateRandomLeaves(0);
+    const newLeaves = generateRandomLeaves(1);
+    await updateAndVerifyFrontier(oldLeaves, newLeaves);
+  });
+
+  it('update frontier with one oldLeaf and one newLeaves', async () => {
+    const oldLeaves = generateRandomLeaves(1);
+    const newLeaves = generateRandomLeaves(1);
+    await updateAndVerifyFrontier(oldLeaves, newLeaves);
+  });
+
+  it('update frontier with random oldLeaves length and newLeaves length', async () => {
+    const oldLeaves1 = generateRandomLeaves(Math.round(Math.random() * 2 ** 12));
+    const newLeaves1 = generateRandomLeaves(Math.round(Math.random() * 2 ** 6));
+    await updateAndVerifyFrontier(oldLeaves1, newLeaves1);
+
+    const oldLeaves2 = generateRandomLeaves(Math.round(Math.random() * 2 ** 12));
+    const newLeaves2 = generateRandomLeaves(Math.round(Math.random() * 2 ** 6));
+    await updateAndVerifyFrontier(oldLeaves2, newLeaves2);
+
+    const oldLeaves3 = generateRandomLeaves(Math.round(Math.random() * 2 ** 12));
+    const newLeaves3 = generateRandomLeaves(Math.round(Math.random() * 2 ** 6));
+    await updateAndVerifyFrontier(oldLeaves3, newLeaves3);
+  });
+});

--- a/wallet/package-lock.json
+++ b/wallet/package-lock.json
@@ -46695,8 +46695,7 @@
           "optional": true
         },
         "got": {
-          "version": "12.1.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-12.1.0.tgz",
+          "version": "https://registry.npmjs.org/got/-/got-12.1.0.tgz",
           "integrity": "sha512-hBv2ty9QN2RdbJJMK3hesmSkFTjVIHyIDDbssCKnSmq62edGgImJWD10Eb1k77TiV1bxloxqcFAVK8+9pkhOig==",
           "dev": true,
           "optional": true,
@@ -46843,7 +46842,7 @@
           "optional": true,
           "requires": {
             "@types/node": "^12.12.6",
-            "got": "12.1.0",
+            "got": "9.6.0",
             "swarm-js": "^0.1.40"
           }
         },
@@ -47305,8 +47304,7 @@
           "optional": true
         },
         "got": {
-          "version": "12.1.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-12.1.0.tgz",
+          "version": "https://registry.npmjs.org/got/-/got-12.1.0.tgz",
           "integrity": "sha512-hBv2ty9QN2RdbJJMK3hesmSkFTjVIHyIDDbssCKnSmq62edGgImJWD10Eb1k77TiV1bxloxqcFAVK8+9pkhOig==",
           "dev": true,
           "optional": true,
@@ -47453,7 +47451,7 @@
           "optional": true,
           "requires": {
             "@types/node": "^12.12.6",
-            "got": "12.1.0",
+            "got": "9.6.0",
             "swarm-js": "^0.1.40"
           }
         },
@@ -69289,7 +69287,7 @@
         "buffer": "^5.0.5",
         "eth-lib": "^0.1.26",
         "fs-extra": "^4.0.2",
-        "got": "12.1.0",
+        "got": "^7.1.0",
         "mime-types": "^2.1.16",
         "mkdirp-promise": "^5.0.1",
         "mock-fs": "^4.1.0",
@@ -69391,8 +69389,7 @@
           "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
         },
         "got": {
-          "version": "12.1.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-12.1.0.tgz",
+          "version": "https://registry.npmjs.org/got/-/got-12.1.0.tgz",
           "integrity": "sha512-hBv2ty9QN2RdbJJMK3hesmSkFTjVIHyIDDbssCKnSmq62edGgImJWD10Eb1k77TiV1bxloxqcFAVK8+9pkhOig==",
           "requires": {
             "@sindresorhus/is": "^4.6.0",


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

- Fix calculate root in MerkleTree_Stateless library:
  
    1. Use leafCount instead of lastLeafIndex. This parameter is from Utils.getLeafCount(blockL2.packedInfo), and getLeafCount returns the leaf count and not the last leaf index.
    2. Init node index according to the leaf count and the frontier slot.

- Test MerkleTree_Stateless library. I created tests for calculateRoot and updateFrontier (I didn't find any bugs in this function). I created MerkleTree_StatelessMock so it will be possible to test this library directly.

## Does this close any currently open issues?

As far as I know, there are no open issues on this bug.

## What commands can I run to test the change? 

`npm run unit-test-merkle_tree` or `npm run unit-test`
## Any other comments?

