### PR TITLE
[Regulator] Add Regulator Service

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -107,16 +107,17 @@ module.exports = {
     APPROVERS: process.env.MULTISIG_APPROVERS
       ? process.env.MULTISIG_APPROVERS.split(',')
       : [
-        '0x9C8B2276D490141Ae1440Da660E470E7C0349C63',
-        '0xfeEDA3882Dd44aeb394caEEf941386E7ed88e0E0',
-        '0xfCb059A4dB5B961d3e48706fAC91a55Bad0035C9',
-        '0x4789FD18D5d71982045d85d5218493fD69F55AC4',
-        '0xb9e9997dF5b3ac021AB3B29C64F3c339A2546816',
-      ],
+          '0x9C8B2276D490141Ae1440Da660E470E7C0349C63',
+          '0xfeEDA3882Dd44aeb394caEEf941386E7ed88e0E0',
+          '0xfCb059A4dB5B961d3e48706fAC91a55Bad0035C9',
+          '0x4789FD18D5d71982045d85d5218493fD69F55AC4',
+          '0xb9e9997dF5b3ac021AB3B29C64F3c339A2546816',
+        ],
   },
   BLOCKCHAIN_URL:
     process.env.BLOCKCHAIN_URL ||
-    `ws://${process.env.BLOCKCHAIN_WS_HOST}:${process.env.BLOCKCHAIN_PORT}${process.env.BLOCKCHAIN_PATH || ''
+    `ws://${process.env.BLOCKCHAIN_WS_HOST}:${process.env.BLOCKCHAIN_PORT}${
+      process.env.BLOCKCHAIN_PATH || ''
     }`,
   ETH_PRIVATE_KEY: process.env.ETH_PRIVATE_KEY, // owner's/deployer's private key
   ETH_ADDRESS: process.env.ETH_ADDRESS,
@@ -235,11 +236,12 @@ module.exports = {
       web3WsUrl:
         // eslint-disable-next-line no-nested-ternary
         process.env.BLOCKCHAIN_WS_HOST && process.env.BLOCKCHAIN_PORT
-          ? `ws://${process.env.BLOCKCHAIN_WS_HOST}:${process.env.BLOCKCHAIN_PORT}${process.env.BLOCKCHAIN_PATH || ''
-          }`
+          ? `ws://${process.env.BLOCKCHAIN_WS_HOST}:${process.env.BLOCKCHAIN_PORT}${
+              process.env.BLOCKCHAIN_PATH || ''
+            }`
           : process.env.BLOCKCHAIN_WS_HOST
-            ? `wss://${process.env.BLOCKCHAIN_WS_HOST}`
-            : 'ws://localhost:8546',
+          ? `wss://${process.env.BLOCKCHAIN_WS_HOST}`
+          : 'ws://localhost:8546',
       PROPOSER_KEY:
         process.env.PROPOSER_KEY ||
         process.env.BOOT_PROPOSER_KEY ||

--- a/config/default.js
+++ b/config/default.js
@@ -54,6 +54,7 @@ module.exports = {
   PROPOSER_COLLECTION: 'proposers',
   CHALLENGER_COLLECTION: 'challengers',
   TRANSACTIONS_COLLECTION: 'transactions',
+  TRANSFER_SECRET_COLLECTION: 'transfer_secrets',
   SUBMITTED_BLOCKS_COLLECTION: 'blocks',
   INVALID_BLOCKS_COLLECTION: 'invalid_blocks',
   COMMIT_COLLECTION: 'commits',
@@ -599,4 +600,5 @@ module.exports = {
   },
   TIMER_CHANGE_PROPOSER_SECOND: Number(process.env.TIMER_CHANGE_PROPOSER_SECOND) || 30,
   MAX_ROTATE_TIMES: Number(process.env.MAX_ROTATE_TIMES) || 2,
+  REGULATOR_PRIVATE_KEY: process.env.REGULATOR_PRIVATE_KEY,
 };

--- a/config/default.js
+++ b/config/default.js
@@ -59,6 +59,7 @@ module.exports = {
   INVALID_BLOCKS_COLLECTION: 'invalid_blocks',
   COMMIT_COLLECTION: 'commits',
   COMMITMENTS_COLLECTION: 'commitments',
+  COMMITMENTS_REGULATOR_COLLECTION: 'commitments_regulator',
   TIMBER_COLLECTION: 'timber',
   CIRCUIT_COLLECTION: 'circuit_storage',
   CIRCUIT_HASH_COLLECTION: 'circuit_hash_storage',
@@ -106,17 +107,16 @@ module.exports = {
     APPROVERS: process.env.MULTISIG_APPROVERS
       ? process.env.MULTISIG_APPROVERS.split(',')
       : [
-          '0x9C8B2276D490141Ae1440Da660E470E7C0349C63',
-          '0xfeEDA3882Dd44aeb394caEEf941386E7ed88e0E0',
-          '0xfCb059A4dB5B961d3e48706fAC91a55Bad0035C9',
-          '0x4789FD18D5d71982045d85d5218493fD69F55AC4',
-          '0xb9e9997dF5b3ac021AB3B29C64F3c339A2546816',
-        ],
+        '0x9C8B2276D490141Ae1440Da660E470E7C0349C63',
+        '0xfeEDA3882Dd44aeb394caEEf941386E7ed88e0E0',
+        '0xfCb059A4dB5B961d3e48706fAC91a55Bad0035C9',
+        '0x4789FD18D5d71982045d85d5218493fD69F55AC4',
+        '0xb9e9997dF5b3ac021AB3B29C64F3c339A2546816',
+      ],
   },
   BLOCKCHAIN_URL:
     process.env.BLOCKCHAIN_URL ||
-    `ws://${process.env.BLOCKCHAIN_WS_HOST}:${process.env.BLOCKCHAIN_PORT}${
-      process.env.BLOCKCHAIN_PATH || ''
+    `ws://${process.env.BLOCKCHAIN_WS_HOST}:${process.env.BLOCKCHAIN_PORT}${process.env.BLOCKCHAIN_PATH || ''
     }`,
   ETH_PRIVATE_KEY: process.env.ETH_PRIVATE_KEY, // owner's/deployer's private key
   ETH_ADDRESS: process.env.ETH_ADDRESS,
@@ -235,12 +235,11 @@ module.exports = {
       web3WsUrl:
         // eslint-disable-next-line no-nested-ternary
         process.env.BLOCKCHAIN_WS_HOST && process.env.BLOCKCHAIN_PORT
-          ? `ws://${process.env.BLOCKCHAIN_WS_HOST}:${process.env.BLOCKCHAIN_PORT}${
-              process.env.BLOCKCHAIN_PATH || ''
-            }`
+          ? `ws://${process.env.BLOCKCHAIN_WS_HOST}:${process.env.BLOCKCHAIN_PORT}${process.env.BLOCKCHAIN_PATH || ''
+          }`
           : process.env.BLOCKCHAIN_WS_HOST
-          ? `wss://${process.env.BLOCKCHAIN_WS_HOST}`
-          : 'ws://localhost:8546',
+            ? `wss://${process.env.BLOCKCHAIN_WS_HOST}`
+            : 'ws://localhost:8546',
       PROPOSER_KEY:
         process.env.PROPOSER_KEY ||
         process.env.BOOT_PROPOSER_KEY ||

--- a/docker/docker-compose.client.yml
+++ b/docker/docker-compose.client.yml
@@ -25,9 +25,9 @@ services:
       CIRCOM_WORKER_HOST: worker_1
       MONGO_URL: ${CLIENT_MONGO_URL:-mongodb://mongodb_client_1}
       CONTRACT_FILES_URL: ${CONTRACT_FILES_URL}
-      BLOCKCHAIN_WS_HOST: ${BLOCKCHAIN_WS_HOST}
       LAUNCH_LOCAL: 1
       GAS_ESTIMATE_ENDPOINT: ${GAS_ESTIMATE_ENDPOINT}
+      REGULATOR_PRIVATE_KEY: ${REGULATOR_PRIVATE_KEY}
     command: ['npm', 'run', 'dev']
 
   mongodb_client_1:

--- a/nightfall-client/src/app.mjs
+++ b/nightfall-client/src/app.mjs
@@ -18,6 +18,7 @@ import {
   tokenise,
   burn,
   transform,
+  regulator,
 } from './routes/index.mjs';
 
 const app = express();
@@ -48,6 +49,7 @@ setupHttpDefaults(
     app.use('/set-instant-withdrawal', setInstantWithdrawl);
     app.use('/generate-zkp-keys', generateZkpKeys);
     app.use('/x509', x509);
+    app.use('/regulator', regulator);
   },
   true,
   false,

--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -24,7 +24,7 @@ import {
   saveBlock,
   setTransactionHashSiblingInfo,
 } from '../services/database.mjs';
-import { decryptCommitment } from '../services/commitment-sync.mjs';
+import { decryptCommitment, decryptCommitmentRegulator } from '../services/commitment-sync.mjs';
 
 const { TIMBER_HEIGHT, HASH_TYPE, TXHASH_TREE_HASH_TYPE, REGULATOR_PRIVATE_KEY } = config;
 const { ZERO, WITHDRAW } = constants;
@@ -71,7 +71,7 @@ async function blockProposedEventHandler(data, syncing) {
       !countOfNonZeroCommitments
     ) {
       if (REGULATOR_PRIVATE_KEY) {
-        await decryptCommitment(transaction, [REGULATOR_PRIVATE_KEY], nullifierKeys);
+        await decryptCommitmentRegulator(transaction, [REGULATOR_PRIVATE_KEY], nullifierKeys);
       }
       const transactionDecrypted = await decryptCommitment(
         transaction,

--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -71,11 +71,7 @@ async function blockProposedEventHandler(data, syncing) {
       !countOfNonZeroCommitments
     ) {
       if (REGULATOR_PRIVATE_KEY) {
-        await decryptCommitment(
-          transaction,
-          REGULATOR_PRIVATE_KEY,
-          nullifierKeys,
-        );
+        await decryptCommitment(transaction, REGULATOR_PRIVATE_KEY, nullifierKeys);
       }
       const transactionDecrypted = await decryptCommitment(
         transaction,

--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -26,7 +26,7 @@ import {
 } from '../services/database.mjs';
 import { decryptCommitment } from '../services/commitment-sync.mjs';
 
-const { TIMBER_HEIGHT, HASH_TYPE, TXHASH_TREE_HASH_TYPE } = config;
+const { TIMBER_HEIGHT, HASH_TYPE, TXHASH_TREE_HASH_TYPE, REGULATOR_PRIVATE_KEY } = config;
 const { ZERO, WITHDRAW } = constants;
 
 const { generalise } = gen;
@@ -70,6 +70,13 @@ async function blockProposedEventHandler(data, syncing) {
       (transaction.compressedSecrets[0] !== ZERO || transaction.compressedSecrets[1] !== ZERO) &&
       !countOfNonZeroCommitments
     ) {
+      if (REGULATOR_PRIVATE_KEY) {
+        await decryptCommitment(
+          transaction,
+          REGULATOR_PRIVATE_KEY,
+          nullifierKeys,
+        );
+      }
       const transactionDecrypted = await decryptCommitment(
         transaction,
         zkpPrivateKeys,

--- a/nightfall-client/src/event-handlers/block-proposed.mjs
+++ b/nightfall-client/src/event-handlers/block-proposed.mjs
@@ -71,7 +71,7 @@ async function blockProposedEventHandler(data, syncing) {
       !countOfNonZeroCommitments
     ) {
       if (REGULATOR_PRIVATE_KEY) {
-        await decryptCommitment(transaction, REGULATOR_PRIVATE_KEY, nullifierKeys);
+        await decryptCommitment(transaction, [REGULATOR_PRIVATE_KEY], nullifierKeys);
       }
       const transactionDecrypted = await decryptCommitment(
         transaction,

--- a/nightfall-client/src/routes/index.mjs
+++ b/nightfall-client/src/routes/index.mjs
@@ -13,6 +13,7 @@ import incomingViewingKey from './incoming-viewing-key.mjs';
 import setInstantWithdrawl from './instant-withdrawal.mjs';
 import generateZkpKeys from './generate-zkp-keys.mjs';
 import x509 from './x509.mjs';
+import regulator from './regulator.mjs';
 
 export {
   transfer,
@@ -30,4 +31,5 @@ export {
   setInstantWithdrawl,
   generateZkpKeys,
   x509,
+  regulator,
 };

--- a/nightfall-client/src/routes/regulator.mjs
+++ b/nightfall-client/src/routes/regulator.mjs
@@ -1,0 +1,16 @@
+import express from 'express';
+import { registerPairSenderReceiver } from '../services/registerPairSenderReceiver.mjs';
+
+const router = express.Router();
+
+router.post('/registerPairSenderReceiver', async (req, res, next) => {
+  try {
+    const { PKa, PKb, PKx, intermediateXB } = req.body;
+    const { resultSharedSecret, resultPKx } = await registerPairSenderReceiver(PKa, PKb, PKx, intermediateXB);
+    res.json({ resultSharedSecret, resultPKx });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/nightfall-client/src/routes/regulator.mjs
+++ b/nightfall-client/src/routes/regulator.mjs
@@ -1,12 +1,17 @@
 import express from 'express';
-import { registerPairSenderReceiver } from '../services/registerPairSenderReceiver.mjs';
+import { registerPairSenderReceiver } from '../services/regulator.mjs';
 
 const router = express.Router();
 
 router.post('/registerPairSenderReceiver', async (req, res, next) => {
   try {
     const { PKa, PKb, PKx, intermediateXB } = req.body;
-    const { resultSharedSecret, resultPKx } = await registerPairSenderReceiver(PKa, PKb, PKx, intermediateXB);
+    const { resultSharedSecret, resultPKx } = await registerPairSenderReceiver(
+      PKa,
+      PKb,
+      PKx,
+      intermediateXB,
+    );
     res.json({ resultSharedSecret, resultPKx });
   } catch (err) {
     next(err);

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -18,12 +18,14 @@ import {
 } from './database.mjs';
 import { syncState } from './state-sync.mjs';
 
-const { MONGO_URL, COMMITMENTS_DB, COMMITMENTS_COLLECTION } = config;
+const { MONGO_URL, COMMITMENTS_DB, COMMITMENTS_COLLECTION, REGULATOR_PRIVATE_KEY, COMMITMENTS_REGULATOR_COLLECTION } = config;
 const { generalise } = gen;
 const mutex = new Mutex();
 
 // function to format a commitment for a mongo db and store it
-export async function storeCommitment(_commitment, nullifierKey) {
+export async function storeCommitment(_commitment, nullifierKey, zkpPrivateKey) {
+
+
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(COMMITMENTS_DB);
   // we'll also compute and store the nullifier hash.  This will be useful for
@@ -48,7 +50,13 @@ export async function storeCommitment(_commitment, nullifierKey) {
   logger.debug(`Storing commitment ${commitment._id}`);
   const query = { _id: commitment._id };
   const update = { $set: commitment };
-  return db.collection(COMMITMENTS_COLLECTION).updateOne(query, update, { upsert: true });
+  let collection;
+  if (zkpPrivateKey == REGULATOR_PRIVATE_KEY) {
+    collection = db.collection(COMMITMENTS_REGULATOR_COLLECTION);
+  } else {
+    collection = db.collection(COMMITMENTS_COLLECTION)
+  }
+  return collection.updateOne(query, update, { upsert: true });
 }
 // function to update an existing commitment
 export async function updateCommitment(commitment, updates) {

--- a/nightfall-client/src/services/commitment-storage.mjs
+++ b/nightfall-client/src/services/commitment-storage.mjs
@@ -18,14 +18,18 @@ import {
 } from './database.mjs';
 import { syncState } from './state-sync.mjs';
 
-const { MONGO_URL, COMMITMENTS_DB, COMMITMENTS_COLLECTION, REGULATOR_PRIVATE_KEY, COMMITMENTS_REGULATOR_COLLECTION } = config;
+const {
+  MONGO_URL,
+  COMMITMENTS_DB,
+  COMMITMENTS_COLLECTION,
+  REGULATOR_PRIVATE_KEY,
+  COMMITMENTS_REGULATOR_COLLECTION,
+} = config;
 const { generalise } = gen;
 const mutex = new Mutex();
 
 // function to format a commitment for a mongo db and store it
 export async function storeCommitment(_commitment, nullifierKey, zkpPrivateKey) {
-
-
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(COMMITMENTS_DB);
   // we'll also compute and store the nullifier hash.  This will be useful for
@@ -51,10 +55,10 @@ export async function storeCommitment(_commitment, nullifierKey, zkpPrivateKey) 
   const query = { _id: commitment._id };
   const update = { $set: commitment };
   let collection;
-  if (zkpPrivateKey == REGULATOR_PRIVATE_KEY) {
+  if (zkpPrivateKey === REGULATOR_PRIVATE_KEY) {
     collection = db.collection(COMMITMENTS_REGULATOR_COLLECTION);
   } else {
-    collection = db.collection(COMMITMENTS_COLLECTION)
+    collection = db.collection(COMMITMENTS_COLLECTION);
   }
   return collection.updateOne(query, update, { upsert: true });
 }

--- a/nightfall-client/src/services/commitment-sync.mjs
+++ b/nightfall-client/src/services/commitment-sync.mjs
@@ -50,7 +50,7 @@ export async function decryptCommitment(transaction, zkpPrivateKey, nullifierKey
           commitment,
           transactionHash: transaction.transactionHash,
         });
-        storeCommitments.push(storeCommitment(commitment, nullifierKey[j]));
+        storeCommitments.push(storeCommitment(commitment, nullifierKey[j], zkpPrivateKey));
       }
     } catch (err) {
       // This error will be caught regularly if the commitment isn't for us

--- a/nightfall-client/src/services/commitment-sync.mjs
+++ b/nightfall-client/src/services/commitment-sync.mjs
@@ -9,7 +9,11 @@ import { generalise } from 'general-number';
 import { edwardsDecompress } from '@polygon-nightfall/common-files/utils/curve-maths/curves.mjs';
 import constants from '@polygon-nightfall/common-files/constants/index.mjs';
 import { getAllTransactions } from './database.mjs';
-import { countCommitments, storeCommitment } from './commitment-storage.mjs';
+import {
+  countCommitments,
+  storeCommitment,
+  storeCommitmentRegulator,
+} from './commitment-storage.mjs';
 import { decrypt, packSecrets } from './kem-dem.mjs';
 import { ZkpKeys } from './keys.mjs';
 import Commitment from '../classes/commitment.mjs';
@@ -50,7 +54,57 @@ export async function decryptCommitment(transaction, zkpPrivateKey, nullifierKey
           commitment,
           transactionHash: transaction.transactionHash,
         });
-        storeCommitments.push(storeCommitment(commitment, nullifierKey[j], zkpPrivateKey));
+        storeCommitments.push(storeCommitment(commitment, nullifierKey[j]));
+      }
+    } catch (err) {
+      // This error will be caught regularly if the commitment isn't for us
+      // We dont print anything in order not to pollute the logs
+    }
+  });
+
+  const commitmentsStored = await Promise.all(storeCommitments);
+  if (commitmentsStored.length > 0) {
+    return true;
+  }
+  return false;
+}
+
+/**
+decrypt commitments for a transaction given zkpPrivateKeys and nullifierKeys.
+*/
+export async function decryptCommitmentRegulator(transaction, zkpPrivateKey, nullifierKey) {
+  const nonZeroCommitments = transaction.commitments.flat().filter(n => n !== ZERO);
+  const storeCommitments = [];
+  zkpPrivateKey.forEach((key, j) => {
+    const { zkpPublicKey } = ZkpKeys.calculateZkpPublicKey(generalise(key));
+    try {
+      const cipherTexts = [
+        transaction.ercAddress,
+        transaction.recipientAddress, // It contains the tokenID encrypted (which is a field)
+        ...transaction.compressedSecrets,
+      ];
+      const [packedErc, unpackedTokenID, ...rest] = decrypt(
+        generalise(key),
+        generalise(edwardsDecompress(transaction.tokenId)), // Compressed public key is stored in token ID
+        generalise(cipherTexts),
+        BigInt(transaction.value),
+      );
+      const [erc, tokenId] = packSecrets(generalise(packedErc), generalise(unpackedTokenID), 2, 0);
+      const plainTexts = generalise([erc, tokenId, ...rest]);
+      const commitment = new Commitment({
+        zkpPublicKey,
+        ercAddress: plainTexts[0].bigInt,
+        tokenId: plainTexts[1].bigInt,
+        value: plainTexts[2].bigInt,
+        salt: plainTexts[3].bigInt,
+      });
+      if (commitment.hash.hex(32) === nonZeroCommitments[0]) {
+        logger.info({
+          msg: 'Commitment successfully decrypted for this recipient',
+          commitment,
+          transactionHash: transaction.transactionHash,
+        });
+        storeCommitments.push(storeCommitmentRegulator(commitment, nullifierKey[j]));
       }
     } catch (err) {
       // This error will be caught regularly if the commitment isn't for us

--- a/nightfall-client/src/services/database.mjs
+++ b/nightfall-client/src/services/database.mjs
@@ -18,6 +18,7 @@ const {
   TRANSACTIONS_COLLECTION,
   TIMBER_HEIGHT,
   HASH_TYPE,
+  TRANSFER_SECRET_COLLECTION,
 } = config;
 
 /**
@@ -50,13 +51,13 @@ export async function getLatestTree() {
     timberObjArr.length === 1
       ? timberObjArr[0]
       : {
-          root: 0,
-          frontier: [],
-          leafCount: 0,
-          tree: undefined,
-          hashType: HASH_TYPE,
-          height: TIMBER_HEIGHT,
-        };
+        root: 0,
+        frontier: [],
+        leafCount: 0,
+        tree: undefined,
+        hashType: HASH_TYPE,
+        height: TIMBER_HEIGHT,
+      };
 
   const t = new Timber(
     timberObj.root,
@@ -270,4 +271,21 @@ export async function getTransactionsByTransactionHashesByL2Block(transactionHas
     (a, b) => positions[a.transactionHash] - positions[b.transactionHash],
   );
   return transactions;
+}
+
+export async function getRegisterPairSenderReceiver(PKa, PKb, PKx, intermediateXB, sharedSecret) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  return db.collection(TRANSFER_SECRET_COLLECTION).findOne(
+    { PKa: PKa, PKb: PKb, PKx: PKx, intermediateXB: intermediateXB, sharedSecret: sharedSecret },
+  );
+}
+
+export async function saveRegisterPairSenderReceiver(PKa, PKb, PKx, intermediateXB, sharedSecret) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+
+  logger.debug({ msg: 'Saving register pair sender receiver', PKa, PKb, PKx, intermediateXB, sharedSecret });
+
+  return db.collection(TRANSFER_SECRET_COLLECTION).insertOne({ PKa, PKb, PKx, intermediateXB, sharedSecret });
 }

--- a/nightfall-client/src/services/database.mjs
+++ b/nightfall-client/src/services/database.mjs
@@ -51,13 +51,13 @@ export async function getLatestTree() {
     timberObjArr.length === 1
       ? timberObjArr[0]
       : {
-        root: 0,
-        frontier: [],
-        leafCount: 0,
-        tree: undefined,
-        hashType: HASH_TYPE,
-        height: TIMBER_HEIGHT,
-      };
+          root: 0,
+          frontier: [],
+          leafCount: 0,
+          tree: undefined,
+          hashType: HASH_TYPE,
+          height: TIMBER_HEIGHT,
+        };
 
   const t = new Timber(
     timberObj.root,
@@ -275,17 +275,17 @@ export async function getTransactionsByTransactionHashesByL2Block(transactionHas
 
 export async function getRegisterPairSenderReceiver(PKa, PKb, PKx, intermediateXB, sharedSecret) {
   const connection = await mongo.connection(MONGO_URL);
-  const db = connection.db(OPTIMIST_DB);
-  return db.collection(TRANSFER_SECRET_COLLECTION).findOne(
-    { PKa: PKa, PKb: PKb, PKx: PKx, intermediateXB: intermediateXB, sharedSecret: sharedSecret },
-  );
+  const db = connection.db(COMMITMENTS_DB);
+  return db
+    .collection(TRANSFER_SECRET_COLLECTION)
+    .findOne({ PKa, PKb, PKx, intermediateXB, sharedSecret });
 }
 
 export async function saveRegisterPairSenderReceiver(PKa, PKb, PKx, intermediateXB, sharedSecret) {
   const connection = await mongo.connection(MONGO_URL);
-  const db = connection.db(OPTIMIST_DB);
+  const db = connection.db(COMMITMENTS_DB);
 
-  logger.debug({ msg: 'Saving register pair sender receiver', PKa, PKb, PKx, intermediateXB, sharedSecret });
-
-  return db.collection(TRANSFER_SECRET_COLLECTION).insertOne({ PKa, PKb, PKx, intermediateXB, sharedSecret });
+  return db
+    .collection(TRANSFER_SECRET_COLLECTION)
+    .insertOne({ PKa, PKb, PKx, intermediateXB, sharedSecret });
 }

--- a/nightfall-client/src/services/regulator.mjs
+++ b/nightfall-client/src/services/regulator.mjs
@@ -5,22 +5,25 @@ import { getRegisterPairSenderReceiver, saveRegisterPairSenderReceiver } from '.
 
 const { REGULATOR_PRIVATE_KEY } = constants;
 
-const registerPairSenderReceiver = async (PKa, PKb, PKx, intermediateXB) => {
-  const sharedSecret = scalarMult(
+const registerPairSenderReceiver = async (PKSender, PKReceiver, transferPublicKey, sharedPubRegulator) => {
+  const sharedPubSender = scalarMult(
     REGULATOR_PRIVATE_KEY.bigInt,
-    PKb.map(r => r.bigInt),
+    PKSender.map(r => r.bigInt),
   );
 
-  const { resPKa, resPKb, resPKx, resIntermediateXB, resSharedSecret } =
-    await getRegisterPairSenderReceiver(PKa, PKb, PKx, intermediateXB, sharedSecret);
+  const sharedPubReceiver = scalarMult(
+    REGULATOR_PRIVATE_KEY.bigInt,
+    PKReceiver.map(r => r.bigInt),
+  );
 
-  if (!resPKa && !resPKb && !resPKx && !resIntermediateXB && !resSharedSecret) {
-    await saveRegisterPairSenderReceiver(PKa, PKb, PKx, intermediateXB, sharedSecret);
+  const registerPairSenderReceiver =
+    await getRegisterPairSenderReceiver(PKSender, PKReceiver, transferPublicKey, sharedPubRegulator, sharedPubSender, sharedPubReceiver);
+
+  if (!registerPairSenderReceiver) {
+    await saveRegisterPairSenderReceiver(PKSender, PKReceiver, transferPublicKey, sharedPubRegulator, sharedSecret, sharedPubSender, sharedPubReceiver);
   }
 
-  const actualPKx = resPKx === PKx ? PKx : resPKx;
-
-  return { sharedSecret, actualPKx };
+  return { sharedPubSender, sharedPubReceiver };
 };
 
 export { registerPairSenderReceiver };

--- a/nightfall-client/src/services/regulator.mjs
+++ b/nightfall-client/src/services/regulator.mjs
@@ -1,9 +1,7 @@
+/* eslint-disable import/prefer-default-export */
 import { scalarMult } from '@polygon-nightfall/common-files/utils/curve-maths/curves.mjs';
 import constants from '@polygon-nightfall/common-files/constants/index.mjs';
-import {
-  getRegisterPairSenderReceiver,
-  saveRegisterPairSenderReceiver,
-} from './database.mjs';
+import { getRegisterPairSenderReceiver, saveRegisterPairSenderReceiver } from './database.mjs';
 
 const { REGULATOR_PRIVATE_KEY } = constants;
 
@@ -13,15 +11,16 @@ const registerPairSenderReceiver = async (PKa, PKb, PKx, intermediateXB) => {
     PKb.map(r => r.bigInt),
   );
 
-  const { resPKa, resPKb, resPKx, resIntermediateXB, resSharedSecret } = await getRegisterPairSenderReceiver(PKa, PKb, PKx, intermediateXB, sharedSecret);
+  const { resPKa, resPKb, resPKx, resIntermediateXB, resSharedSecret } =
+    await getRegisterPairSenderReceiver(PKa, PKb, PKx, intermediateXB, sharedSecret);
 
-  if (!resPKa && !resPKb && !resPKx && !resIntermediateXB, !resSharedSecret) {
+  if (!resPKa && !resPKb && !resPKx && !resIntermediateXB && !resSharedSecret) {
     await saveRegisterPairSenderReceiver(PKa, PKb, PKx, intermediateXB, sharedSecret);
   }
 
-  PKx = resPKx === PKx ? PKx : resPKx;
+  const actualPKx = resPKx === PKx ? PKx : resPKx;
 
-  return { sharedSecret, PKx };
+  return { sharedSecret, actualPKx };
 };
 
 export { registerPairSenderReceiver };

--- a/nightfall-client/src/services/regulator.mjs
+++ b/nightfall-client/src/services/regulator.mjs
@@ -1,0 +1,27 @@
+import { scalarMult } from '@polygon-nightfall/common-files/utils/curve-maths/curves.mjs';
+import constants from '@polygon-nightfall/common-files/constants/index.mjs';
+import {
+  getRegisterPairSenderReceiver,
+  saveRegisterPairSenderReceiver,
+} from './database.mjs';
+
+const { REGULATOR_PRIVATE_KEY } = constants;
+
+const registerPairSenderReceiver = async (PKa, PKb, PKx, intermediateXB) => {
+  const sharedSecret = scalarMult(
+    REGULATOR_PRIVATE_KEY.bigInt,
+    PKb.map(r => r.bigInt),
+  );
+
+  const { resPKa, resPKb, resPKx, resIntermediateXB, resSharedSecret } = await getRegisterPairSenderReceiver(PKa, PKb, PKx, intermediateXB, sharedSecret);
+
+  if (!resPKa && !resPKb && !resPKx && !resIntermediateXB, !resSharedSecret) {
+    await saveRegisterPairSenderReceiver(PKa, PKb, PKx, intermediateXB, sharedSecret);
+  }
+
+  PKx = resPKx === PKx ? PKx : resPKx;
+
+  return { sharedSecret, PKx };
+};
+
+export { registerPairSenderReceiver };

--- a/nightfall-client/src/services/regulator.mjs
+++ b/nightfall-client/src/services/regulator.mjs
@@ -5,7 +5,12 @@ import { getRegisterPairSenderReceiver, saveRegisterPairSenderReceiver } from '.
 
 const { REGULATOR_PRIVATE_KEY } = constants;
 
-const registerPairSenderReceiver = async (PKSender, PKReceiver, transferPublicKey, sharedPubRegulator) => {
+const registerPairSenderReceiver = async (
+  PKSender,
+  PKReceiver,
+  transferPublicKey,
+  sharedPubRegulator,
+) => {
   const sharedPubSender = scalarMult(
     REGULATOR_PRIVATE_KEY.bigInt,
     PKSender.map(r => r.bigInt),
@@ -16,11 +21,24 @@ const registerPairSenderReceiver = async (PKSender, PKReceiver, transferPublicKe
     PKReceiver.map(r => r.bigInt),
   );
 
-  const registerPairSenderReceiver =
-    await getRegisterPairSenderReceiver(PKSender, PKReceiver, transferPublicKey, sharedPubRegulator, sharedPubSender, sharedPubReceiver);
+  const registeredValue = await getRegisterPairSenderReceiver(
+    PKSender,
+    PKReceiver,
+    transferPublicKey,
+    sharedPubRegulator,
+    sharedPubSender,
+    sharedPubReceiver,
+  );
 
-  if (!registerPairSenderReceiver) {
-    await saveRegisterPairSenderReceiver(PKSender, PKReceiver, transferPublicKey, sharedPubRegulator, sharedSecret, sharedPubSender, sharedPubReceiver);
+  if (!registeredValue) {
+    await saveRegisterPairSenderReceiver(
+      PKSender,
+      PKReceiver,
+      transferPublicKey,
+      sharedPubRegulator,
+      sharedPubSender,
+      sharedPubReceiver,
+    );
   }
 
   return { sharedPubSender, sharedPubReceiver };


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

- [x] Add REGULATOR_PRIVATE_KEY as parameter for the container to configure a private key for the Regulator Service.
- [x] Add endpoint registerPairSenderReceiver to receive client calls with { PKa, PKb, PKx, pkx * PKb } parameters and result of scalar mult { pkr * PKb }. This registration will store parameters in some collection transfer_secrets.
- [x] Update the client service to be able to decrypt commitments for the regulator using the previous information and the commitments from transactions. Use another commitment collection commitments_regulator in the database for the regulator commitments.
- [ ] Add the corresponding tests

## Does this close any currently open issues?

## What commands can I run to test the change? 

## Any other comments?

