### PR TITLE
Wallet import commitments

### DIFF
--- a/wallet/src/utils/CommitmentsBackup/commitmentsVerification.js
+++ b/wallet/src/utils/CommitmentsBackup/commitmentsVerification.js
@@ -1,4 +1,5 @@
 /* ignore unused exports */
+import { edwardsCompress } from '../../common-files/utils/curve-maths/curves';
 /**
  *
  * @description this function should verify if the commitment's compressedZkpPublicKey match with one of the derived keys.
@@ -11,7 +12,11 @@ const isCommitmentsCPKDMatchDerivedKeys = (indexedDBDerivedKeys, commitmentsFrom
   return new Promise(resolve => {
     commitmentsFromBackup.forEach(commitment => {
       for (let i = 0; i < indexedDBDerivedKeys.length; i++) {
-        if (indexedDBDerivedKeys[i] === commitment.preimage.compressedZkpPublicKey) {
+        const compressedZkpPublicKey = edwardsCompress([
+          BigInt(commitment.preimage.zkpPublicKey[0]),
+          BigInt(commitment.preimage.zkpPublicKey[1]),
+        ]);
+        if (indexedDBDerivedKeys[i] === compressedZkpPublicKey) {
           break;
         }
         if (i === indexedDBDerivedKeys.length - 1) {


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
When importing commitments with the wallet, we should convert preimage.zkpKeys to compressed format before comparing with expected keys.

## Does this close any currently open issues?
No

## What commands can I run to test the change? 
Export and Import commitments with wallet

## Any other comments?
No
