### PR TITLE
Update Client Service to enable Regulator for transfers

### DIFF
--- a/common-files/constants/constants.json
+++ b/common-files/constants/constants.json
@@ -7,6 +7,7 @@
   "DEPOSIT": "deposit",
   "DEPOSIT_FEE": "depositfee",
   "TRANSFER": "transfer",
+  "TRANSFER_REGULATOR": "transfer_regulator",
   "WITHDRAW": "withdraw",
   "TOKENISE": "tokenise",
   "BURN": "burn",

--- a/config/default.js
+++ b/config/default.js
@@ -118,6 +118,7 @@ module.exports = {
       process.env.BLOCKCHAIN_PATH || ''
     }`,
   REGULATOR_URL: process.env.REGULATOR_URL,
+  NONCE_ENCRYPTION_BITS: process.env.NONCE_ENCRYPTION_BITS || 48,
   ETH_PRIVATE_KEY: process.env.ETH_PRIVATE_KEY, // owner's/deployer's private key
   ETH_ADDRESS: process.env.ETH_ADDRESS,
   WEB3_OPTIONS: {

--- a/config/default.js
+++ b/config/default.js
@@ -117,6 +117,7 @@ module.exports = {
     `ws://${process.env.BLOCKCHAIN_WS_HOST}:${process.env.BLOCKCHAIN_PORT}${
       process.env.BLOCKCHAIN_PATH || ''
     }`,
+  REGULATOR_URL: process.env.REGULATOR_URL,
   ETH_PRIVATE_KEY: process.env.ETH_PRIVATE_KEY, // owner's/deployer's private key
   ETH_ADDRESS: process.env.ETH_ADDRESS,
   WEB3_OPTIONS: {
@@ -160,6 +161,12 @@ module.exports = {
       isWithdrawing: false,
     },
     transfer: {
+      numberNullifiers: 4,
+      numberCommitments: 3,
+      isEscrowRequired: false,
+      isWithdrawing: false,
+    },
+    transfer_regulator: {
       numberNullifiers: 4,
       numberCommitments: 3,
       isEscrowRequired: false,

--- a/docker/docker-compose.deployment.yml
+++ b/docker/docker-compose.deployment.yml
@@ -52,6 +52,7 @@ services:
       OPTIMIST_PORT: ${OPTIMIST_PORT:-80}
       RABBITMQ_HOST: ${RABBITMQ_HOST:-amqp://rabbitmq}
       RABBITMQ_PORT: ${RABBITMQ_PORT:-5672}
+      REGULATOR_URL: ${REGULATOR_URL}
       STATE_GENESIS_BLOCK: ${STATE_GENESIS_BLOCK:-0}
       USE_EXTERNAL_NODE: ${USE_EXTERNAL_NODE}
     command: ['npm', 'run', 'start']
@@ -91,7 +92,7 @@ services:
       UPGRADE: ${UPGRADE_CONTRACTS}
       USDC_RESTRICT: ${USDC_RESTRICT}
       WHITELISTING: ${WHITELISTING?WHITELISTING-not-set}
-      
+
   mongodb:
     image: mongo:4.4.1-bionic
     hostname: mongodb

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -56,9 +56,9 @@ services:
       RABBITMQ_PORT: ${RABBITMQ_PORT:-5672}
       OPTIMIST_HOST: ${OPTIMIST_HOST:-optimist}
       OPTIMIST_PORT: ${OPTIMIST_PORT:-80}
+      REGULATOR_URL: ${REGULATOR_URL}
       STATE_GENESIS_BLOCK: ${STATE_GENESIS_BLOCK:-0}
       USE_EXTERNAL_NODE: ${USE_EXTERNAL_NODE}
-      REGULATOR_URL: ${REGULATOR_URL}
     command: ['npm', 'run', 'dev']
 
     # Temporary container to deploy contracts and circuits and populate volumes

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - mongodb
     environment:
       AUTOSTART_RETRIES: ${AUTOSTART_RETRIES:-600}
-      BLOCKCHAIN_URL: ${BLOCKCHAIN_URL} 
+      BLOCKCHAIN_URL: ${BLOCKCHAIN_URL}
       BLOCKCHAIN_WS_HOST: ${BLOCKCHAIN_WS_HOST:-blockchain}
       BLOCKCHAIN_PORT: ${BLOCKCHAIN_PORT:-8546}
       CIRCOM_WORKER_HOST: ${CIRCOM_WORKER_HOST:-worker}
@@ -58,6 +58,7 @@ services:
       OPTIMIST_PORT: ${OPTIMIST_PORT:-80}
       STATE_GENESIS_BLOCK: ${STATE_GENESIS_BLOCK:-0}
       USE_EXTERNAL_NODE: ${USE_EXTERNAL_NODE}
+      REGULATOR_URL: ${REGULATOR_URL}
     command: ['npm', 'run', 'dev']
 
     # Temporary container to deploy contracts and circuits and populate volumes
@@ -99,7 +100,7 @@ services:
       USDC_RESTRICT: ${USDC_RESTRICT}
       UPGRADE: ${UPGRADE_CONTRACTS}
       WHITELISTING: ${WHITELISTING}
-      WETH_RESTRICT: ${WETH_RESTRICT} 
+      WETH_RESTRICT: ${WETH_RESTRICT}
 
   hosted-utils-api-server:
     build:

--- a/nightfall-client/src/routes/transfer.mjs
+++ b/nightfall-client/src/routes/transfer.mjs
@@ -1,14 +1,24 @@
 /**
 Route for transferring a crypto commitment.
 */
+import config from 'config';
 import express from 'express';
 import transfer from '../services/transfer.mjs';
+import transferRegulator from '../services/transfer-regulator.mjs';
 
+const { REGULATOR_URL } = config;
 const router = express.Router();
 
 router.post('/', async (req, res, next) => {
   try {
-    const { rawTransaction: txDataToSign, transaction } = await transfer(req.body);
+    let txDataToSign;
+    let transaction;
+
+    if (!REGULATOR_URL) {
+      ({ rawTransaction: txDataToSign, transaction } = await transfer(req.body));
+    } else {
+      ({ rawTransaction: txDataToSign, transaction } = await transferRegulator(req.body));
+    }
     res.json({ txDataToSign, transaction });
   } catch (err) {
     res.json({ error: err.message });

--- a/nightfall-client/src/services/kem-dem.mjs
+++ b/nightfall-client/src/services/kem-dem.mjs
@@ -122,14 +122,15 @@ const genTransferKeysForObservers = async (senderPrivateKey, receiverPublicKey) 
 };
 
 /**
-This function gets a random hex nonce of numPositions bytes, and another one of 32 bytes based on the previous one.
-@function randomHexNonce
-@param {Number} numPositions - The private key of the sender
+This function gets a random nonce between min and max.
+@function randomNonce
+@param {Number} min - Min value of the nonce
+@param {Number} max - Max value of the nonce
 @returns {GeneralNumber} The random hex nonce 
 */
-export const randomHexNonce = numPositions => {
-  const nonce = (Math.random() * 0xf ** (numPositions + 2)).toString(16).slice(0, numPositions);
-  return new GN(`0x${nonce}`, 'hex');
+export const randomNonce = (min, max) => {
+  const nonce = BigInt(Math.floor(Math.random() * (max - min + 1) + min));
+  return nonce;
 };
 
 /**

--- a/nightfall-client/src/services/kem-dem.mjs
+++ b/nightfall-client/src/services/kem-dem.mjs
@@ -1,6 +1,6 @@
 import { scalarMult } from '@polygon-nightfall/common-files/utils/curve-maths/curves.mjs';
 import { randValueLT } from '@polygon-nightfall/common-files/utils/crypto/crypto-random.mjs';
-import { generalise, stitchLimbs } from 'general-number';
+import { generalise, stitchLimbs, GN } from 'general-number';
 import poseidon from '@polygon-nightfall/common-files/utils/crypto/poseidon/poseidon.mjs';
 import constants from '@polygon-nightfall/common-files/constants/index.mjs';
 
@@ -106,18 +106,49 @@ const deDem = (encryptionKey, ciphertexts) => {
 };
 
 /**
+This function generates the transfer key pair for the observers
+@function genTransferKeysForObservers
+@param {GeneralNumber} senderPrivateKey - The private key of the sender
+@param {Array<GeneralNumber>} receiverPublicKey - The public pkd of the recipient
+@returns {Promise<Array<GeneralNumber, Array<BigInt>>>} The private and public key pair
+*/
+const genTransferKeysForObservers = async (senderPrivateKey, receiverPublicKey) => {
+  // We generate a private key derived from sender private key and receiver private key
+  // to be deterministic for the sender
+  let privateKey = await kem(senderPrivateKey, receiverPublicKey).toString(16);
+  privateKey = new GN(`0x${privateKey}`, 'hex');
+  const publicKey = scalarMult(privateKey.bigInt, BABYJUBJUB.GENERATOR);
+  return [privateKey, publicKey];
+};
+
+/**
+This function gets a random hex nonce of numPositions bytes, and another one of 32 bytes based on the previous one.
+@function randomHexNonce
+@param {Number} numPositions - The private key of the sender
+@returns {GeneralNumber} The random hex nonce 
+*/
+export const randomHexNonce = numPositions => {
+  const nonce = (Math.random() * 0xf ** (numPositions + 1)).toString(16).slice(0, numPositions);
+  return new GN(`0x${nonce}`, 'hex');
+};
+
+/**
 This function performs the kem-dem required to encrypt plaintext.
 @function encrypt
 @param {GeneralNumber} ephemeralPrivate - The private key that generates the ephemeralPub
 @param {Array<GeneralNumber>} ephemeralPub - The ephemeralPubKey
 @param {Array<GeneralNumber>} recipientPkds - The public pkd of the recipients
 @param {Array<BigInt>} plaintexts - The array of plain text to be encrypted, the ordering is [ercAddress,tokenId, value, salt]
+@param {BigInt} nonce - Nonce to do XOR
 @returns {Array<BigInt>} The encrypted ciphertexts.
 */
-const encrypt = (ephemeralPrivate, recipientPkds, plaintexts) => {
-  const encKey = kem(ephemeralPrivate, recipientPkds);
+const encrypt = (ephemeralPrivate, recipientPkds, plaintexts, nonce) => {
+  let encKey = kem(ephemeralPrivate, recipientPkds);
+  if (nonce) {
+    // eslint-disable-next-line no-bitwise
+    encKey ^= nonce;
+  }
   return dem(encKey, plaintexts);
-  // return cipherTexts;
 };
 
 /**
@@ -126,11 +157,16 @@ This function performs the kem-deDem required to decrypt plaintext.
 @param {GeneralNumber} privateKey - The private key of the recipient pkd
 @param {Array<GeneralNumber>} ephemeralPub - The ephemeralPubKey
 @param {Array<GeneralNumber>} ciphertexts - The array of ciphertexts to be decrypted
+@param {BigInt} nonce - Nonce to do XOR
 @returns {Array<GeneralNumber>} The decrypted plaintexts, the ordering is [ercAddress,tokenId, value, salt]
 */
-const decrypt = (privateKey, ephemeralPub, cipherTexts) => {
-  const encKey = kem(privateKey, ephemeralPub);
+const decrypt = (privateKey, ephemeralPub, cipherTexts, nonce) => {
+  let encKey = kem(privateKey, ephemeralPub);
+  if (nonce) {
+    // eslint-disable-next-line no-bitwise
+    encKey ^= nonce;
+  }
   return deDem(encKey, cipherTexts);
 };
 
-export { encrypt, decrypt, genEphemeralKeys, packSecrets };
+export { encrypt, decrypt, genEphemeralKeys, genTransferKeysForObservers, packSecrets };

--- a/nightfall-client/src/services/kem-dem.mjs
+++ b/nightfall-client/src/services/kem-dem.mjs
@@ -128,7 +128,7 @@ This function gets a random hex nonce of numPositions bytes, and another one of 
 @returns {GeneralNumber} The random hex nonce 
 */
 export const randomHexNonce = numPositions => {
-  const nonce = (Math.random() * 0xf ** (numPositions + 1)).toString(16).slice(0, numPositions);
+  const nonce = (Math.random() * 0xf ** (numPositions + 2)).toString(16).slice(0, numPositions);
   return new GN(`0x${nonce}`, 'hex');
 };
 

--- a/nightfall-client/src/services/kem-dem.mjs
+++ b/nightfall-client/src/services/kem-dem.mjs
@@ -106,7 +106,7 @@ const deDem = (encryptionKey, ciphertexts) => {
 };
 
 /**
-This function generates the transfer key pair for the observers
+This function generates the transfer key pair for the observers (receiver and regulator)
 @function genTransferKeysForObservers
 @param {GeneralNumber} senderPrivateKey - The private key of the sender
 @param {Array<GeneralNumber>} receiverPublicKey - The public pkd of the recipient

--- a/nightfall-client/src/services/kem-dem.mjs
+++ b/nightfall-client/src/services/kem-dem.mjs
@@ -128,9 +128,8 @@ This function gets a random nonce between min and max.
 @param {Number} max - Max value of the nonce
 @returns {GeneralNumber} The random hex nonce 
 */
-export const randomNonce = (min, max) => {
-  const nonce = BigInt(Math.floor(Math.random() * (max - min + 1) + min));
-  return nonce;
+const randomNonce = (min, max) => {
+  return BigInt(Math.floor(Math.random() * (max - min + 1) + min));
 };
 
 /**
@@ -140,7 +139,7 @@ This function performs the kem-dem required to encrypt plaintext.
 @param {Array<GeneralNumber>} ephemeralPub - The ephemeralPubKey
 @param {Array<GeneralNumber>} recipientPkds - The public pkd of the recipients
 @param {Array<BigInt>} plaintexts - The array of plain text to be encrypted, the ordering is [ercAddress,tokenId, value, salt]
-@param {BigInt} nonce - Nonce to do XOR
+@param {BigInt} nonce - Nonce to do XOR. This is used in transfer for regulator so the encryption key has some randomness
 @returns {Array<BigInt>} The encrypted ciphertexts.
 */
 const encrypt = (ephemeralPrivate, recipientPkds, plaintexts, nonce) => {
@@ -158,7 +157,7 @@ This function performs the kem-deDem required to decrypt plaintext.
 @param {GeneralNumber} privateKey - The private key of the recipient pkd
 @param {Array<GeneralNumber>} ephemeralPub - The ephemeralPubKey
 @param {Array<GeneralNumber>} ciphertexts - The array of ciphertexts to be decrypted
-@param {BigInt} nonce - Nonce to do XOR
+@param {BigInt} nonce - Nonce to do XOR. This is used in transfer for regulator so the encryption key has some randomness
 @returns {Array<GeneralNumber>} The decrypted plaintexts, the ordering is [ercAddress,tokenId, value, salt]
 */
 const decrypt = (privateKey, ephemeralPub, cipherTexts, nonce) => {
@@ -170,4 +169,11 @@ const decrypt = (privateKey, ephemeralPub, cipherTexts, nonce) => {
   return deDem(encKey, cipherTexts);
 };
 
-export { encrypt, decrypt, genEphemeralKeys, genTransferKeysForObservers, packSecrets };
+export {
+  encrypt,
+  decrypt,
+  genEphemeralKeys,
+  genTransferKeysForObservers,
+  randomNonce,
+  packSecrets,
+};

--- a/nightfall-client/src/services/transfer-regulator.mjs
+++ b/nightfall-client/src/services/transfer-regulator.mjs
@@ -1,0 +1,200 @@
+/**
+ * This module contains the logic needed create a zkp transfer, i.e. to nullify
+ * two input commitments and create two new output commitments to the same value.
+ * It is agnostic to whether we are dealing with an ERC20 or ERC721 (or ERC1155).
+ * @module deposit.mjs
+ * @author westlad, ChaitanyaKonda, iAmMichaelConnor, will-kim
+ */
+import config from 'config';
+import gen from 'general-number';
+import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
+import {
+  edwardsCompress,
+  compressProof,
+} from '@polygon-nightfall/common-files/utils/curve-maths/curves.mjs';
+import constants from '@polygon-nightfall/common-files/constants/index.mjs';
+import { waitForContract } from '@polygon-nightfall/common-files/utils/contract.mjs';
+import {
+  getCircuitHash,
+  generateProof,
+} from '@polygon-nightfall/common-files/utils/worker-calls.mjs';
+import { Transaction } from '../classes/index.mjs';
+import { ZkpKeys } from './keys.mjs';
+import { computeCircuitInputs } from '../utils/computeCircuitInputs.mjs';
+import { encrypt, genTransferKeysForObservers, packSecrets, randomHexNonce } from './kem-dem.mjs';
+import registerPairSenderReceiverToRegulator from '../utils/regulator.mjs';
+import { clearPending } from './commitment-storage.mjs';
+import { getCommitmentInfo } from '../utils/getCommitmentInfo.mjs';
+import { submitTransaction } from '../utils/submitTransaction.mjs';
+
+const { VK_IDS, REGULATOR_URL } = config;
+const { SHIELD_CONTRACT_NAME, TRANSFER_REGULATOR } = constants;
+const { generalise } = gen;
+
+async function transferRegulator(transferParams) {
+  logger.info('Creating a transfer transaction');
+  // let's extract the input items
+  const {
+    offchain = false,
+    providedCommitments,
+    providedCommitmentsFee,
+    ...items
+  } = transferParams;
+  const { tokenId, recipientData, rootKey, fee } = generalise(items);
+  const { compressedZkpPublicKey, nullifierKey, zkpPrivateKey, zkpPublicKey } = new ZkpKeys(
+    rootKey,
+  );
+  const ercAddress = generalise(items.ercAddress.toLowerCase());
+  const { recipientCompressedZkpPublicKeys, values } = recipientData;
+  const recipientZkpPublicKeys = recipientCompressedZkpPublicKeys.map(key =>
+    ZkpKeys.decompressZkpPublicKey(key),
+  );
+  if (recipientCompressedZkpPublicKeys.length > 1)
+    throw new Error(`Batching is not supported yet: only one recipient is allowed`); // this will not always be true so we try to make the following code agnostic to the number of commitments
+
+  const shieldContractInstance = await waitForContract(SHIELD_CONTRACT_NAME);
+
+  const feeL2TokenAddress = generalise(
+    (await shieldContractInstance.methods.getFeeL2TokenAddress().call()).toLowerCase(),
+  );
+
+  logger.debug({
+    msg: 'Transfer with regulator ERC Token & Fee addresses',
+    ercAddress: ercAddress.hex(32),
+    feeL2TokenAddress: feeL2TokenAddress.hex(32),
+  });
+
+  const circuitName = TRANSFER_REGULATOR;
+
+  const totalValueToSend = values.reduce((acc, value) => acc + value.bigInt, 0n);
+  const commitmentsInfo = await getCommitmentInfo({
+    totalValueToSend,
+    fee,
+    recipientZkpPublicKeysArray: recipientZkpPublicKeys,
+    ercAddress,
+    feeL2TokenAddress,
+    tokenId,
+    rootKey,
+    maxNullifiers: VK_IDS[circuitName].numberNullifiers,
+    providedCommitments,
+    providedCommitmentsFee,
+  });
+
+  try {
+    let nonce = 0;
+
+    // KEM-DEM encryption with 3 peers
+    const [ePrivate, ePublic] = await genTransferKeysForObservers(
+      generalise(zkpPrivateKey),
+      generalise(recipientZkpPublicKeys[0]),
+    );
+
+    const [sharedPubSender, sharedPubReceiver] = registerPairSenderReceiverToRegulator(
+      REGULATOR_URL,
+      generalise(zkpPublicKey),
+      generalise(recipientZkpPublicKeys[0]),
+      generalise(ePublic),
+      generalise(ePrivate),
+    );
+
+    const [unpackedTokenID, packedErc] = packSecrets(tokenId, ercAddress, 0, 2);
+    nonce = randomHexNonce(12); // generate a 6 bytes random nonce (12 hex digits)
+
+    const compressedSecrets = encrypt(
+      generalise(ePrivate),
+      generalise(sharedPubSender),
+      [packedErc.bigInt, unpackedTokenID.bigInt, values[0].bigInt, commitmentsInfo.salts[0].bigInt],
+      nonce.bigInt,
+    );
+
+    // Compress the public key as it will be put on-chain for the receiver
+    const compressedEPub = edwardsCompress(sharedPubReceiver);
+    const circuitHash = await getCircuitHash(circuitName);
+
+    // now we have everything we need to create a Witness and compute a proof
+    const publicData = new Transaction({
+      fee,
+      historicRootBlockNumberL2: commitmentsInfo.blockNumberL2s,
+      circuitHash,
+      ercAddress: compressedSecrets[0], // this is the encrypted ercAddress
+      tokenId: compressedEPub,
+      recipientAddress: compressedSecrets[1], // this is the encrypted tokenID
+      commitments: commitmentsInfo.newCommitments,
+      nullifiers: commitmentsInfo.nullifiers,
+      compressedSecrets: compressedSecrets.slice(2), // these are the [value, salt]
+      numberNullifiers: VK_IDS[circuitName].numberNullifiers,
+      numberCommitments: VK_IDS[circuitName].numberCommitments,
+      isOnlyL2: true,
+      value: nonce ? nonce.bigInt : 0,
+    });
+
+    const privateData = {
+      rootKey,
+      oldCommitmentPreimage: commitmentsInfo.oldCommitments.map(o => {
+        return { value: o.preimage.value, salt: o.preimage.salt };
+      }),
+      paths: commitmentsInfo.localSiblingPaths.map(siblingPath => siblingPath.slice(1)),
+      orders: commitmentsInfo.leafIndices,
+      newCommitmentPreimage: commitmentsInfo.newCommitments.map(o => {
+        return { value: o.preimage.value, salt: o.preimage.salt };
+      }),
+      recipientPublicKeys: commitmentsInfo.newCommitments.map(o => o.preimage.zkpPublicKey),
+      ercAddress,
+      tokenId,
+      ephemeralKey: ePrivate,
+      sharedPubSender,
+    };
+
+    const witness = computeCircuitInputs(
+      publicData,
+      privateData,
+      commitmentsInfo.roots,
+      feeL2TokenAddress,
+      VK_IDS[circuitName].numberNullifiers,
+      VK_IDS[circuitName].numberCommitments,
+    );
+
+    logger.debug({
+      msg: 'witness input is',
+      witness,
+    });
+
+    // call a worker to generate the proof
+    const res = await generateProof({ folderpath: circuitName, witness });
+
+    logger.trace({
+      msg: 'Received response from generate-proof',
+      response: res.data,
+    });
+
+    const { proof } = res.data;
+    // and work out the ABI encoded data that the caller should sign and send to the shield contract
+    const transaction = { ...publicData, proof: compressProof(proof) };
+    transaction.transactionHash = Transaction.calcHash(transaction);
+
+    logger.debug({
+      msg: `Client made ${circuitName}`,
+      transaction,
+      offchain,
+    });
+
+    const rawTransaction = await shieldContractInstance.methods
+      .submitTransaction(Transaction.buildSolidityStruct(transaction))
+      .encodeABI();
+    await submitTransaction(
+      transaction,
+      commitmentsInfo,
+      compressedZkpPublicKey,
+      nullifierKey,
+      offchain,
+    );
+
+    return { rawTransaction, transaction };
+  } catch (error) {
+    await Promise.all(commitmentsInfo.oldCommitments.map(o => clearPending(o)));
+    logger.error(error);
+    throw error;
+  }
+}
+
+export default transferRegulator;

--- a/nightfall-client/src/services/transfer.mjs
+++ b/nightfall-client/src/services/transfer.mjs
@@ -2,7 +2,7 @@
  * This module contains the logic needed create a zkp transfer, i.e. to nullify
  * two input commitments and create two new output commitments to the same value.
  * It is agnostic to whether we are dealing with an ERC20 or ERC721 (or ERC1155).
- * @module deposit.mjs
+ * @module transfer.mjs
  * @author westlad, ChaitanyaKonda, iAmMichaelConnor, will-kim
  */
 import config from 'config';

--- a/nightfall-client/src/utils/computeCircuitInputs.mjs
+++ b/nightfall-client/src/utils/computeCircuitInputs.mjs
@@ -115,6 +115,7 @@ export const computeCircuitInputs = (
     value,
     inputTokens,
     outputTokens,
+    sharedPubSender,
   } = generalise(privateData);
   if (numberNullifiers > 0) {
     witness = {
@@ -148,6 +149,13 @@ export const computeCircuitInputs = (
 
   if (ephemeralKey) {
     witness.ephemeralKey = ephemeralKey.field(BN128_GROUP_ORDER);
+  }
+
+  if (sharedPubSender) {
+    witness.sharedPubSender = [
+      sharedPubSender[0].field(BN128_GROUP_ORDER),
+      sharedPubSender[1].field(BN128_GROUP_ORDER),
+    ];
   }
 
   if (value) {

--- a/nightfall-client/src/utils/regulator.mjs
+++ b/nightfall-client/src/utils/regulator.mjs
@@ -1,8 +1,6 @@
 import { scalarMult } from '@polygon-nightfall/common-files/utils/curve-maths/curves.mjs';
-import constants from '@polygon-nightfall/common-files/constants/index.mjs';
 import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
 
-const { BABYJUBJUB } = constants;
 /**
 This function registers the sender-receiver to the regulator and gets the sharedPub for the sender to generate the secret.
 @function registerPairSenderReceiv1er

--- a/nightfall-client/src/utils/regulator.mjs
+++ b/nightfall-client/src/utils/regulator.mjs
@@ -38,7 +38,10 @@ const registerPairSenderReceiverToRegulator = (
     BigInt(privateKeyRegulator),
     receiverPublicKey.map(r => r.bigInt),
   );
-  const sharedPubReceiver = scalarMult(BigInt(privateKeyRegulator), senderPublicKey);
+  const sharedPubReceiver = scalarMult(
+    BigInt(privateKeyRegulator),
+    senderPublicKey.map(s => s.bigInt),
+  );
   // -----------------------------------------------------------------------------
 
   return [sharedPubSender, sharedPubReceiver];

--- a/nightfall-client/src/utils/regulator.mjs
+++ b/nightfall-client/src/utils/regulator.mjs
@@ -35,14 +35,14 @@ const registerPairSenderReceiverToRegulator = (
 
   const privateKeyRegulator = '0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69e'; // test private key for mock regulator
   // This simulate the response from the regulator (regulatorPublicKey, sharedPubSender)
-  const regulatorPublicKey = scalarMult(BigInt(privateKeyRegulator), BABYJUBJUB.GENERATOR);
+  // const regulatorPublicKey = scalarMult(BigInt(privateKeyRegulator), BABYJUBJUB.GENERATOR);
   const sharedPubSender = scalarMult(
     BigInt(privateKeyRegulator),
     receiverPublicKey.map(r => r.bigInt),
   );
+  const sharedPubReceiver = scalarMult(BigInt(privateKeyRegulator), senderPublicKey);
   // -----------------------------------------------------------------------------
 
-  const sharedPubReceiver = scalarMult(transferPrivateKey.bigInt, regulatorPublicKey);
   return [sharedPubSender, sharedPubReceiver];
 };
 

--- a/nightfall-client/src/utils/regulator.mjs
+++ b/nightfall-client/src/utils/regulator.mjs
@@ -1,0 +1,49 @@
+import { scalarMult } from '@polygon-nightfall/common-files/utils/curve-maths/curves.mjs';
+import constants from '@polygon-nightfall/common-files/constants/index.mjs';
+import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
+
+const { BABYJUBJUB } = constants;
+/**
+This function registers the sender-receiver to the regulator and gets the sharedPub for the sender to generate the secret.
+@function registerPairSenderReceiv1er
+@param {String} hex1 - parameter 1 hex string
+@param {String} hex2 - parameter 2 hex string
+@returns {String} XOR result hex string
+*/
+const registerPairSenderReceiverToRegulator = (
+  regulatorUrl,
+  senderPublicKey,
+  receiverPublicKey,
+  transferPublicKey,
+  transferPrivateKey,
+) => {
+  const sharedPubRegulator = scalarMult(
+    transferPrivateKey.bigInt,
+    receiverPublicKey.map(r => r.bigInt),
+  );
+
+  // ------------- REGULATOR SERVICE CALL AND RESPONSE -----------------------
+  // registerPairSenderReceiver (PKa, PKb, PKx, pkx * PKb) in the Regulator Service and receive response
+  // TODO: call to Regulator service to get the sharedPubSender. Now we simulate with private from the sender
+  logger.debug({
+    msg: `Registering sender-receiver to regulator ${regulatorUrl}`,
+    senderPublicKey,
+    receiverPublicKey,
+    transferPublicKey,
+    sharedPubRegulator,
+  });
+
+  const privateKeyRegulator = '0x4775af73d6dc84a0ae76f8726bda4b9ecf187c377229cb39e1afa7a18236a69e'; // test private key for mock regulator
+  // This simulate the response from the regulator (regulatorPublicKey, sharedPubSender)
+  const regulatorPublicKey = scalarMult(BigInt(privateKeyRegulator), BABYJUBJUB.GENERATOR);
+  const sharedPubSender = scalarMult(
+    BigInt(privateKeyRegulator),
+    receiverPublicKey.map(r => r.bigInt),
+  );
+  // -----------------------------------------------------------------------------
+
+  const sharedPubReceiver = scalarMult(transferPrivateKey.bigInt, regulatorPublicKey);
+  return [sharedPubSender, sharedPubReceiver];
+};
+
+export default registerPairSenderReceiverToRegulator;

--- a/nightfall-client/src/utils/regulator.mjs
+++ b/nightfall-client/src/utils/regulator.mjs
@@ -4,9 +4,12 @@ import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
 /**
 This function registers the sender-receiver to the regulator and gets the sharedPub for the sender to generate the secret.
 @function registerPairSenderReceiv1er
-@param {String} hex1 - parameter 1 hex string
-@param {String} hex2 - parameter 2 hex string
-@returns {String} XOR result hex string
+@param {String} regulatorUrl - regulator Url for registering the pair sender receiver
+@param {String} senderPublicKey - sender public key
+@param {String} receiverPublicKey - receiver public key
+@param {String} transferPublicKey - transfer public key
+@param {String} transferPrivateKey - transfer private key
+@returns {[String, String]} [sharedPubSender, sharedPubReceiver] - shared public secret for sender and receiver
 */
 const registerPairSenderReceiverToRegulator = (
   regulatorUrl,
@@ -36,11 +39,11 @@ const registerPairSenderReceiverToRegulator = (
   // const regulatorPublicKey = scalarMult(BigInt(privateKeyRegulator), BABYJUBJUB.GENERATOR);
   const sharedPubSender = scalarMult(
     BigInt(privateKeyRegulator),
-    receiverPublicKey.map(r => r.bigInt),
+    receiverPublicKey.map(pk => pk.bigInt),
   );
   const sharedPubReceiver = scalarMult(
     BigInt(privateKeyRegulator),
-    senderPublicKey.map(s => s.bigInt),
+    transferPublicKey.map(pk => pk.bigInt),
   );
   // -----------------------------------------------------------------------------
 

--- a/nightfall-deployer/circuits/common/utils/kem_dem.circom
+++ b/nightfall-deployer/circuits/common/utils/kem_dem.circom
@@ -4,7 +4,7 @@ include "../../../node_modules/circomlib/circuits/poseidon.circom";
 include "../../../node_modules/circomlib/circuits/escalarmulany.circom";
 include "../../../node_modules/circomlib/circuits/escalarmulfix.circom";
 include "../../../node_modules/circomlib/circuits/bitify.circom";
-
+include "../../../node_modules/circomlib/circuits/gates.circom";
 /**
  * Calculates the shared encryption Key
  * @input ephemeralKey[256] - {Array[Bool]} -
@@ -104,10 +104,15 @@ template KemDemReg(N) {
     var encryptionKeyBits[256] = Num2Bits(256)(encryptionKey);
     var nonceBits[256] = Num2Bits(256)(nonce);
 
-    // var encryptionKeyNonce = encryptionKey ^ nonce; // This is non quadratic constraint!!!
+    var encryptionKeyNonceBits[256];
+    // Calculate the root using the sibling path
+    for(var i = 0; i < 256; i++) {   
+        encryptionKeyNonceBits[i] = XOR()(encryptionKeyBits[i], nonceBits[i]);
+    }
+    var encryptionKeyNonce = Bits2Num(256)(encryptionKeyNonceBits);
 
     // Encrpyt the plain texts using the encryption key
-    cipherText <== Dem(N)(encryptionKey, plainText);
+    cipherText <== Dem(N)(encryptionKeyNonce, plainText);
     
     // Calculate the ephemeral Public key
     ephemeralPublicKey <== EscalarMulFix(256, 

--- a/nightfall-deployer/circuits/common/utils/kem_dem.circom
+++ b/nightfall-deployer/circuits/common/utils/kem_dem.circom
@@ -77,3 +77,40 @@ template KemDem(N) {
         [16540640123574156134436876038791482806971768689494387082833631921987005038935, 
         20819045374670962167435360035096875258406992893633759881276124905556507972311])(ephemeralKeyBits);
 }
+
+/**
+ * Implements the KemDem algorithm: Calculates the shared encryption Key and then encrypts the fields
+ * @param N - number of plain texts to cipher
+ * @input ephemeralKey - {Array[Bool]} - private key of the ephemeral key
+ * @input recipientPub[2] - {Array[Field]} - public key of the recipient
+ * @input plainText[N] - {Array[Field]} - array of fields that will be encrpyted
+ */
+template KemDemReg(N) {
+    signal input ephemeralKey;
+    signal input recipientPub[2];
+    signal input plainText[N];
+    signal input nonce;
+
+    signal output cipherText[N];
+    signal output ephemeralPublicKey[2];
+
+    // Get the binary representation of the ephemeral Key
+    var ephemeralKeyBits[256] = Num2Bits(256)(ephemeralKey);
+   
+    // Calculate the encryption key
+    var encryptionKey = Kem()(ephemeralKeyBits, recipientPub);
+    
+    // Calculate XOR encryptionKey with the nonce
+    var encryptionKeyBits[256] = Num2Bits(256)(encryptionKey);
+    var nonceBits[256] = Num2Bits(256)(nonce);
+
+    // var encryptionKeyNonce = encryptionKey ^ nonce; // This is non quadratic constraint!!!
+
+    // Encrpyt the plain texts using the encryption key
+    cipherText <== Dem(N)(encryptionKey, plainText);
+    
+    // Calculate the ephemeral Public key
+    ephemeralPublicKey <== EscalarMulFix(256, 
+        [16540640123574156134436876038791482806971768689494387082833631921987005038935, 
+        20819045374670962167435360035096875258406992893633759881276124905556507972311])(ephemeralKeyBits);
+}

--- a/nightfall-deployer/circuits/common/verifiers/verify_encryption_regulator.circom
+++ b/nightfall-deployer/circuits/common/verifiers/verify_encryption_regulator.circom
@@ -42,8 +42,8 @@ template VerifyEncryptionRegulator() {
     cipherText[3] === cipherTextKemDem[3];
 
     // Check that the compressed ephemeral public key obtained from the kem dem algorithm matches with the one stored in the sharedPubRecipientCompressed
-    var compressedPoint[256] = Point2Bits_Strict()(sharedPublicKey);
-    compressedPoint === sharedPubRecipientCompressed;
+    // var compressedPoint[256] = Point2Bits_Strict()(sharedPublicKey);
+    // compressedPoint === sharedPubRecipientCompressed;
     
     valid <== 1;
 

--- a/nightfall-deployer/circuits/common/verifiers/verify_encryption_regulator.circom
+++ b/nightfall-deployer/circuits/common/verifiers/verify_encryption_regulator.circom
@@ -1,0 +1,50 @@
+pragma circom 2.1.2;
+
+include "../../../node_modules/circomlib/circuits/bitify.circom";
+include "../../../node_modules/circomlib/circuits/pointbits.circom";
+
+include "../utils/kem_dem.circom";
+
+/**
+ * Verifies that the encryption of the commitment preimage values for the recipient was performed properly.
+ * @input cipherText[4] - {Array[Field]} - 
+ * @input packedErcAddress - {Uint192} - erc address concatenated with the first 32 bytes of the token id
+ * @input idRemainder - {Uint224} - 224 last bits of the token id
+ * @input newCommitmentValue - {Uint252} - Value of the preimage of the new commitment
+ * @input newCommitmentSalt - {Field} - Salt of the preimage of the new commitment
+ * @input recipientPublicKey[2] - {Array[Field]} - Public key of the commitment's recipient
+ * @input ephemeralPublicKeyCompressed[256] - {Array[Bool]} - Contains the ephemeral public key compressed
+ * @input ephemeralKey - {Field} - Key used by the sender to create the shared key (KemDem)
+ */
+template VerifyEncryptionRegulator() {
+    signal input cipherText[4];
+    signal input packedErcAddress;
+    signal input idRemainder;
+    signal input newCommitmentValue;
+    signal input newCommitmentSalt;
+    signal input sharedPubSender[2];
+    signal input sharedPubRecipientCompressed[256];
+    signal input ephemeralKey;
+    signal input nonce;
+
+    signal output valid;
+    
+    var cipherTextKemDem[4], sharedPublicKey[2];
+    
+    // Calculate Kem Dem encryption for 3 peers including regulator
+    (cipherTextKemDem, sharedPublicKey) = KemDemReg(4)(ephemeralKey, sharedPubSender, 
+        [packedErcAddress, idRemainder, newCommitmentValue, newCommitmentSalt], nonce);
+
+    // Verify that the encryption matches with the encrypted values stored in the public transaction
+    cipherText[0] === cipherTextKemDem[0];
+    cipherText[1] === cipherTextKemDem[1];
+    cipherText[2] === cipherTextKemDem[2];
+    cipherText[3] === cipherTextKemDem[3];
+
+    // Check that the compressed ephemeral public key obtained from the kem dem algorithm matches with the one stored in the sharedPubRecipientCompressed
+    var compressedPoint[256] = Point2Bits_Strict()(sharedPublicKey);
+    compressedPoint === sharedPubRecipientCompressed;
+    
+    valid <== 1;
+
+}

--- a/nightfall-deployer/circuits/transfer_regulator.circom
+++ b/nightfall-deployer/circuits/transfer_regulator.circom
@@ -1,0 +1,171 @@
+pragma circom 2.1.2;
+
+include "./common/utils/calculate_keys.circom";
+include "./common/utils/array_uint32_to_bits.circom";
+include "./common/verifiers/verify_duplicates.circom";
+include "./common/verifiers/commitments/verify_commitments_generic.circom";
+include "./common/verifiers/commitments/verify_commitments.circom";
+include "./common/verifiers/nullifiers/verify_nullifiers.circom";
+include "./common/verifiers/nullifiers/verify_nullifiers_generic.circom";
+include "./common/verifiers/verify_encryption_regulator.circom";
+
+include "../node_modules/circomlib/circuits/bitify.circom";
+
+/**
+ * Checks that a transfer transaction is valid
+ * @input value - {Uint112} - Set to zero
+ * @input fee - {Uint96} 
+ * @input circuitHash - {Uint40}
+ * @input tokenType - {Uint8} It is zero 
+ * @input historicRootBlockNumberL2[N] - {Array[Field]}
+ * @input tokenId[8] - {Array[Uint32]} - Contains the ephemeral public key used for KemDem compressed
+ * @input ercAddress - {Field} - Contains the packedErc encrypted
+ * @input recipientAddress - {Field} - Contains the tokenId encrpyted
+ * @input commitments[C] - {Array[Field]}
+ * @input nullifiers[N] - {Array[Field]}
+ * @input compressedSecrets[2] - {Array[Field]} - Contains the value and salt encrypted
+ * @input roots[N] - {Array[Field]}
+ * @input feeAddress - {Uint160}
+ * @input rootKey - {Field}
+ * @input nullifiersValues[N] - {Array[Field]}
+ * @input nullifiersSalts[N] - {Array[Field]}
+ * @input paths[N][32] - {Array[Array[Field]]}
+ * @input orders[N] - {Array[Uint32]}
+ * @input commitmentsValues[C] - {Array[Field]}
+ * @input commitmentsSalts[C] - {Array[Field]}
+ * @input recipientPublicKey[C][2] - {Array[Array[Field]]}
+ * @input packedErcAddressPrivate - {Uint192} - Contains the packedErcAddress of the token transferred
+ * @input idRemainderPrivate - {Uint224} - Contains the idRemainder of the token transferred
+ * @input ephemeralKey - {Field}
+ */
+template TransferRegulator(N,C) {
+    signal input value;
+    signal input fee;
+    signal input circuitHash;
+    signal input tokenType;
+    signal input historicRootBlockNumberL2[N];
+    signal input ercAddress;
+    signal input tokenId[8];
+    signal input recipientAddress;
+    signal input commitments[C];
+    signal input nullifiers[N];
+    signal input compressedSecrets[2];
+    signal input roots[N];
+    signal input feeAddress;
+    signal input rootKey;
+    signal input nullifiersValues[N];
+    signal input nullifiersSalts[N];
+    signal input paths[N][32];
+    signal input orders[N];
+    signal input commitmentsValues[C];
+    signal input commitmentsSalts[C];
+    signal input recipientPublicKey[C][2];
+    signal input packedErcAddressPrivate;
+    signal input idRemainderPrivate;
+    signal input ephemeralKey;
+    signal input sharedPubSender[C][2];
+    
+    // Check that the transaction does not have nullifiers nor commitments duplicated
+    var checkDuplicates = VerifyDuplicates(N,C)(nullifiers, commitments);
+    checkDuplicates === 1;
+
+    // Check that the ercAddress is different than zero (it contains one of the 4 encrypted KemDem values)
+    assert(ercAddress != 0);
+
+    // Check that the recipientAddress is different than zero (it contains the second cipher text)
+    assert(recipientAddress != 0);
+
+    // Check that at least one of the compressed secrets is not zero
+    assert(compressedSecrets[0] != 0 || compressedSecrets[1] != 0);
+
+    // Check that the first commitment is different than zero
+    assert(commitments[0] != 0);
+
+    // Check that the first nullifier is different than zero
+    assert(nullifiers[0] != 0);
+
+    // Convert the nullifiers values to numbers and calculate its sum
+    var nullifiersSum = 0;
+    for(var i = 0; i < N; i++) {
+        nullifiersSum += nullifiersValues[i];
+        var nullifierValueBits[254] = Num2Bits(254)(nullifiersValues[i]);
+        nullifierValueBits[253] === 0;
+        nullifierValueBits[252] === 0;
+    }
+    
+    // Convert the commitment values to numbers and calculate its sum
+    var commitmentsSum = 0;
+    for(var i = 0; i < C; i++) {
+        commitmentsSum += commitmentsValues[i];
+        var commitmentValueBits[254] = Num2Bits(254)(commitmentsValues[i]);
+        commitmentValueBits[253] === 0;
+        commitmentValueBits[252] === 0;
+    }
+
+    // Check that the value holds
+    nullifiersSum === commitmentsSum + fee;
+
+    // Calculate the nullifierKeys and the zkpPublicKeys from the root key
+    var nullifierKeys, zkpPublicKeys[2];
+    (nullifierKeys, zkpPublicKeys) = CalculateKeys()(rootKey);
+     
+    // Check that the first nullifier is valid and corresponds to the packedErcAddress
+    var checkNullifier = VerifyNullifiers(1)(packedErcAddressPrivate, idRemainderPrivate, nullifierKeys, zkpPublicKeys, [nullifiers[0]], [roots[0]],
+        [nullifiersValues[0]], [nullifiersSalts[0]], [paths[0]], [orders[0]]);
+
+    checkNullifier === 1;
+
+    // Check that the other nullifiers are valid either using a ercAddress commitment, a feeAddress commitment or if value is zero
+    component checkGenericNullifiers = VerifyNullifiersGeneric(N - 1);
+    checkGenericNullifiers.packedErcAddress <== packedErcAddressPrivate;
+    checkGenericNullifiers.idRemainder <== idRemainderPrivate;
+    checkGenericNullifiers.feeAddress <== feeAddress;
+    checkGenericNullifiers.nullifierKey <== nullifierKeys;
+    checkGenericNullifiers.zkpPublicKey <== zkpPublicKeys;
+    for(var i = 1; i < N; i++) {
+        checkGenericNullifiers.nullifiersHashes[i - 1] <== nullifiers[i];
+        checkGenericNullifiers.oldCommitmentValues[i - 1] <== nullifiersValues[i];
+        checkGenericNullifiers.oldCommitmentSalts[i - 1] <== nullifiersSalts[i];
+        checkGenericNullifiers.roots[i - 1] <== roots[i];
+        checkGenericNullifiers.orders[i - 1] <== orders[i];
+        checkGenericNullifiers.paths[i - 1] <== paths[i];
+    }
+    checkGenericNullifiers.valid === 1;
+
+    // Check that the first commitment is valid and corresponds to the packedErcAddress
+    var checkCommitment = VerifyCommitments(1)(packedErcAddressPrivate, idRemainderPrivate, [commitments[0]],[commitmentsValues[0]], [commitmentsSalts[0]], [recipientPublicKey[0]]);
+    checkCommitment === 1;
+
+    // Check that the other commitments are valid either using the ercAddress, the feeAddress or if value is zero
+    component checkGenericCommitments = VerifyCommitmentsGeneric(C - 1);
+    checkGenericCommitments.packedErcAddress <== packedErcAddressPrivate;
+    checkGenericCommitments.idRemainder <== idRemainderPrivate;
+    checkGenericCommitments.feeAddress <== feeAddress;
+    for(var i = 1; i < C; i++) {
+        checkGenericCommitments.commitmentsHashes[i - 1] <== commitments[i];
+        checkGenericCommitments.newCommitmentsValues[i - 1] <== commitmentsValues[i];
+        checkGenericCommitments.newCommitmentsSalts[i - 1] <== commitmentsSalts[i];
+        checkGenericCommitments.recipientPublicKey[i - 1][0] <== recipientPublicKey[i][0];
+        checkGenericCommitments.recipientPublicKey[i - 1][1] <== recipientPublicKey[i][1];
+    }
+    checkGenericCommitments.valid === 1;
+
+    // Verify the withdraw change
+    assert(commitmentsValues[C - 2] == 0 || (
+        zkpPublicKeys[0] == recipientPublicKey[C - 2][0] && zkpPublicKeys[1] == recipientPublicKey[C - 2][1]));
+    
+    // Verify the fee change
+    assert(commitmentsValues[C - 1] == 0 || (
+        zkpPublicKeys[0] == recipientPublicKey[C - 1][0] && zkpPublicKeys[1] == recipientPublicKey[C - 1][1]));
+
+
+    var tokenIdBits[256] = ArrayUint32ToBits(8)(tokenId);
+    // Check that the encryption of the recipient's commitment preimage was performed appropiately
+    var checkEncryption = VerifyEncryptionRegulator()([ercAddress, recipientAddress, compressedSecrets[0], compressedSecrets[1]], 
+        packedErcAddressPrivate, idRemainderPrivate, commitmentsValues[0], commitmentsSalts[0], sharedPubSender[0], 
+        tokenIdBits, ephemeralKey, value);
+    checkEncryption === 1;
+}
+
+component main {public [value, fee, circuitHash, tokenType, historicRootBlockNumberL2, tokenId, ercAddress, recipientAddress, commitments, nullifiers, compressedSecrets,roots, feeAddress]} = TransferRegulator(4,3);
+

--- a/nightfall-deployer/circuits/transfer_regulator.circom
+++ b/nightfall-deployer/circuits/transfer_regulator.circom
@@ -63,7 +63,7 @@ template TransferRegulator(N,C) {
     signal input packedErcAddressPrivate;
     signal input idRemainderPrivate;
     signal input ephemeralKey;
-    signal input sharedPubSender[C][2];
+    signal input sharedPubSender[2];
     
     // Check that the transaction does not have nullifiers nor commitments duplicated
     var checkDuplicates = VerifyDuplicates(N,C)(nullifiers, commitments);
@@ -162,7 +162,7 @@ template TransferRegulator(N,C) {
     var tokenIdBits[256] = ArrayUint32ToBits(8)(tokenId);
     // Check that the encryption of the recipient's commitment preimage was performed appropiately
     var checkEncryption = VerifyEncryptionRegulator()([ercAddress, recipientAddress, compressedSecrets[0], compressedSecrets[1]], 
-        packedErcAddressPrivate, idRemainderPrivate, commitmentsValues[0], commitmentsSalts[0], sharedPubSender[0], 
+        packedErcAddressPrivate, idRemainderPrivate, commitmentsValues[0], commitmentsSalts[0], sharedPubSender, 
         tokenIdBits, ephemeralKey, value);
     checkEncryption === 1;
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test-administrator": "npx hardhat test --bail --no-compile test/multisig/administrator.test.mjs ",
     "test-optimist-sync": "npx hardhat test --no-compile --bail test/optimist-resync.test.mjs",
     "test-adversary": "npx hardhat test --no-compile --bail test/adversary.test.mjs",
-    "test-general-stuff": "npx hardhat test --bail --no-compile test/kem-dem.test.mjs test/timber.test.mjs",
+    "test-general-stuff": "npx hardhat test --bail --no-compile test/kem-dem.test.mjs test/kem-dem-regulator.test.mjs test/timber.test.mjs",
     "test-x509": "LOG_LEVEL=debug npx hardhat test --bail --no-compile test/x509.test.mjs",
     "unit-test": "npx hardhat test --bail test/unit/SmartContracts/*",
     "unit-test-whitelist": "npx hardhat test --bail test/unit/SmartContracts/whitelist.unit.test.mjs",

--- a/test/kem-dem-regulator.test.mjs
+++ b/test/kem-dem-regulator.test.mjs
@@ -58,20 +58,5 @@ describe('KEM-DEM Regulator Tests', () => {
         ),
       );
     });
-    it('packing should be reversible ', () => {
-      fc.assert(
-        fc.property(
-          fc.bigInt({ min: 0n, max: BN128_GROUP_ORDER - 1n }),
-          fc.bigInt({ min: 0n, max: 2n ** 160n - 1n }),
-          (a, b) => {
-            const [unpackedA, packedB] = packSecrets(generalise(a), generalise(b), 0, 2);
-            const [originalB, originalA] = packSecrets(packedB, unpackedA, 2, 0);
-
-            expect(originalA.bigInt).to.equal(a);
-            expect(originalB.bigInt).to.equal(b);
-          },
-        ),
-      );
-    });
   });
 });

--- a/test/kem-dem-regulator.test.mjs
+++ b/test/kem-dem-regulator.test.mjs
@@ -3,7 +3,7 @@ import fc from 'fast-check';
 import { generalise } from 'general-number';
 import { scalarMult } from '@polygon-nightfall/common-files/utils/curve-maths/curves.mjs';
 import constants from '@polygon-nightfall/common-files/constants/index.mjs';
-import { encrypt, decrypt, packSecrets } from '../nightfall-client/src/services/kem-dem.mjs';
+import { encrypt, decrypt } from '../nightfall-client/src/services/kem-dem.mjs';
 
 const { expect } = chai;
 

--- a/test/kem-dem-regulator.test.mjs
+++ b/test/kem-dem-regulator.test.mjs
@@ -1,0 +1,77 @@
+import chai from 'chai';
+import fc from 'fast-check';
+import { generalise } from 'general-number';
+import { scalarMult } from '@polygon-nightfall/common-files/utils/curve-maths/curves.mjs';
+import constants from '@polygon-nightfall/common-files/constants/index.mjs';
+import { encrypt, decrypt, packSecrets } from '../nightfall-client/src/services/kem-dem.mjs';
+
+const { expect } = chai;
+
+const { BN128_GROUP_ORDER, BABYJUBJUB } = constants;
+
+describe('KEM-DEM Regulator Tests', () => {
+  describe('Check encryption and decryption', () => {
+    it('decrypt . encrypt should be an identity ', () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.bigUint({ max: BN128_GROUP_ORDER - 1n }), { minLength: 1, maxLength: 10 }),
+          fc.bigUint({ max: BN128_GROUP_ORDER - 1n }),
+          fc.bigUint({ max: BN128_GROUP_ORDER - 1n }),
+          fc.bigUint({ max: BN128_GROUP_ORDER - 1n }),
+          fc.bigUint({ max: BigInt(2 ** 48 - 1) }),
+          (plaintexts, senderPrivateKey, recipientPrivateKey, regulatorPrivateKey, nonce) => {
+            const genSenderPrivateKey = generalise(senderPrivateKey);
+            const recipientPublicKey = scalarMult(recipientPrivateKey, BABYJUBJUB.GENERATOR);
+            const genRecipientPrivateKey = generalise(recipientPrivateKey);
+            const regulatorPublicKey = scalarMult(regulatorPrivateKey, BABYJUBJUB.GENERATOR);
+            // Secret Key: (senderPrivateKey * regulatorPrivateKey * recipientPublicKey) ^ nonce
+
+            // ENCRYPT
+            // 1) regulatorPrivateKey * recipientPublicKey
+            const sharedPubSender = scalarMult(
+              regulatorPrivateKey,
+              recipientPublicKey.map(r => r),
+            );
+            // 2) (genSenderPrivateKey * sharedPubSender) ^ nonce
+            const enc = encrypt(
+              genSenderPrivateKey,
+              generalise(sharedPubSender),
+              plaintexts,
+              nonce,
+            );
+
+            // DECRYPT
+            // 1) senderPrivateKey * regulatorPublicKey
+            const sharedPubReceiver = scalarMult(
+              senderPrivateKey,
+              regulatorPublicKey.map(r => r),
+            );
+            // 2) (genRecipientPrivateKey * sharedPubReceiver) ^ nonce
+            const dec = decrypt(
+              genRecipientPrivateKey,
+              generalise(sharedPubReceiver),
+              generalise(enc),
+              nonce,
+            );
+            expect(dec).to.deep.equal(plaintexts);
+          },
+        ),
+      );
+    });
+    it('packing should be reversible ', () => {
+      fc.assert(
+        fc.property(
+          fc.bigInt({ min: 0n, max: BN128_GROUP_ORDER - 1n }),
+          fc.bigInt({ min: 0n, max: 2n ** 160n - 1n }),
+          (a, b) => {
+            const [unpackedA, packedB] = packSecrets(generalise(a), generalise(b), 0, 2);
+            const [originalB, originalA] = packSecrets(packedB, unpackedA, 2, 0);
+
+            expect(originalA.bigInt).to.equal(a);
+            expect(originalB.bigInt).to.equal(b);
+          },
+        ),
+      );
+    });
+  });
+});

--- a/test/unit/circuits/transfer-regulator.circom.test.mjs
+++ b/test/unit/circuits/transfer-regulator.circom.test.mjs
@@ -42,56 +42,57 @@ describe('Test transfer regulator circuit', function () {
   let packedErcAddressPrivate;
   let idRemainderPrivate;
   let ephemeralKey;
+  let sharedPubSender;
 
   before(async () => {
     circuit = await tester(circuitPath, { reduceConstraints: false });
     await circuit.loadConstraints();
     console.log(`Constraints: ${circuit.constraints.length}\n`);
 
-    value = '0';
+    value = '52615104113680';
     fee = '1';
     tokenType = '0';
+    historicRootBlockNumberL2 = ['0', '2', '0', '0'];
+    ercAddress = '11037928113065011723621837603297555372128306067490168468476261520333215016451';
     tokenId = [
-      '312823736',
-      '3256528173',
-      '1469971658',
-      '2066892461',
-      '3857016417',
-      '3719684205',
-      '3518546394',
-      '1383280089',
+      '2767640935',
+      '2692862831',
+      '1366970421',
+      '341149654',
+      '3926962466',
+      '3136837739',
+      '2024592492',
+      '1079674086',
     ];
-    historicRootBlockNumberL2 = ['2', '0', '0', '0'];
-    ercAddress = '132879599395472219364501254852296720465866736717521941213348774738587710070';
+    recipientAddress =
+      '7204897914463877751569834808582585821054161548271355365331299819830610376760';
     commitments = [
-      '17757779475771887336357842275909057132037232354039100658148751003055531261983',
-      '12554361619243879049908583107882479056516016877280674758017429953383772997808',
+      '14152439929049712769864808654206087814269625799394135115988216087473179820627',
+      '15934666674837230553448159446654843311594766542351759235099852343111418588705',
       '0',
     ];
     nullifiers = [
-      '117197709477382921538019157130002666423833032783762819352913222960882908146',
-      '14300342375687883043781581600514382717671282147270299098452723711992633103162',
+      '17311493958849545193602041137608621636003642830429344983018506157521356554344',
+      '2207729929134374905111074270014121907881219345201302297326087557849574514218',
       '0',
       '0',
     ];
     compressedSecrets = [
-      '21168098505838680327273190678857184515054246835679269731579160077666503959877',
-      '10169841309943788425388858633837196980948099681313251904021825048923098020873',
+      '11585055354989698269877797980452971517592487277655690579135000134735218481243',
+      '9255503910041462247771821600280469663667490657631042670808205807969725761063',
     ];
     roots = [
-      '20964734282951928498431654994464533343258690792797020655572338130275330702810',
-      '3255859854610022712078710786625410158921384524803529764848754866431549438369',
+      '8115467701260440528096245764453859000019448019831060381341109750413454423249',
+      '912572422606684321134210801401173594062464573954172864442802425149947088851',
       '0',
       '0',
     ];
     feeAddress = '1319533947831612348694315757168650042041713553662';
-    recipientAddress =
-      '7756502216251446190890576589102414109278544248834858022081187213535079180632';
     rootKey = '2279923558995011751611063584918713773156544989985830828459384641106187332209';
-    nullifiersValues = ['0', '10', '0', '0'];
+    nullifiersValues = ['9', '9', '0', '0'];
     nullifiersSalts = [
-      '15340017689176527589104004637940033165402219799349309558245567952247042957987',
-      '17050793308128068127075637850076756759332532730466377884930007248365074989258',
+      '20513902764086722279230790388316452049712019845264173356954799219117530020083',
+      '10841558031173063604568111398826688175705902243878693366886722960342536541599',
       '0',
       '0',
     ];
@@ -127,7 +128,7 @@ describe('Test transfer regulator circuit', function () {
         '0',
         '0',
         '0',
-        '20485083585002706637081569015766164906760950525323997630771107581802573080375',
+        '0',
         '0',
       ],
       [
@@ -161,7 +162,7 @@ describe('Test transfer regulator circuit', function () {
         '0',
         '0',
         '0',
-        '0',
+        '525251941230013484363380026201828190666339810465305938728643722253281424202',
         '0',
       ],
       [
@@ -233,12 +234,11 @@ describe('Test transfer regulator circuit', function () {
         '0',
       ],
     ];
-
-    orders = ['2', '0', '0', '0'];
-    commitmentsValues = ['0', '9', '0'];
+    orders = ['0', '2', '0', '0'];
+    commitmentsValues = ['10', '7', '0'];
     commitmentsSalts = [
-      '21076183789647231661714109116890378504343710611690685717543855437204853365978',
-      '1522068224836897283121160171456811218383856683932886147822804168466578616752',
+      '12151054110963596045688559756029865234382274992995212084244447308464320651325',
+      '17683441280872854890097587392811695118644690590701452057917597918623544285485',
       '0',
     ];
     recipientPublicKey = [
@@ -252,10 +252,13 @@ describe('Test transfer regulator circuit', function () {
       ],
       ['0', '0'],
     ];
-
-    packedErcAddressPrivate = '1569275434574047503899461711674324182407852210045805191109';
-    idRemainderPrivate = '3';
-    ephemeralKey = '963948797541814037237923107657092227793394179262775402387658355273258414634';
+    packedErcAddressPrivate = '1319533947831612348694315757168650042041713553662';
+    idRemainderPrivate = '0';
+    ephemeralKey = '909701221553055453461978359737195753310684621371530022208323508315457158526';
+    sharedPubSender = [
+      '7854089346243255544872520686583446599765321252248122998010154744180687431657',
+      '15142832371551347777184090185309351432826131118144007300084258255168829320473',
+    ];
   });
 
   it('Should verify a valid transfer', async () => {
@@ -284,6 +287,7 @@ describe('Test transfer regulator circuit', function () {
       packedErcAddressPrivate,
       idRemainderPrivate,
       ephemeralKey,
+      sharedPubSender,
     };
 
     const w = await circuit.calculateWitness(input);
@@ -320,6 +324,7 @@ describe('Test transfer regulator circuit', function () {
       packedErcAddressPrivate,
       idRemainderPrivate,
       ephemeralKey,
+      sharedPubSender,
     };
 
     try {
@@ -361,6 +366,7 @@ describe('Test transfer regulator circuit', function () {
       packedErcAddressPrivate,
       idRemainderPrivate,
       ephemeralKey,
+      sharedPubSender,
     };
 
     try {
@@ -397,6 +403,7 @@ describe('Test transfer regulator circuit', function () {
       packedErcAddressPrivate,
       idRemainderPrivate,
       ephemeralKey,
+      sharedPubSender,
     };
 
     try {
@@ -433,6 +440,7 @@ describe('Test transfer regulator circuit', function () {
       packedErcAddressPrivate,
       idRemainderPrivate,
       ephemeralKey,
+      sharedPubSender,
     };
 
     try {
@@ -469,6 +477,7 @@ describe('Test transfer regulator circuit', function () {
       packedErcAddressPrivate,
       idRemainderPrivate,
       ephemeralKey,
+      sharedPubSender,
     };
 
     try {
@@ -505,6 +514,7 @@ describe('Test transfer regulator circuit', function () {
       packedErcAddressPrivate,
       idRemainderPrivate,
       ephemeralKey,
+      sharedPubSender,
     };
 
     try {
@@ -541,6 +551,7 @@ describe('Test transfer regulator circuit', function () {
       packedErcAddressPrivate,
       idRemainderPrivate,
       ephemeralKey,
+      sharedPubSender,
     };
 
     try {
@@ -577,6 +588,7 @@ describe('Test transfer regulator circuit', function () {
       packedErcAddressPrivate,
       idRemainderPrivate,
       ephemeralKey,
+      sharedPubSender,
     };
 
     try {
@@ -613,6 +625,7 @@ describe('Test transfer regulator circuit', function () {
       packedErcAddressPrivate,
       idRemainderPrivate,
       ephemeralKey,
+      sharedPubSender,
     };
 
     try {
@@ -649,6 +662,7 @@ describe('Test transfer regulator circuit', function () {
       packedErcAddressPrivate,
       idRemainderPrivate,
       ephemeralKey,
+      sharedPubSender,
     };
 
     try {
@@ -692,6 +706,7 @@ describe('Test transfer regulator circuit', function () {
       packedErcAddressPrivate,
       idRemainderPrivate,
       ephemeralKey,
+      sharedPubSender,
     };
 
     try {
@@ -728,6 +743,7 @@ describe('Test transfer regulator circuit', function () {
       packedErcAddressPrivate,
       idRemainderPrivate,
       ephemeralKey: 0,
+      sharedPubSender,
     };
 
     try {

--- a/test/unit/circuits/transfer-regulator.circom.test.mjs
+++ b/test/unit/circuits/transfer-regulator.circom.test.mjs
@@ -1,0 +1,740 @@
+// import chai from 'chai';
+import path from 'path';
+import circomTester from 'circom_tester';
+import { fileURLToPath } from 'url';
+// import { generalise } from 'general-number';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const tester = circomTester.wasm;
+// const { expect } = chai;
+
+describe('Test transfer regulator circuit', function () {
+  this.timeout(60000);
+  const circuitPath = path.join(
+    __dirname,
+    '../../../nightfall-deployer/circuits/transfer_regulator.circom',
+  );
+  let circuit;
+
+  let value;
+  let fee;
+  const circuitHash = '1';
+  let tokenType;
+  let ercAddress;
+  let historicRootBlockNumberL2;
+  let tokenId;
+  let recipientAddress;
+  let commitments;
+  let nullifiers;
+  let compressedSecrets;
+  let roots;
+  let feeAddress;
+  let rootKey;
+  let nullifiersValues;
+  let nullifiersSalts;
+  let paths;
+  let orders;
+  let commitmentsSalts;
+  let commitmentsValues;
+  let recipientPublicKey;
+  let packedErcAddressPrivate;
+  let idRemainderPrivate;
+  let ephemeralKey;
+
+  before(async () => {
+    circuit = await tester(circuitPath, { reduceConstraints: false });
+    await circuit.loadConstraints();
+    console.log(`Constraints: ${circuit.constraints.length}\n`);
+
+    value = '0';
+    fee = '1';
+    tokenType = '0';
+    tokenId = [
+      '312823736',
+      '3256528173',
+      '1469971658',
+      '2066892461',
+      '3857016417',
+      '3719684205',
+      '3518546394',
+      '1383280089',
+    ];
+    historicRootBlockNumberL2 = ['2', '0', '0', '0'];
+    ercAddress = '132879599395472219364501254852296720465866736717521941213348774738587710070';
+    commitments = [
+      '17757779475771887336357842275909057132037232354039100658148751003055531261983',
+      '12554361619243879049908583107882479056516016877280674758017429953383772997808',
+      '0',
+    ];
+    nullifiers = [
+      '117197709477382921538019157130002666423833032783762819352913222960882908146',
+      '14300342375687883043781581600514382717671282147270299098452723711992633103162',
+      '0',
+      '0',
+    ];
+    compressedSecrets = [
+      '21168098505838680327273190678857184515054246835679269731579160077666503959877',
+      '10169841309943788425388858633837196980948099681313251904021825048923098020873',
+    ];
+    roots = [
+      '20964734282951928498431654994464533343258690792797020655572338130275330702810',
+      '3255859854610022712078710786625410158921384524803529764848754866431549438369',
+      '0',
+      '0',
+    ];
+    feeAddress = '1319533947831612348694315757168650042041713553662';
+    recipientAddress =
+      '7756502216251446190890576589102414109278544248834858022081187213535079180632';
+    rootKey = '2279923558995011751611063584918713773156544989985830828459384641106187332209';
+    nullifiersValues = ['0', '10', '0', '0'];
+    nullifiersSalts = [
+      '15340017689176527589104004637940033165402219799349309558245567952247042957987',
+      '17050793308128068127075637850076756759332532730466377884930007248365074989258',
+      '0',
+      '0',
+    ];
+    paths = [
+      [
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '20485083585002706637081569015766164906760950525323997630771107581802573080375',
+        '0',
+      ],
+      [
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+      ],
+      [
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+      ],
+      [
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+      ],
+    ];
+
+    orders = ['2', '0', '0', '0'];
+    commitmentsValues = ['0', '9', '0'];
+    commitmentsSalts = [
+      '21076183789647231661714109116890378504343710611690685717543855437204853365978',
+      '1522068224836897283121160171456811218383856683932886147822804168466578616752',
+      '0',
+    ];
+    recipientPublicKey = [
+      [
+        '21455585142010026507269989850142987603845789706340301710583334029113247699665',
+        '5026357651889742986360178720315154348945488195628612719416852550950370706302',
+      ],
+      [
+        '8490685904787475746369366901729727151930997402058548597274067437080179631982',
+        '16019898780588040648157153023567746553375452631966740349901590026272037097498',
+      ],
+      ['0', '0'],
+    ];
+
+    packedErcAddressPrivate = '1569275434574047503899461711674324182407852210045805191109';
+    idRemainderPrivate = '3';
+    ephemeralKey = '963948797541814037237923107657092227793394179262775402387658355273258414634';
+  });
+
+  it('Should verify a valid transfer', async () => {
+    const input = {
+      value,
+      fee,
+      circuitHash,
+      tokenType,
+      historicRootBlockNumberL2,
+      ercAddress,
+      tokenId,
+      recipientAddress,
+      commitments,
+      nullifiers,
+      compressedSecrets,
+      roots,
+      feeAddress,
+      rootKey,
+      nullifiersValues,
+      nullifiersSalts,
+      paths,
+      orders,
+      commitmentsValues,
+      commitmentsSalts,
+      recipientPublicKey,
+      packedErcAddressPrivate,
+      idRemainderPrivate,
+      ephemeralKey,
+    };
+
+    const w = await circuit.calculateWitness(input);
+    await circuit.assertOut(w, {});
+  });
+
+  it('Should fail if transaction has a duplicate commitment', async () => {
+    const input = {
+      value,
+      fee,
+      circuitHash,
+      tokenType,
+      historicRootBlockNumberL2,
+      ercAddress,
+      tokenId,
+      recipientAddress,
+      commitments: [
+        '18494771599034867623561540682859693959325329137772357382989983287248677307908',
+        '18494771599034867623561540682859693959325329137772357382989983287248677307908',
+        '0',
+      ],
+      nullifiers,
+      compressedSecrets,
+      roots,
+      feeAddress,
+      rootKey,
+      nullifiersValues,
+      nullifiersSalts,
+      paths,
+      orders,
+      commitmentsValues,
+      commitmentsSalts,
+      recipientPublicKey,
+      packedErcAddressPrivate,
+      idRemainderPrivate,
+      ephemeralKey,
+    };
+
+    try {
+      await circuit.calculateWitness(input, { logOutput: false });
+      expect(true).to.be.equal(false);
+    } catch (error) {
+      expect(error.message.includes('Assert Failed')).to.be.equal(true);
+    }
+  });
+
+  it('Should fail if transaction has a duplicate nullifier', async () => {
+    const input = {
+      value,
+      fee,
+      circuitHash,
+      tokenType,
+      historicRootBlockNumberL2,
+      ercAddress,
+      tokenId,
+      recipientAddress,
+      commitments,
+      nullifiers: [
+        '17999105792329651812725678444463795258152753649215938181082241399954600642554',
+        '17999105792329651812725678444463795258152753649215938181082241399954600642554',
+        '0',
+        '0',
+      ],
+      compressedSecrets,
+      roots,
+      feeAddress,
+      rootKey,
+      nullifiersValues,
+      nullifiersSalts,
+      paths,
+      orders,
+      commitmentsValues,
+      commitmentsSalts,
+      recipientPublicKey,
+      packedErcAddressPrivate,
+      idRemainderPrivate,
+      ephemeralKey,
+    };
+
+    try {
+      await circuit.calculateWitness(input, { logOutput: false });
+      expect(true).to.be.equal(false);
+    } catch (error) {
+      expect(error.message.includes('Assert Failed')).to.be.equal(true);
+    }
+  });
+
+  it('Should fail if compressed secrets is zero', async () => {
+    const input = {
+      value,
+      fee,
+      circuitHash,
+      tokenType,
+      historicRootBlockNumberL2,
+      ercAddress,
+      tokenId,
+      recipientAddress,
+      commitments,
+      nullifiers,
+      compressedSecrets: ['0', '0'],
+      roots,
+      feeAddress,
+      rootKey,
+      nullifiersValues,
+      nullifiersSalts,
+      paths,
+      orders,
+      commitmentsValues,
+      commitmentsSalts,
+      recipientPublicKey,
+      packedErcAddressPrivate,
+      idRemainderPrivate,
+      ephemeralKey,
+    };
+
+    try {
+      await circuit.calculateWitness(input, { logOutput: false });
+      expect(true).to.be.equal(false);
+    } catch (error) {
+      expect(error.message.includes('Assert Failed')).to.be.equal(true);
+    }
+  });
+
+  it('Should fail if ercAddress is zero', async () => {
+    const input = {
+      value,
+      fee,
+      circuitHash,
+      tokenType,
+      historicRootBlockNumberL2,
+      ercAddress: 0,
+      tokenId,
+      recipientAddress,
+      commitments,
+      nullifiers,
+      compressedSecrets,
+      roots,
+      feeAddress,
+      rootKey,
+      nullifiersValues,
+      nullifiersSalts,
+      paths,
+      orders,
+      commitmentsValues,
+      commitmentsSalts,
+      recipientPublicKey,
+      packedErcAddressPrivate,
+      idRemainderPrivate,
+      ephemeralKey,
+    };
+
+    try {
+      await circuit.calculateWitness(input, { logOutput: false });
+      expect(true).to.be.equal(false);
+    } catch (error) {
+      expect(error.message.includes('Assert Failed')).to.be.equal(true);
+    }
+  });
+
+  it('Should fail if recipient address is zero', async () => {
+    const input = {
+      value,
+      fee,
+      circuitHash,
+      tokenType,
+      historicRootBlockNumberL2,
+      ercAddress,
+      tokenId,
+      recipientAddress: 0,
+      commitments,
+      nullifiers,
+      compressedSecrets,
+      roots,
+      feeAddress,
+      rootKey,
+      nullifiersValues,
+      nullifiersSalts,
+      paths,
+      orders,
+      commitmentsValues,
+      commitmentsSalts,
+      recipientPublicKey,
+      packedErcAddressPrivate,
+      idRemainderPrivate,
+      ephemeralKey,
+    };
+
+    try {
+      await circuit.calculateWitness(input, { logOutput: false });
+      expect(true).to.be.equal(false);
+    } catch (error) {
+      expect(error.message.includes('Assert Failed')).to.be.equal(true);
+    }
+  });
+
+  it('Should fail if first nullifier is zero', async () => {
+    const input = {
+      value,
+      fee,
+      circuitHash,
+      tokenType,
+      historicRootBlockNumberL2,
+      ercAddress,
+      tokenId,
+      recipientAddress,
+      commitments,
+      nullifiers: ['0', '0', '0', '0'],
+      compressedSecrets,
+      roots,
+      feeAddress,
+      rootKey,
+      nullifiersValues,
+      nullifiersSalts,
+      paths,
+      orders,
+      commitmentsValues,
+      commitmentsSalts,
+      recipientPublicKey,
+      packedErcAddressPrivate,
+      idRemainderPrivate,
+      ephemeralKey,
+    };
+
+    try {
+      await circuit.calculateWitness(input, { logOutput: false });
+      expect(true).to.be.equal(false);
+    } catch (error) {
+      expect(error.message.includes('Assert Failed')).to.be.equal(true);
+    }
+  });
+
+  it('Should fail if first commitment is zero', async () => {
+    const input = {
+      value,
+      fee,
+      circuitHash,
+      tokenType,
+      historicRootBlockNumberL2,
+      ercAddress,
+      tokenId,
+      recipientAddress,
+      commitments: ['0', '0', '0'],
+      nullifiers,
+      compressedSecrets,
+      roots,
+      feeAddress,
+      rootKey,
+      nullifiersValues,
+      nullifiersSalts,
+      paths,
+      orders,
+      commitmentsValues,
+      commitmentsSalts,
+      recipientPublicKey,
+      packedErcAddressPrivate,
+      idRemainderPrivate,
+      ephemeralKey,
+    };
+
+    try {
+      await circuit.calculateWitness(input, { logOutput: false });
+      expect(true).to.be.equal(false);
+    } catch (error) {
+      expect(error.message.includes('Assert Failed')).to.be.equal(true);
+    }
+  });
+
+  it('Should fail if value sum does not hold', async () => {
+    const input = {
+      value,
+      fee: '0',
+      circuitHash,
+      tokenType,
+      historicRootBlockNumberL2,
+      ercAddress,
+      tokenId,
+      recipientAddress,
+      commitments,
+      nullifiers,
+      compressedSecrets,
+      roots,
+      feeAddress,
+      rootKey,
+      nullifiersValues,
+      nullifiersSalts,
+      paths,
+      orders,
+      commitmentsValues,
+      commitmentsSalts,
+      recipientPublicKey,
+      packedErcAddressPrivate,
+      idRemainderPrivate,
+      ephemeralKey,
+    };
+
+    try {
+      await circuit.calculateWitness(input, { logOutput: false });
+      expect(true).to.be.equal(false);
+    } catch (error) {
+      expect(error.message.includes('Assert Failed')).to.be.equal(true);
+    }
+  });
+
+  it('Should fail if verify nullifiers fail', async () => {
+    const input = {
+      value,
+      fee,
+      circuitHash,
+      tokenType,
+      historicRootBlockNumberL2,
+      ercAddress,
+      tokenId,
+      recipientAddress,
+      commitments,
+      nullifiers,
+      compressedSecrets,
+      roots,
+      feeAddress,
+      rootKey,
+      nullifiersValues,
+      nullifiersSalts,
+      paths,
+      orders: ['1', '0', '0', '0'],
+      commitmentsValues,
+      commitmentsSalts,
+      recipientPublicKey,
+      packedErcAddressPrivate,
+      idRemainderPrivate,
+      ephemeralKey,
+    };
+
+    try {
+      await circuit.calculateWitness(input, { logOutput: false });
+      expect(true).to.be.equal(false);
+    } catch (error) {
+      expect(error.message.includes('Assert Failed')).to.be.equal(true);
+    }
+  });
+
+  it('Should fail if verify commitments fail', async () => {
+    const input = {
+      value,
+      fee,
+      circuitHash,
+      tokenType,
+      historicRootBlockNumberL2,
+      ercAddress,
+      tokenId,
+      recipientAddress,
+      commitments,
+      nullifiers,
+      compressedSecrets,
+      roots,
+      feeAddress,
+      rootKey,
+      nullifiersValues,
+      nullifiersSalts,
+      paths,
+      orders,
+      commitmentsValues,
+      commitmentsSalts: ['1', '0', '0'],
+      recipientPublicKey,
+      packedErcAddressPrivate,
+      idRemainderPrivate,
+      ephemeralKey,
+    };
+
+    try {
+      await circuit.calculateWitness(input, { logOutput: false });
+      expect(true).to.be.equal(false);
+    } catch (error) {
+      expect(error.message.includes('Assert Failed')).to.be.equal(true);
+    }
+  });
+
+  it('Should fail if recipientPublicKey does not match with the change', async () => {
+    const input = {
+      value,
+      fee,
+      circuitHash,
+      tokenType,
+      historicRootBlockNumberL2,
+      ercAddress,
+      tokenId,
+      recipientAddress,
+      commitments,
+      nullifiers,
+      compressedSecrets,
+      roots,
+      feeAddress,
+      rootKey,
+      nullifiersValues,
+      nullifiersSalts,
+      paths,
+      orders,
+      commitmentsValues,
+      commitmentsSalts,
+      recipientPublicKey: [
+        [
+          '21455585142010026507269989850142987603845789706340301710583334029113247699665',
+          '5026357651889742986360178720315154348945488195628612719416852550950370706302',
+        ],
+        ['0', '0'],
+        ['0', '0'],
+      ],
+      packedErcAddressPrivate,
+      idRemainderPrivate,
+      ephemeralKey,
+    };
+
+    try {
+      await circuit.calculateWitness(input, { logOutput: false });
+      expect(true).to.be.equal(false);
+    } catch (error) {
+      expect(error.message.includes('Assert Failed')).to.be.equal(true);
+    }
+  });
+
+  it('Should fail if verify encryption fails', async () => {
+    const input = {
+      value,
+      fee,
+      circuitHash,
+      tokenType,
+      historicRootBlockNumberL2,
+      ercAddress,
+      tokenId,
+      recipientAddress,
+      commitments,
+      nullifiers,
+      compressedSecrets,
+      roots,
+      feeAddress,
+      rootKey,
+      nullifiersValues,
+      nullifiersSalts,
+      paths,
+      orders,
+      commitmentsValues,
+      commitmentsSalts,
+      recipientPublicKey,
+      packedErcAddressPrivate,
+      idRemainderPrivate,
+      ephemeralKey: 0,
+    };
+
+    try {
+      await circuit.calculateWitness(input, { logOutput: false });
+      expect(true).to.be.equal(false);
+    } catch (error) {
+      expect(error.message.includes('Assert Failed')).to.be.equal(true);
+    }
+  });
+});


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Update in the client to enable regulator for the transfers.

## Does this close any currently open issues?
#1372 

## What commands can I run to test the change? 
Start nightfall with `REGULATOR_URL=http://localhost:8080 NF_SERVICES_TO_START=blockchain,client,worker,optimist,deployer ./bin/start-nightfall -g -d` to indicate a regulator url for the client to create transfers enabled for the regulator.

- npx hardhat test --bail --no-compile test/unit/circuits/transfer-regulator.circom.test.mjs (This is also included in `npm run unit-test-circuits`
- npx hardhat test --bail --no-compile test/kem-dem-regulator.test.mjs (This is also included in `npm run test-general-stuff`
- npm run test-erc20-tokens (To test in real scenario you need to simulate a regulator in start-nightfall with a REGULATOR_URL  `REGULATOR_URL=http://localhost:8080 NF_SERVICES_TO_START=blockchain,client,deployer,optimist,worker ./bin/start-nightfall -g -d`)

## Any other comments?
This is part of the regulator feature and the part for the regulator service is simulated now, waiting for the corresponding PR that will be merged in this feature branch and then integrated.
