### PR TITLE
avoid trying to 'ping' when ws state is not 'OPEN'

### DIFF
--- a/cli/lib/nf3.mjs
+++ b/cli/lib/nf3.mjs
@@ -26,6 +26,12 @@ import {
   GAS_ESTIMATE_ENDPOINT,
 } from './constants.mjs';
 
+function ping(ws) {
+  if (ws.readyState === WebSocket.OPEN) {
+    ws.ping();
+  }
+}
+
 function createQueue(options) {
   const queue = new Queue(options);
   queue.on('error', error => logger.error({ msg: 'Error caught by queue', error }));
@@ -903,7 +909,7 @@ class Nf3 {
       // setup a ping every 15s
       this.intervalIDs.push(
         setInterval(() => {
-          connection._ws.ping();
+          ping(connection._ws);
         }, WEBSOCKET_PING_TIME),
       );
       // and a listener for the pong
@@ -1223,7 +1229,7 @@ class Nf3 {
       // setup a ping every 15s
       this.intervalIDs.push(
         setInterval(() => {
-          connection._ws.ping();
+          ping(connection._ws);
         }, WEBSOCKET_PING_TIME),
       );
       // and a listener for the pong
@@ -1315,7 +1321,7 @@ class Nf3 {
       // setup a ping every 15s
       this.intervalIDs.push(
         setInterval(() => {
-          connection._ws.ping();
+          ping(connection._ws);
         }, WEBSOCKET_PING_TIME),
       );
       // and a listener for the pong


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Fixes an issue caused when trying to 'ping' by directly accessing the underlying ws while it is not in 'OPEN' state which
might lead to an error thrown (causing 'optimist-sync-test' to fail [spordically](https://github.com/EYBlockchain/nightfall_3/actions/runs/3948865503/jobs/6759374472) or crash 'proposer'/'challenger').

## Does this close any currently open issues?
Not sure

## What commands can I run to test the change? 
run 'optimist-sync-test' locally or in ci:
```bash
NF_SERVICES_TO_START=blockchain,client,deployer,mongodb,optimist,rabbitmq,worker ./bin/setup-nightfall
NF_SERVICES_TO_START=blockchain,client,deployer,mongodb,optimist,rabbitmq,worker CONFIRMATIONS=1 ./bin/start-nightfall -g -d
npm run test-optimist-sync
```

## Any other comments?
- Consider reviewing [managment](https://dev.to/ndrbrt/wait-for-the-websocket-connection-to-be-open-before-sending-a-message-1h12) of websocket state in general
- Consider which [solution](https://github.com/websockets/ws/issues/2040) to use for auto-reconnect (perhaps avoiding external dependency is preferable)
