### PR TITLE
enrich root '.dockerignore'

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,34 @@
+/.git
+/.github
+/.vscode
+/.husky
+
+test
+doc
+bin
+docker
+cli/build
 config/geth/data
+common-files/test
 backup
+wallet
+jsdoc.json
+LICENSE
+
+# Ignore unnecessary files inside allowed directories
+# This should go after the allowed directories
+**/*~
+**/*.log
+**/.DS_Store
+**/Thumbs.db
+**/node_modules/
+**/dist
+**/npm-debug.log
+**/.coverage
+**/.coverage.*
+**/.env
+**/.npmrc
+**/.nvmrc
+**/*.md
+**/.dockerignore
+**/.gitignore


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Currently all container images are built with a build context of the entire repo. 
The `.dockerignore` file helps avoiding sending over large or sensitive files to the docker daemon and copying these into images. It follows the same syntax as '.gitignore' and can work recursively (with wildcards such as '**/node_modules/').
**However, Docker/Podman CLI will [only look](https://medium.com/@LihauTan/took-me-hours-to-realise-why-docker-build-ignores-my-dockerignore-and-this-is-what-ive-learned-2f87c770ea9c) for .dockerignore file in the root directory of the context!** so all those '.dockerignore' files in sub-directories are ignored and the root file (the only one that counts) is far from being conclusive.
**This can be especially detrimental when working against a remote machine or a local VM (as is the case with Docker Desktop for Mac/Windows)**.
So I edited the root `.dockerignore`, it now excludes anything that can be excluded from the build context of all containers.

## Does this close any currently open issues?
Nope

## What commands can I run to test the change? 
Just build the images and run some tests locally or via ci, there used to be a huge delay when running on a Mac with podman or docker desktop (due to copying a huge build context) which is now eliminated.

## Any other comments?
A few suggestions:
- Consider removing `.dockerignore` files from any sub-directories that are never used as container build context (which currently i think is all but the entire repo root) since these are ignored and therefore misleading
- For fine-grained control when using a large build context for building muultiple images, you may define a [custom file](https://stackoverflow.com/a/57774684) alongside the target 'Dockerfile.foo' named 'Dockerfile.foo.dockerignore' (requires buildkit)
