### PR TITLE
Parallelize trusted setup and contracts deployment

### DIFF
--- a/nightfall-deployer/entrypoint.sh
+++ b/nightfall-deployer/entrypoint.sh
@@ -7,17 +7,4 @@ if [ -z "${ETH_PRIVATE_KEY}" ]; then
   while ! nc -z ${BLOCKCHAIN_WS_HOST} ${BLOCKCHAIN_PORT}; do sleep 3; done
 fi
 
-if [ "${SKIP_DEPLOYMENT}" != "true" ]; then
-  npx truffle compile --all
-
-  if [ -z "${UPGRADE}" ]; then
-    echo "Deploying contracts to ${ETH_NETWORK}"
-    npx truffle migrate --to 3 --network=${ETH_NETWORK}
-    echo 'Done'
-  else
-    echo 'Upgrading contracts'
-    npx truffle migrate -f 4 --network=${ETH_NETWORK} --skip-dry-run
-  fi
-fi
-
 npm start

--- a/nightfall-deployer/src/index.mjs
+++ b/nightfall-deployer/src/index.mjs
@@ -1,27 +1,84 @@
 import Web3 from '@polygon-nightfall/common-files/utils/web3.mjs';
 import logger from '@polygon-nightfall/common-files/utils/logger.mjs';
+import { promisify } from 'util';
+import child from 'child_process';
 import circuits from './circuit-setup.mjs';
 import setupContracts from './contract-setup.mjs';
 
-// TODO these can be paralleled
-async function main() {
-  await circuits.waitForWorker();
-  await circuits.setupCircuits();
+const execPromise = promisify(child.exec);
+
+const { SKIP_DEPLOYMENT, UPGRADE = '', ETH_NETWORK } = process.env;
+
+async function execShellCommand(cmd) {
+  const shellPromise = execPromise(cmd);
+  const shell = shellPromise.child;
+  shell.stdout.on('data', function (data) {
+    logger.debug(`shell stdout: ${data}`);
+  });
+  shell.stderr.on('data', function (data) {
+    logger.warn(`shell stderr: ${data}`);
+  });
+  shell.on('close', function (code) {
+    logger.info(`shell closing code: ${code}`);
+  });
+  const { stdout, stderr } = await shellPromise;
+  if (stdout) {
+    logger.info('shell stdout:', stdout);
+  }
+  if (stderr) {
+    logger.warn('shell stderr:', stderr);
+  }
+}
+
+async function deployContracts() {
+  if (SKIP_DEPLOYMENT === 'true') {
+    logger.info(`skipping contract deployment`);
+    return;
+  }
+  console.time('deployContracts - Execution Time');
+  await execShellCommand(`npx truffle compile --all`);
+  if (!UPGRADE) {
+    await execShellCommand(`npx truffle migrate --to 3 --network=${ETH_NETWORK}`);
+  } else {
+    await execShellCommand(`npx truffle migrate -f 4 --network=${ETH_NETWORK} --skip-dry-run`);
+  }
+  console.timeEnd('deployContracts - Execution Time');
+}
+
+async function safeSetupContracts() {
   try {
     await setupContracts();
   } catch (err) {
     if (err.message.includes('Transaction has been reverted by the EVM'))
       logger.warn(
-        'Writing contract addresses to the State contract failed. This is probably because they are aready set. Did you already run deployer?',
+        'Writing contract addresses to the State contract failed. This is probably because they are already set. Did you already run deployer?',
       );
     else throw new Error(err);
   }
+}
+
+async function setupCircuits() {
+  await circuits.waitForWorker();
+  console.time('setupCircuits - Execution Time');
+  await circuits.setupCircuits();
+  console.timeEnd('setupCircuits - Execution Time');
+}
+
+async function bootstrap() {
+  // eslint-disable-next-line no-unused-vars
+  return Promise.all([deployContracts(), setupCircuits()]).then(_values => safeSetupContracts());
+}
+
+async function main() {
+  logger.info(`deployer starting bootstrap`);
+  await bootstrap();
   try {
     Web3.disconnect();
   } catch (err) {
     logger.warn(`Attempt to disconnect web3 failed because ${err}`);
     process.exit(0);
   }
+  logger.info(`deployer bootstrap done`);
 }
 
 main();


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Executes the "trusted setup" process in-parallel to the "smart contracts deployment"(compilation + migrations) process which reduces system bootstap (`./bin/start-nightfall` / `docker-compose up`) time by up to 2 minutes (on local dev machines and ci agents alike). Executes 'truffle' commands via a "promisified" shell.
Executes the contracts setup (transfer of ownership and so) after both "trusted setup" and "smart contracts deployment" are concluded. Failure of any of the aforementioned stages should fail the entire bootsrap process.

## Does this close any currently open issues?
There has been a relevant inline "[TODO](https://github.com/EYBlockchain/nightfall_3/blob/ece2c9400ca473417e8144b861c4b66054db71ce/nightfall-deployer/src/index.mjs#L6)" but not an issue.

## What commands can I run to test the change? 
- Build the core nf3 components via `NF_SERVICES_TO_START=blockchain,client,deployer,mongodb,optimist,rabbitmq,worker ./bin/setup-nightfall`
- Run the core nf3 components via `NF_SERVICES_TO_START=blockchain,client,deployer,mongodb,optimist,rabbitmq,worker ./bin/start-nightfall -g`
- Make sure deployer exits after properly deploying the contracts and performing trusted setup 

**Sucessfull boostrap**
- 'deployer' should not report any errors and print "deployer bootstrap done" before exiting with code '0'
- Contracts artifacts (JSON metadata files with ABIs and addresses) should be created on shared volume `build`
- "Proving files" (global `*.ptau` files, per circuit `<circuit_name>.zkey`, `<circuit_name>.r1c1`, `<circuit_name>.wasm`) should be created on shared volume `proving_files`

**Use-cases**
- Both "trusted setup" and "smart contracts deployment" are not skipped, `ALWAYS_DO_TRUSTED_SETUP` is unset and "proving files" are not present on shared volume, `SKIP_DEPLOYMENT` is not set to 'true'
- "trusted setup" is skipped but "smart contracts deployment" is not, `ALWAYS_DO_TRUSTED_SETUP` is set or "proving files" are present on shared volume, `SKIP_DEPLOYMENT` is not set to 'true'
"trusted setup" is not skipped but "smart contracts deployment" is, `ALWAYS_DO_TRUSTED_SETUP` is unset and "proving files" are not present on shared volume, `SKIP_DEPLOYMENT` is set to 'true'
- Both "trusted setup" and "smart contracts deployment" are skipped, `ALWAYS_DO_TRUSTED_SETUP` is set or "proving files" are present on shared volume, `SKIP_DEPLOYMENT` is set to 'true'

## Any other comments?
Nope
