### PR TITLE
Optimize container images build

### DIFF
--- a/.github/workflows/on-pull-request-master.yml
+++ b/.github/workflows/on-pull-request-master.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
 
 env:
+  DOCKER_BUILDKIT: 1 # enable docker buildkit
 # Whitelisting is disabled during testing for backwards compatibility with these tests.  It must not be disabled in production.
   WHITELISTING: disable
 
@@ -141,7 +142,7 @@ jobs:
           if [ $RESULT != "200"]; then
             exit 1
           fi
-      
+
       - name: Authentication Test - endpoint whitelisted_1 OK
         run: |
           RESULT=$(curl -w "%{http_code}" -o /dev/null --silent http://localhost:8080/commitment/salt/?salt=0123456789)
@@ -963,7 +964,7 @@ jobs:
             curl -i http://localhost:8092/healthcheck
           attempt_limit: 10
           attempt_delay: 30000
-      
+
       - name: 'Check challenger liveliness'
         uses: Wandalen/wretry.action@v1.0.11
         with:

--- a/docker/admin.Dockerfile
+++ b/docker/admin.Dockerfile
@@ -11,15 +11,10 @@ ENTRYPOINT ["/app/admin/docker-entrypoint.sh"]
 
 WORKDIR /app
 COPY common-files common-files
-COPY cli cli
 
 WORKDIR /app/common-files
 RUN npm ci
 RUN npm link
-
-
-WORKDIR /app/cli
-RUN npm ci
 
 WORKDIR /app/admin
 COPY config/default.js config/default.js

--- a/docker/admin.Dockerfile
+++ b/docker/admin.Dockerfile
@@ -1,7 +1,11 @@
-FROM node:16.17
+FROM node:16.17-bullseye-slim
 
-RUN apt-get update -y
-RUN apt-get install -y netcat
+# 'node-gyp' requires 'python3', 'make' and 'g++''
+# entrypoint script requires 'netcat'
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    python3 make g++ netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/app/admin/docker-entrypoint.sh"]
 

--- a/docker/challenger.Dockerfile
+++ b/docker/challenger.Dockerfile
@@ -1,7 +1,11 @@
-FROM node:16.17
+FROM node:16.17-bullseye-slim
 
-RUN apt-get update -y
-RUN apt-get install -y netcat-openbsd
+# 'node-gyp' requires 'python3', 'make' and 'g++''
+# entrypoint script requires 'netcat'
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    python3 make g++ netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
 
 # websocket port 8080
 EXPOSE 8080

--- a/docker/circom.Dockerfile
+++ b/docker/circom.Dockerfile
@@ -1,5 +1,11 @@
 # build circom from source for local verify
-FROM rust:1.53.0 as builder
+FROM rust:1.53.0-slim as builder
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 # Circom
 RUN git clone -b 'v2.1.2' --single-branch https://github.com/iden3/circom.git

--- a/docker/circom.Dockerfile
+++ b/docker/circom.Dockerfile
@@ -12,5 +12,5 @@ RUN git clone -b 'v2.1.2' --single-branch https://github.com/iden3/circom.git
 
 WORKDIR /app/circom
 # For Mac Silicon this will default to aarch64-unknown-linux-gnu
-RUN rustup toolchain install nightly
-RUN cargo +nightly build --release
+RUN rustup toolchain install stable
+RUN cargo +stable build --release

--- a/docker/client.Dockerfile
+++ b/docker/client.Dockerfile
@@ -1,7 +1,11 @@
-FROM node:16.17
+FROM node:16.17-bullseye-slim
 
-RUN apt-get update -y
-RUN apt-get install -y netcat
+# 'node-gyp' requires 'python3', 'make' and 'g++''
+# entrypoint script requires 'netcat'
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    python3 make g++ netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 80 9229
 

--- a/docker/deployer.Dockerfile
+++ b/docker/deployer.Dockerfile
@@ -1,7 +1,11 @@
-FROM node:16.17
+FROM node:16.17-bullseye-slim
 
-RUN apt-get update -y
-RUN apt-get install -y netcat-openbsd
+# 'node-gyp' requires 'python3', 'make' and 'g++''
+# entrypoint script requires 'netcat'
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    python3 make g++ netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 

--- a/docker/hosted-utils-api-server.Dockerfile
+++ b/docker/hosted-utils-api-server.Dockerfile
@@ -1,7 +1,9 @@
-FROM node:16.17
+FROM node:16.17-bullseye-slim
 
-RUN apt-get update -y
-RUN apt-get install -y md5deep
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    md5deep \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/docker/optimist.Dockerfile
+++ b/docker/optimist.Dockerfile
@@ -1,8 +1,11 @@
-FROM node:16.17
+FROM node:16.17-bullseye-slim
 
-# install node
-RUN apt-get update
-RUN apt-get install -y netcat
+# 'node-gyp' requires 'python3', 'make' and 'g++''
+# entrypoint script requires 'netcat'
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    python3 make g++ netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 80 8080 9229
 

--- a/docker/optimist.Dockerfile
+++ b/docker/optimist.Dockerfile
@@ -4,9 +4,6 @@ FROM node:16.17
 RUN apt-get update
 RUN apt-get install -y netcat
 
-# installs libs required for zokrates
-RUN apt-get install -y libgmpxx4ldbl libgmp3-dev
-
 EXPOSE 80 8080 9229
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker/optimist.standalone.Dockerfile
+++ b/docker/optimist.standalone.Dockerfile
@@ -8,8 +8,6 @@ RUN apt-get install -y curl
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 RUN apt-get install -y nodejs gcc g++ make
 RUN apt-get install -y netcat
-# installs libs required for zokrates
-RUN apt-get install -y libgmpxx4ldbl libgmp3-dev
 
 ARG OPTIMIST_PORT=80
 ARG OPTIMIST_WS_PORT=8080

--- a/docker/proposer.Dockerfile
+++ b/docker/proposer.Dockerfile
@@ -1,7 +1,11 @@
-FROM node:16.17
+FROM node:16.17-bullseye-slim
 
-RUN apt-get update -y
-RUN apt-get install -y netcat-openbsd
+# 'node-gyp' requires 'python3', 'make' and 'g++''
+# entrypoint script requires 'netcat'
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    python3 make g++ netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
 
 # websocket port 8080
 EXPOSE 8080

--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -1,12 +1,14 @@
 # build circom from source for local verify
 FROM ghcr.io/eyblockchain/local-circom as builder
 
-FROM ubuntu:20.04
+FROM node:16.17-bullseye-slim
 
-RUN apt-get update -y
-RUN apt-get install -y netcat curl
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
-RUN apt-get install -y nodejs gcc g++ make
+# 'node-gyp' requires 'python3', 'make' and 'g++''
+# entrypoint script requires 'netcat'
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    python3 make g++ netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 80
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Trying to both improve container images build time on dev machines and on CI and produce lean images 
which is beneficial for both security (reduced attack surface) and performance.
- In contrast to Docker Desktop distributions, in this linux CI runner we have to opt-in to leverage the newer,
more performant and feature-rich [Buildkit](https://docs.docker.com/build/buildkit/) by setting environment variable `DOCKER_BUILDKIT=1`. This allows leverging buildkit while using `docker-compose`/ docker CLI in shell scripts. 
This change alone reduces the images build time by about 1.5-2 minutes (varies per ci job).
- Prefering the "slim" variants of rust/node base images which is applicable and only requires installing relevant packages such as 'git' for the circom and 'python3', 'make' and 'g++' required by 'node-gyp' to build binaries. 
- For circom, using "stable" rust channel instead of "nightly"
- For 'optimist' drop some unnecessary Zokrates dependencies
- Using 'apt' package manager according to [best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run) for avoiding caching issues and aiming for minimal image layers and small final image size 
- 'admin' does not require 'cli' module so removed it
- Consolidated (almost) all base images to `node:16.17-bullseye-slim` which is beneficial for consitency and caching ('worker' used 'ubuntu' as a base image for no apparent reason)

**Image Sizes - Before**

REPOSITORY                                               TAG         IMAGE ID      CREATED         SIZE
ghcr.io/eyblockchain/nightfall3-worker                   latest      0e17d0e7d21b  8 minutes ago   787 MB
ghcr.io/eyblockchain/nightfall3-proposer                 latest      a869c816c53f  9 minutes ago   1.2 GB
ghcr.io/eyblockchain/nightfall3-optimist                 latest      63b11c9bdf80  10 minutes ago  1.24 GB
ghcr.io/eyblockchain/nightfall3-hosted-utils-api-server  latest      3ba0204b5581  11 minutes ago  904 MB
ghcr.io/eyblockchain/nightfall3-deployer                 latest      86e26a0619f5  12 minutes ago  1.89 GB
ghcr.io/eyblockchain/nightfall3-client                   latest      f98737e6ac29  14 minutes ago  1.09 GB
ghcr.io/eyblockchain/nightfall3-administrator            latest      dd537413fa11  16 minutes ago  1.22 GB
ghcr.io/eyblockchain/local-circom                        latest      86c1fb12c78e  18 minutes ago  2.95 GB
docker.io/library/ubuntu                                 20.04       c9eb527b091d  11 days ago     68.1 MB
docker.io/library/node                                   16.17       a03050d564a2  4 months ago    879 MB
docker.io/library/rust                                   1.53.0      50aa7777bc81  19 months ago   1.39 GB

**Image Sizes - After**

REPOSITORY                                               TAG                  IMAGE ID      CREATED         SIZE
ghcr.io/eyblockchain/nightfall3-worker                   latest               4b5000ef4ae3  2 minutes ago   782 MB
ghcr.io/eyblockchain/nightfall3-proposer                 latest               93481f7ec98c  3 minutes ago   721 MB
ghcr.io/eyblockchain/nightfall3-optimist                 latest               e99e680f10f5  4 minutes ago   756 MB
ghcr.io/eyblockchain/nightfall3-hosted-utils-api-server  latest               12f841401d2c  5 minutes ago   198 MB
ghcr.io/eyblockchain/nightfall3-deployer                 latest               549092f71979  5 minutes ago   1.41 GB
ghcr.io/eyblockchain/nightfall3-client                   latest               ed6b6fdc0d5b  6 minutes ago   605 MB
ghcr.io/eyblockchain/nightfall3-administrator            latest               7d140a399c9d  9 minutes ago   621 MB
ghcr.io/eyblockchain/local-circom                        latest               8e39c440b11d  10 minutes ago  2.43 GB
docker.io/library/node                                   16.17-bullseye-slim  caf3332699b2  4 months ago    189 MB
docker.io/library/rust                                   1.53.0-slim          4057b273e8d8  19 months ago   792 MB

**CI Start Containers Step Runtime - Before **

'circuits-test' - 9m 55s
'ganache-protocol-test' - 10m 19s
'ganache-erc20-test' - 10m 9s
'administrator-test' - 11m 9s
'optimist-sync-test' - 11m 45s
'adversary-test' - 12m 33s
'ping-pong-test' - 10m 26s

**CI Start Containers Step Runtime - After **

'circuits-test' - 6m 57s
'ganache-protocol-test' - 6m 33s
'ganache-erc20-test' - 8m 3s
'administrator-test' - 7m 1s
'optimist-sync-test' - 6m 35s
'adversary-test' - 7m 37s
'ping-pong-test' - 6m 2s

## Does this close any currently open issues?
Nope

## What commands can I run to test the change? 
Build and start a sub-set of nf3 components and run any e2e test (locally or via ci)

## Any other comments?

**Future enhancements**
- I think that `docker/optimist.standalone.Dockerfile` can be merged with `docker/optimist.Dockerfile`
- Another optimization tested on my branch is skipping building the 'local-circom' image (does not depend on any repo sources but only on a pinned circom release and can be pulled from ghcr.io assuming it is pushed and defined with "public" package scope). This greatly improved build times!
- Another optimization that allows for better build parallelization and caching by buildkit and further reduces final image sizes (also test on my branch and can be submitted as a follow-up PR) is leveraging "multi-stage" [pattern](https://docs.docker.com/build/building/multi-stage/) (so these binaries required for building with 'node-gyp' are not part of the final artifact)
- I think that the current usage of local dependencies (where 'cli' and multiple other modules depend on 'common-files') could be improved (and I see you intend to refactor [it](https://github.com/EYBlockchain/nightfall_3/pull/1383#issuecomment-1425648398)). Most modules depend on `@polygon-nightfall/common-files` from remote registry while at least 2 modules ('optimist' and 'deployer') decalare both the local module and the remote one as a dependency. In most Dockerfile(s) `npm link` is misused (does not do what it should and common-files are only properly overidden with local sources if relying on mounts to host) and perhaps using only local dependencies with `--install-links` [flag](https://docs.npmjs.com/cli/v8/commands/npm-ci#install-links) can be more monorepo + docker friendly (also tested successfully)