### PR TITLE
add '.gitattributes' to prevent issues when using docker on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+*.sh text eol=lf
+*.conf text eol=lf


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Makes sure on clone/checkout shell scripts are kept with linux file new line whitespaces otherwise if files are copied-over or bounded and executed from within a docker container if it uses windows CRLF shell will report that file does not exists or parsing error.
See: https://stackoverflow.com/questions/65320180/issue-with-line-endings-when-developing-on-a-windows-but-running-on-a-unix-docke

## Does this close any currently open issues?
Nope

## What commands can I run to test the change? 
Clone and checkout 'master' branch on a windows machine and open shell scripts in notepad++ while viewing all symbols to make sure newlines LF (and maybe start some docker services with `-d` flag as a sanity check).

## Any other comments?
Nope