### PR TITLE
Update worker with rapidsnark for faster proof generation

### DIFF
--- a/bin/setup-nightfall
+++ b/bin/setup-nightfall
@@ -19,6 +19,9 @@ if [ "$SKIP_CIRCOM_BUILD" == "" ]; then
   docker build ${NO_CACHE_FLAG} -t ghcr.io/eyblockchain/local-circom -f docker/circom.Dockerfile .
 fi
 
+if [ "$SKIP_RAPIDSNARK_BUILD" == "" ]; then
+  docker build ${NO_CACHE_FLAG} -t ghcr.io/eyblockchain/local-rapidsnark -f docker/rapidsnark.Dockerfile .
+fi
 # containers built separately. A parallel build fails.
 
 if [[ -z "${NF_SERVICES_TO_START}" || "${NF_SERVICES_TO_START}" == *"administrator"* ]]; then

--- a/docker/rapidsnark.Dockerfile
+++ b/docker/rapidsnark.Dockerfile
@@ -1,0 +1,22 @@
+FROM node:16.17 as rapidsnark
+
+RUN apt-get update -y
+RUN apt-get install -y netcat
+RUN apt-get install -y git
+
+WORKDIR /app
+
+# Rapidsnark
+RUN git clone https://github.com/iden3/rapidsnark.git
+
+WORKDIR /app/rapidsnark
+# For Mac Silicon this will default to aarch64-unknown-linux-gnu
+RUN apt install -y build-essential
+RUN apt-get install -y libgmp-dev
+RUN apt-get install -y libsodium-dev
+RUN apt-get install -y nasm
+RUN npm install
+RUN git submodule init
+RUN git submodule update
+RUN npx task createFieldSources
+RUN npx task buildProver

--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -1,5 +1,6 @@
 # build circom from source for local verify
 FROM ghcr.io/eyblockchain/local-circom as builder
+FROM ghcr.io/eyblockchain/local-rapidsnark as rapidsnark
 
 FROM ubuntu:20.04
 
@@ -7,6 +8,10 @@ RUN apt-get update -y
 RUN apt-get install -y netcat curl
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
 RUN apt-get install -y nodejs gcc g++ make
+RUN apt install -y build-essential
+RUN apt-get install -y libgmp-dev
+RUN apt-get install -y libsodium-dev
+RUN apt-get install -y nasm
 
 EXPOSE 80
 
@@ -22,6 +27,7 @@ WORKDIR /app
 COPY config/default.js config/default.js
 COPY /nightfall-deployer/circuits circuits
 COPY --from=builder /app/circom/target/release/circom /app/circom
+COPY --from=rapidsnark /app/rapidsnark/build/prover /app/prover
 COPY ./worker/package.json ./worker/package-lock.json ./
 COPY ./worker/src ./src
 COPY ./worker/start-script ./start-script

--- a/worker/src/utils/filing.mjs
+++ b/worker/src/utils/filing.mjs
@@ -59,6 +59,17 @@ export const deleteFile = async filePath => {
   );
 };
 
+export const readJsonFile = filePath => {
+  if (fs.existsSync(filePath)) {
+    const file = fs.readFileSync(filePath);
+    return JSON.parse(file);
+  }
+
+  logger.warn({ msg: 'Unable to locate file', filePath });
+
+  return null;
+};
+
 export const getFilesRecursively = (dir, fileList = []) => {
   const files = fs.readdirSync(dir);
 

--- a/worker/src/utils/rapidsnark.mjs
+++ b/worker/src/utils/rapidsnark.mjs
@@ -1,0 +1,31 @@
+import childProcess from 'child_process';
+
+const { spawn } = childProcess;
+
+/**
+ * Takes in a proving key and a compiled code file and outputs a proof.
+ * ./build/prove <circuit.zkey> <witness.wtns> <proof.json> <public.json>
+ * @param {String} circuitKey - Path to proving key
+ * @param {String} witness - Witness file
+ * @param {String} jsonProof - JSON proof as output
+ * @param {String} jsonPublic - JSON public inputs as output
+ * @returns {Object} JSON of the proof.
+ */
+export default async function generateProof(circuitKey, witness, jsonProof, jsonPublic) {
+  const args = [circuitKey, witness, jsonProof, jsonPublic];
+
+  return new Promise((resolve, reject) => {
+    const prover = spawn('/app/prover', args, {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+
+    prover.stderr.on('data', err => {
+      reject(new Error(`Generate proof failed: ${err}`));
+    });
+
+    prover.on('close', () => {
+      // Generate-proof doesn't seem to have any output, so we're not doing the same check as the other functions.
+      resolve();
+    });
+  });
+}

--- a/worker/src/utils/rapidsnark.mjs
+++ b/worker/src/utils/rapidsnark.mjs
@@ -9,7 +9,6 @@ const { spawn } = childProcess;
  * @param {String} witness - Witness file
  * @param {String} jsonProof - JSON proof as output
  * @param {String} jsonPublic - JSON public inputs as output
- * @returns {Object} JSON of the proof.
  */
 export default async function generateProof(circuitKey, witness, jsonProof, jsonPublic) {
   const args = [circuitKey, witness, jsonProof, jsonPublic];

--- a/worker/src/utils/rapidsnark.mjs
+++ b/worker/src/utils/rapidsnark.mjs
@@ -3,8 +3,7 @@ import childProcess from 'child_process';
 const { spawn } = childProcess;
 
 /**
- * Takes in a proving key and a compiled code file and outputs a proof.
- * ./build/prove <circuit.zkey> <witness.wtns> <proof.json> <public.json>
+ * Takes in a circuit proving key and a witness and outputs a proof and public inputs json files.
  * @param {String} circuitKey - Path to proving key
  * @param {String} witness - Witness file
  * @param {String} jsonProof - JSON proof as output


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Update worker and move from snarkjs to rapidsnark for faster proof generartion.

Performance test in a laptop with a Ryzen 7 4800HS processor with 8 cores 16 threads and 16GB of RAM.
| Prover | Deposit | Transfer | Withdraw |
|---|---|---|---|
| snarkjs | 361 ms  | 2395 ms  | 2140 ms  | 
| rapidsnark | 67 ms  |  1572 ms |  642 ms | 

## Does this close any currently open issues?
No

## What commands can I run to test the change? 
Any previous test that generates proofs in the worker. 
- npm run test-erc20-tokens
- npm run test-erc721-tokens 
- npm run test-erc1155-tokens 

## Any other comments?
Rapidsnark it's not working for ARM. We close the PR.
