### PR TITLE
Configure solcover (Solidity Coverage)

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,3 +1,3 @@
 module.exports = {
-  skipFiles: ['MerkleTree_Stateless.sol', 'Poseidon.sol', 'Migrations.sol'],
+  skipFiles: ['MerkleTree_Stateless.sol', 'Poseidon.sol', 'Migrations.sol', 'mocks'],
 };

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,3 +1,3 @@
 module.exports = {
-  skipFiles: ['MerkleTree_Stateless.sol', 'Poseidon.sol'],
+  skipFiles: ['MerkleTree_Stateless.sol', 'Poseidon.sol', 'Migrations.sol'],
 };

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,3 +1,3 @@
 module.exports = {
-  skipFiles: ['MerkleTree_Stateless.sol', 'Poseidon.sol', 'Migrations.sol', 'mocks'],
+  skipFiles: ['Migrations.sol', 'mocks'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "prettier-plugin-solidity": "^1.0.0-beta.10",
         "queue": "^6.0.2",
         "reconnecting-websocket": "^4.4.0",
-        "solidity-coverage": "^0.7.22",
+        "solidity-coverage": "^0.8.2",
         "terser": "^5.14.2",
         "ts-node": "^10.9.1",
         "typechain": "^8.1.0",
@@ -3167,8 +3167,9 @@
       }
     },
     "node_modules/@solidity-parser/parser": {
-      "version": "0.14.3",
-      "integrity": "sha512-29g2SZ29HtsqA58pLCtopI1P/cPy5/UAzlcAXO6T/CNJimG6yA8kx4NaseMyJULiC+TEs02Y9/yeHzClqoA0hw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.15.0.tgz",
+      "integrity": "sha512-5UFJJTzWi1hgFk6aGCZ5rxG2DJkCJOzJ74qg7UkWSNCDSigW+CJLoYUb5bLiKrtI34Nr9rpFSUNHfkqtlL+N/w==",
       "dev": true,
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4"
@@ -3815,369 +3816,6 @@
       }
     },
     "node_modules/@truffle/interface-adapter/node_modules/web3-utils": {
-      "version": "1.7.4",
-      "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
-      "dev": true,
-      "dependencies": {
-        "bn.js": "^5.2.1",
-        "ethereum-bloom-filters": "^1.0.6",
-        "ethereumjs-util": "^7.1.0",
-        "ethjs-unit": "0.1.6",
-        "number-to-bn": "1.7.0",
-        "randombytes": "^2.1.0",
-        "utf8": "3.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider": {
-      "version": "0.2.62",
-      "integrity": "sha512-MxfUkt+fUO66F1u4wjYu7j8ZZxkodnOALII4CUTd55rTHd0mw0rRtVtYiNAaK+WDljqHb55bc6ecE45ioeTnqA==",
-      "dev": true,
-      "dependencies": {
-        "@truffle/error": "^0.1.1",
-        "@truffle/interface-adapter": "^0.5.23",
-        "debug": "^4.3.1",
-        "web3": "1.7.4"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/@types/node": {
-      "version": "12.20.55",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-      "dev": true
-    },
-    "node_modules/@truffle/provider/node_modules/bignumber.js": {
-      "version": "9.1.0",
-      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/eth-lib": {
-      "version": "0.2.8",
-      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-      "dev": true,
-      "dependencies": {
-        "bn.js": "^4.11.6",
-        "elliptic": "^6.4.0",
-        "xhr-request-promise": "^0.1.2"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/eth-lib/node_modules/bn.js": {
-      "version": "4.12.0",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-      "dev": true
-    },
-    "node_modules/@truffle/provider/node_modules/uuid": {
-      "version": "3.3.2",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "dev": true,
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3": {
-      "version": "1.7.4",
-      "integrity": "sha512-iFGK5jO32vnXM/ASaJBaI0+gVR6uHozvYdxkdhaeOCD6HIQ4iIXadbO2atVpE9oc/H8l2MovJ4LtPhG7lIBN8A==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "web3-bzz": "1.7.4",
-        "web3-core": "1.7.4",
-        "web3-eth": "1.7.4",
-        "web3-eth-personal": "1.7.4",
-        "web3-net": "1.7.4",
-        "web3-shh": "1.7.4",
-        "web3-utils": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-bzz": {
-      "version": "1.7.4",
-      "integrity": "sha512-w9zRhyEqTK/yi0LGRHjZMcPCfP24LBjYXI/9YxFw9VqsIZ9/G0CRCnUt12lUx0A56LRAMpF7iQ8eA73aBcO29Q==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@types/node": "^12.12.6",
-        "got": "9.6.0",
-        "swarm-js": "^0.1.40"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-core": {
-      "version": "1.7.4",
-      "integrity": "sha512-L0DCPlIh9bgIED37tYbe7bsWrddoXYc897ANGvTJ6MFkSNGiMwDkTLWSgYd9Mf8qu8b4iuPqXZHMwIo4atoh7Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/bn.js": "^5.1.0",
-        "@types/node": "^12.12.6",
-        "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.7.4",
-        "web3-core-method": "1.7.4",
-        "web3-core-requestmanager": "1.7.4",
-        "web3-utils": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-core-helpers": {
-      "version": "1.7.4",
-      "integrity": "sha512-F8PH11qIkE/LpK4/h1fF/lGYgt4B6doeMi8rukeV/s4ivseZHHslv1L6aaijLX/g/j4PsFmR42byynBI/MIzFg==",
-      "dev": true,
-      "dependencies": {
-        "web3-eth-iban": "1.7.4",
-        "web3-utils": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-core-method": {
-      "version": "1.7.4",
-      "integrity": "sha512-56K7pq+8lZRkxJyzf5MHQPI9/VL3IJLoy4L/+q8HRdZJ3CkB1DkXYaXGU2PeylG1GosGiSzgIfu1ljqS7CP9xQ==",
-      "dev": true,
-      "dependencies": {
-        "@ethersproject/transactions": "^5.6.2",
-        "web3-core-helpers": "1.7.4",
-        "web3-core-promievent": "1.7.4",
-        "web3-core-subscriptions": "1.7.4",
-        "web3-utils": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-core-promievent": {
-      "version": "1.7.4",
-      "integrity": "sha512-o4uxwXKDldN7ER7VUvDfWsqTx9nQSP1aDssi1XYXeYC2xJbVo0n+z6ryKtmcoWoRdRj7uSpVzal3nEmlr480mA==",
-      "dev": true,
-      "dependencies": {
-        "eventemitter3": "4.0.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-core-requestmanager": {
-      "version": "1.7.4",
-      "integrity": "sha512-IuXdAm65BQtPL4aI6LZJJOrKAs0SM5IK2Cqo2/lMNvVMT9Kssq6qOk68Uf7EBDH0rPuINi+ReLP+uH+0g3AnPA==",
-      "dev": true,
-      "dependencies": {
-        "util": "^0.12.0",
-        "web3-core-helpers": "1.7.4",
-        "web3-providers-http": "1.7.4",
-        "web3-providers-ipc": "1.7.4",
-        "web3-providers-ws": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-core-subscriptions": {
-      "version": "1.7.4",
-      "integrity": "sha512-VJvKWaXRyxk2nFWumOR94ut9xvjzMrRtS38c4qj8WBIRSsugrZr5lqUwgndtj0qx4F+50JhnU++QEqUEAtKm3g==",
-      "dev": true,
-      "dependencies": {
-        "eventemitter3": "4.0.4",
-        "web3-core-helpers": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-eth": {
-      "version": "1.7.4",
-      "integrity": "sha512-JG0tTMv0Ijj039emXNHi07jLb0OiWSA9O24MRSk5vToTQyDNXihdF2oyq85LfHuF690lXZaAXrjhtLNlYqb7Ug==",
-      "dev": true,
-      "dependencies": {
-        "web3-core": "1.7.4",
-        "web3-core-helpers": "1.7.4",
-        "web3-core-method": "1.7.4",
-        "web3-core-subscriptions": "1.7.4",
-        "web3-eth-abi": "1.7.4",
-        "web3-eth-accounts": "1.7.4",
-        "web3-eth-contract": "1.7.4",
-        "web3-eth-ens": "1.7.4",
-        "web3-eth-iban": "1.7.4",
-        "web3-eth-personal": "1.7.4",
-        "web3-net": "1.7.4",
-        "web3-utils": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-eth-abi": {
-      "version": "1.7.4",
-      "integrity": "sha512-eMZr8zgTbqyL9MCTCAvb67RbVyN5ZX7DvA0jbLOqRWCiw+KlJKTGnymKO6jPE8n5yjk4w01e165Qb11hTDwHgg==",
-      "dev": true,
-      "dependencies": {
-        "@ethersproject/abi": "^5.6.3",
-        "web3-utils": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-eth-accounts": {
-      "version": "1.7.4",
-      "integrity": "sha512-Y9vYLRKP7VU7Cgq6wG1jFaG2k3/eIuiTKAG8RAuQnb6Cd9k5BRqTm5uPIiSo0AP/u11jDomZ8j7+WEgkU9+Btw==",
-      "dev": true,
-      "dependencies": {
-        "@ethereumjs/common": "^2.5.0",
-        "@ethereumjs/tx": "^3.3.2",
-        "crypto-browserify": "3.12.0",
-        "eth-lib": "0.2.8",
-        "ethereumjs-util": "^7.0.10",
-        "scrypt-js": "^3.0.1",
-        "uuid": "3.3.2",
-        "web3-core": "1.7.4",
-        "web3-core-helpers": "1.7.4",
-        "web3-core-method": "1.7.4",
-        "web3-utils": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-eth-contract": {
-      "version": "1.7.4",
-      "integrity": "sha512-ZgSZMDVI1pE9uMQpK0T0HDT2oewHcfTCv0osEqf5qyn5KrcQDg1GT96/+S0dfqZ4HKj4lzS5O0rFyQiLPQ8LzQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/bn.js": "^5.1.0",
-        "web3-core": "1.7.4",
-        "web3-core-helpers": "1.7.4",
-        "web3-core-method": "1.7.4",
-        "web3-core-promievent": "1.7.4",
-        "web3-core-subscriptions": "1.7.4",
-        "web3-eth-abi": "1.7.4",
-        "web3-utils": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-eth-ens": {
-      "version": "1.7.4",
-      "integrity": "sha512-Gw5CVU1+bFXP5RVXTCqJOmHn71X2ghNk9VcEH+9PchLr0PrKbHTA3hySpsPco1WJAyK4t8SNQVlNr3+bJ6/WZA==",
-      "dev": true,
-      "dependencies": {
-        "content-hash": "^2.5.2",
-        "eth-ens-namehash": "2.0.8",
-        "web3-core": "1.7.4",
-        "web3-core-helpers": "1.7.4",
-        "web3-core-promievent": "1.7.4",
-        "web3-eth-abi": "1.7.4",
-        "web3-eth-contract": "1.7.4",
-        "web3-utils": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-eth-iban": {
-      "version": "1.7.4",
-      "integrity": "sha512-XyrsgWlZQMv5gRcjXMsNvAoCRvV5wN7YCfFV5+tHUCqN8g9T/o4XUS20vDWD0k4HNiAcWGFqT1nrls02MGZ08w==",
-      "dev": true,
-      "dependencies": {
-        "bn.js": "^5.2.1",
-        "web3-utils": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-eth-personal": {
-      "version": "1.7.4",
-      "integrity": "sha512-O10C1Hln5wvLQsDhlhmV58RhXo+GPZ5+W76frSsyIrkJWLtYQTCr5WxHtRC9sMD1idXLqODKKgI2DL+7xeZ0/g==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "^12.12.6",
-        "web3-core": "1.7.4",
-        "web3-core-helpers": "1.7.4",
-        "web3-core-method": "1.7.4",
-        "web3-net": "1.7.4",
-        "web3-utils": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-net": {
-      "version": "1.7.4",
-      "integrity": "sha512-d2Gj+DIARHvwIdmxFQ4PwAAXZVxYCR2lET0cxz4KXbE5Og3DNjJi+MoPkX+WqoUXqimu/EOd4Cd+7gefqVAFDg==",
-      "dev": true,
-      "dependencies": {
-        "web3-core": "1.7.4",
-        "web3-core-method": "1.7.4",
-        "web3-utils": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-providers-http": {
-      "version": "1.7.4",
-      "integrity": "sha512-AU+/S+49rcogUER99TlhW+UBMk0N2DxvN54CJ2pK7alc2TQ7+cprNPLHJu4KREe8ndV0fT6JtWUfOMyTvl+FRA==",
-      "dev": true,
-      "dependencies": {
-        "web3-core-helpers": "1.7.4",
-        "xhr2-cookies": "1.1.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-providers-ipc": {
-      "version": "1.7.4",
-      "integrity": "sha512-jhArOZ235dZy8fS8090t60nTxbd1ap92ibQw5xIrAQ9m7LcZKNfmLAQUVsD+3dTFvadRMi6z1vCO7zRi84gWHw==",
-      "dev": true,
-      "dependencies": {
-        "oboe": "2.1.5",
-        "web3-core-helpers": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-providers-ws": {
-      "version": "1.7.4",
-      "integrity": "sha512-g72X77nrcHMFU8hRzQJzfgi/072n8dHwRCoTw+WQrGp+XCQ71fsk2qIu3Tp+nlp5BPn8bRudQbPblVm2uT4myQ==",
-      "dev": true,
-      "dependencies": {
-        "eventemitter3": "4.0.4",
-        "web3-core-helpers": "1.7.4",
-        "websocket": "^1.0.32"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-shh": {
-      "version": "1.7.4",
-      "integrity": "sha512-mlSZxSYcMkuMCxqhTYnZkUdahZ11h+bBv/8TlkXp/IHpEe4/Gg+KAbmfudakq3EzG/04z70XQmPgWcUPrsEJ+A==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "web3-core": "1.7.4",
-        "web3-core-method": "1.7.4",
-        "web3-core-subscriptions": "1.7.4",
-        "web3-net": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@truffle/provider/node_modules/web3-utils": {
       "version": "1.7.4",
       "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
       "dev": true,
@@ -5165,6 +4803,7 @@
     },
     "node_modules/antlr4ts": {
       "version": "0.5.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz",
       "integrity": "sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==",
       "dev": true
     },
@@ -6230,6 +5869,20 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chokidar/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
@@ -7202,6 +6855,18 @@
     "node_modules/diffie-hellman/node_modules/bn.js": {
       "version": "4.12.0",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
+    "node_modules/difflib": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
+      "integrity": "sha512-9YVwmMb0wQHQNr5J9m6BSj6fk4pfGITGQOOs+D9Fl+INODWFOfvhIU1hNv6GgR1RBoC/9NJcwu77zShxV0kT7w==",
+      "dev": true,
+      "dependencies": {
+        "heap": ">= 0.2.0"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -9702,6 +9367,21 @@
       "version": "1.0.0",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
+    "node_modules/fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
@@ -10758,6 +10438,12 @@
         "no-case": "^2.2.0",
         "upper-case": "^1.1.3"
       }
+    },
+    "node_modules/heap": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
+      "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==",
+      "dev": true
     },
     "node_modules/help-me": {
       "version": "4.1.0",
@@ -15634,31 +15320,145 @@
       "dev": true
     },
     "node_modules/solidity-coverage": {
-      "version": "0.7.22",
-      "integrity": "sha512-I6Zd5tsFY+gmj1FDIp6w7OrUePx6ZpMgKQZg7dWgPaQHePLi3Jk+iJ8lwZxsWEoNy2Lcv91rMxATWHqRaFdQpw==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.2.tgz",
+      "integrity": "sha512-cv2bWb7lOXPE9/SSleDO6czkFiMHgP4NXPj+iW9W7iEKLBk7Cj0AGBiNmGX3V1totl9wjPrT0gHmABZKZt65rQ==",
       "dev": true,
       "dependencies": {
-        "@solidity-parser/parser": "^0.14.0",
-        "@truffle/provider": "^0.2.24",
+        "@ethersproject/abi": "^5.0.9",
+        "@solidity-parser/parser": "^0.14.1",
         "chalk": "^2.4.2",
         "death": "^1.1.0",
         "detect-port": "^1.3.0",
+        "difflib": "^0.2.4",
         "fs-extra": "^8.1.0",
         "ghost-testrpc": "^0.0.2",
         "global-modules": "^2.0.0",
         "globby": "^10.0.1",
         "jsonschema": "^1.2.4",
         "lodash": "^4.17.15",
+        "mocha": "7.1.2",
         "node-emoji": "^1.10.0",
         "pify": "^4.0.1",
         "recursive-readdir": "^2.2.2",
         "sc-istanbul": "^0.4.5",
         "semver": "^7.3.4",
         "shelljs": "^0.8.3",
-        "web3-utils": "^1.3.0"
+        "web3-utils": "^1.3.6"
       },
       "bin": {
         "solidity-coverage": "plugins/bin.js"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.11.0"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/chokidar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.1.1"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "node_modules/solidity-coverage/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/flat": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+      "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "~2.0.3"
+      },
+      "bin": {
+        "flat": "cli.js"
       }
     },
     "node_modules/solidity-coverage/node_modules/fs-extra": {
@@ -15672,6 +15472,23 @@
       },
       "engines": {
         "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/solidity-coverage/node_modules/globby": {
@@ -15700,12 +15517,50 @@
         "node": ">= 4"
       }
     },
+    "node_modules/solidity-coverage/node_modules/js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/solidity-coverage/node_modules/jsonfile": {
       "version": "4.0.0",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/solidity-coverage/node_modules/lru-cache": {
@@ -15717,6 +15572,142 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/mocha": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
+      "integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.3.0",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "3.0.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.5",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.6",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
+    },
+    "node_modules/solidity-coverage/node_modules/object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/readdirp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/solidity-coverage/node_modules/semver": {
@@ -15733,6 +15724,53 @@
         "node": ">=10"
       }
     },
+    "node_modules/solidity-coverage/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/supports-color": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/solidity-coverage/node_modules/universalify": {
       "version": "0.1.2",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
@@ -15741,10 +15779,74 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/solidity-coverage/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
+    },
     "node_modules/solidity-coverage/node_modules/yallist": {
       "version": "4.0.0",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/solidity-coverage/node_modules/yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "dependencies": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/sonic-boom": {
       "version": "3.2.0",
@@ -20308,8 +20410,9 @@
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
     },
     "@solidity-parser/parser": {
-      "version": "0.14.3",
-      "integrity": "sha512-29g2SZ29HtsqA58pLCtopI1P/cPy5/UAzlcAXO6T/CNJimG6yA8kx4NaseMyJULiC+TEs02Y9/yeHzClqoA0hw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.15.0.tgz",
+      "integrity": "sha512-5UFJJTzWi1hgFk6aGCZ5rxG2DJkCJOzJ74qg7UkWSNCDSigW+CJLoYUb5bLiKrtI34Nr9rpFSUNHfkqtlL+N/w==",
       "dev": true,
       "requires": {
         "antlr4ts": "^0.5.0-alpha.4"
@@ -20744,300 +20847,6 @@
               "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
               "dev": true
             }
-          }
-        },
-        "web3-eth-contract": {
-          "version": "1.7.4",
-          "integrity": "sha512-ZgSZMDVI1pE9uMQpK0T0HDT2oewHcfTCv0osEqf5qyn5KrcQDg1GT96/+S0dfqZ4HKj4lzS5O0rFyQiLPQ8LzQ==",
-          "dev": true,
-          "requires": {
-            "@types/bn.js": "^5.1.0",
-            "web3-core": "1.7.4",
-            "web3-core-helpers": "1.7.4",
-            "web3-core-method": "1.7.4",
-            "web3-core-promievent": "1.7.4",
-            "web3-core-subscriptions": "1.7.4",
-            "web3-eth-abi": "1.7.4",
-            "web3-utils": "1.7.4"
-          }
-        },
-        "web3-eth-ens": {
-          "version": "1.7.4",
-          "integrity": "sha512-Gw5CVU1+bFXP5RVXTCqJOmHn71X2ghNk9VcEH+9PchLr0PrKbHTA3hySpsPco1WJAyK4t8SNQVlNr3+bJ6/WZA==",
-          "dev": true,
-          "requires": {
-            "content-hash": "^2.5.2",
-            "eth-ens-namehash": "2.0.8",
-            "web3-core": "1.7.4",
-            "web3-core-helpers": "1.7.4",
-            "web3-core-promievent": "1.7.4",
-            "web3-eth-abi": "1.7.4",
-            "web3-eth-contract": "1.7.4",
-            "web3-utils": "1.7.4"
-          }
-        },
-        "web3-eth-iban": {
-          "version": "1.7.4",
-          "integrity": "sha512-XyrsgWlZQMv5gRcjXMsNvAoCRvV5wN7YCfFV5+tHUCqN8g9T/o4XUS20vDWD0k4HNiAcWGFqT1nrls02MGZ08w==",
-          "dev": true,
-          "requires": {
-            "bn.js": "^5.2.1",
-            "web3-utils": "1.7.4"
-          }
-        },
-        "web3-eth-personal": {
-          "version": "1.7.4",
-          "integrity": "sha512-O10C1Hln5wvLQsDhlhmV58RhXo+GPZ5+W76frSsyIrkJWLtYQTCr5WxHtRC9sMD1idXLqODKKgI2DL+7xeZ0/g==",
-          "dev": true,
-          "requires": {
-            "@types/node": "^12.12.6",
-            "web3-core": "1.7.4",
-            "web3-core-helpers": "1.7.4",
-            "web3-core-method": "1.7.4",
-            "web3-net": "1.7.4",
-            "web3-utils": "1.7.4"
-          }
-        },
-        "web3-net": {
-          "version": "1.7.4",
-          "integrity": "sha512-d2Gj+DIARHvwIdmxFQ4PwAAXZVxYCR2lET0cxz4KXbE5Og3DNjJi+MoPkX+WqoUXqimu/EOd4Cd+7gefqVAFDg==",
-          "dev": true,
-          "requires": {
-            "web3-core": "1.7.4",
-            "web3-core-method": "1.7.4",
-            "web3-utils": "1.7.4"
-          }
-        },
-        "web3-providers-http": {
-          "version": "1.7.4",
-          "integrity": "sha512-AU+/S+49rcogUER99TlhW+UBMk0N2DxvN54CJ2pK7alc2TQ7+cprNPLHJu4KREe8ndV0fT6JtWUfOMyTvl+FRA==",
-          "dev": true,
-          "requires": {
-            "web3-core-helpers": "1.7.4",
-            "xhr2-cookies": "1.1.0"
-          }
-        },
-        "web3-providers-ipc": {
-          "version": "1.7.4",
-          "integrity": "sha512-jhArOZ235dZy8fS8090t60nTxbd1ap92ibQw5xIrAQ9m7LcZKNfmLAQUVsD+3dTFvadRMi6z1vCO7zRi84gWHw==",
-          "dev": true,
-          "requires": {
-            "oboe": "2.1.5",
-            "web3-core-helpers": "1.7.4"
-          }
-        },
-        "web3-providers-ws": {
-          "version": "1.7.4",
-          "integrity": "sha512-g72X77nrcHMFU8hRzQJzfgi/072n8dHwRCoTw+WQrGp+XCQ71fsk2qIu3Tp+nlp5BPn8bRudQbPblVm2uT4myQ==",
-          "dev": true,
-          "requires": {
-            "eventemitter3": "4.0.4",
-            "web3-core-helpers": "1.7.4",
-            "websocket": "^1.0.32"
-          }
-        },
-        "web3-shh": {
-          "version": "1.7.4",
-          "integrity": "sha512-mlSZxSYcMkuMCxqhTYnZkUdahZ11h+bBv/8TlkXp/IHpEe4/Gg+KAbmfudakq3EzG/04z70XQmPgWcUPrsEJ+A==",
-          "dev": true,
-          "requires": {
-            "web3-core": "1.7.4",
-            "web3-core-method": "1.7.4",
-            "web3-core-subscriptions": "1.7.4",
-            "web3-net": "1.7.4"
-          }
-        },
-        "web3-utils": {
-          "version": "1.7.4",
-          "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
-          "dev": true,
-          "requires": {
-            "bn.js": "^5.2.1",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethereumjs-util": "^7.1.0",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "utf8": "3.0.0"
-          }
-        }
-      }
-    },
-    "@truffle/provider": {
-      "version": "0.2.62",
-      "integrity": "sha512-MxfUkt+fUO66F1u4wjYu7j8ZZxkodnOALII4CUTd55rTHd0mw0rRtVtYiNAaK+WDljqHb55bc6ecE45ioeTnqA==",
-      "dev": true,
-      "requires": {
-        "@truffle/error": "^0.1.1",
-        "@truffle/interface-adapter": "^0.5.23",
-        "debug": "^4.3.1",
-        "web3": "1.7.4"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.20.55",
-          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-          "dev": true
-        },
-        "bignumber.js": {
-          "version": "9.1.0",
-          "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
-          "dev": true
-        },
-        "eth-lib": {
-          "version": "0.2.8",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "dev": true,
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.0",
-              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-              "dev": true
-            }
-          }
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-          "dev": true
-        },
-        "web3": {
-          "version": "1.7.4",
-          "integrity": "sha512-iFGK5jO32vnXM/ASaJBaI0+gVR6uHozvYdxkdhaeOCD6HIQ4iIXadbO2atVpE9oc/H8l2MovJ4LtPhG7lIBN8A==",
-          "dev": true,
-          "requires": {
-            "web3-bzz": "1.7.4",
-            "web3-core": "1.7.4",
-            "web3-eth": "1.7.4",
-            "web3-eth-personal": "1.7.4",
-            "web3-net": "1.7.4",
-            "web3-shh": "1.7.4",
-            "web3-utils": "1.7.4"
-          }
-        },
-        "web3-bzz": {
-          "version": "1.7.4",
-          "integrity": "sha512-w9zRhyEqTK/yi0LGRHjZMcPCfP24LBjYXI/9YxFw9VqsIZ9/G0CRCnUt12lUx0A56LRAMpF7iQ8eA73aBcO29Q==",
-          "dev": true,
-          "requires": {
-            "@types/node": "^12.12.6",
-            "got": "9.6.0",
-            "swarm-js": "^0.1.40"
-          }
-        },
-        "web3-core": {
-          "version": "1.7.4",
-          "integrity": "sha512-L0DCPlIh9bgIED37tYbe7bsWrddoXYc897ANGvTJ6MFkSNGiMwDkTLWSgYd9Mf8qu8b4iuPqXZHMwIo4atoh7Q==",
-          "dev": true,
-          "requires": {
-            "@types/bn.js": "^5.1.0",
-            "@types/node": "^12.12.6",
-            "bignumber.js": "^9.0.0",
-            "web3-core-helpers": "1.7.4",
-            "web3-core-method": "1.7.4",
-            "web3-core-requestmanager": "1.7.4",
-            "web3-utils": "1.7.4"
-          }
-        },
-        "web3-core-helpers": {
-          "version": "1.7.4",
-          "integrity": "sha512-F8PH11qIkE/LpK4/h1fF/lGYgt4B6doeMi8rukeV/s4ivseZHHslv1L6aaijLX/g/j4PsFmR42byynBI/MIzFg==",
-          "dev": true,
-          "requires": {
-            "web3-eth-iban": "1.7.4",
-            "web3-utils": "1.7.4"
-          }
-        },
-        "web3-core-method": {
-          "version": "1.7.4",
-          "integrity": "sha512-56K7pq+8lZRkxJyzf5MHQPI9/VL3IJLoy4L/+q8HRdZJ3CkB1DkXYaXGU2PeylG1GosGiSzgIfu1ljqS7CP9xQ==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/transactions": "^5.6.2",
-            "web3-core-helpers": "1.7.4",
-            "web3-core-promievent": "1.7.4",
-            "web3-core-subscriptions": "1.7.4",
-            "web3-utils": "1.7.4"
-          }
-        },
-        "web3-core-promievent": {
-          "version": "1.7.4",
-          "integrity": "sha512-o4uxwXKDldN7ER7VUvDfWsqTx9nQSP1aDssi1XYXeYC2xJbVo0n+z6ryKtmcoWoRdRj7uSpVzal3nEmlr480mA==",
-          "dev": true,
-          "requires": {
-            "eventemitter3": "4.0.4"
-          }
-        },
-        "web3-core-requestmanager": {
-          "version": "1.7.4",
-          "integrity": "sha512-IuXdAm65BQtPL4aI6LZJJOrKAs0SM5IK2Cqo2/lMNvVMT9Kssq6qOk68Uf7EBDH0rPuINi+ReLP+uH+0g3AnPA==",
-          "dev": true,
-          "requires": {
-            "util": "^0.12.0",
-            "web3-core-helpers": "1.7.4",
-            "web3-providers-http": "1.7.4",
-            "web3-providers-ipc": "1.7.4",
-            "web3-providers-ws": "1.7.4"
-          }
-        },
-        "web3-core-subscriptions": {
-          "version": "1.7.4",
-          "integrity": "sha512-VJvKWaXRyxk2nFWumOR94ut9xvjzMrRtS38c4qj8WBIRSsugrZr5lqUwgndtj0qx4F+50JhnU++QEqUEAtKm3g==",
-          "dev": true,
-          "requires": {
-            "eventemitter3": "4.0.4",
-            "web3-core-helpers": "1.7.4"
-          }
-        },
-        "web3-eth": {
-          "version": "1.7.4",
-          "integrity": "sha512-JG0tTMv0Ijj039emXNHi07jLb0OiWSA9O24MRSk5vToTQyDNXihdF2oyq85LfHuF690lXZaAXrjhtLNlYqb7Ug==",
-          "dev": true,
-          "requires": {
-            "web3-core": "1.7.4",
-            "web3-core-helpers": "1.7.4",
-            "web3-core-method": "1.7.4",
-            "web3-core-subscriptions": "1.7.4",
-            "web3-eth-abi": "1.7.4",
-            "web3-eth-accounts": "1.7.4",
-            "web3-eth-contract": "1.7.4",
-            "web3-eth-ens": "1.7.4",
-            "web3-eth-iban": "1.7.4",
-            "web3-eth-personal": "1.7.4",
-            "web3-net": "1.7.4",
-            "web3-utils": "1.7.4"
-          }
-        },
-        "web3-eth-abi": {
-          "version": "1.7.4",
-          "integrity": "sha512-eMZr8zgTbqyL9MCTCAvb67RbVyN5ZX7DvA0jbLOqRWCiw+KlJKTGnymKO6jPE8n5yjk4w01e165Qb11hTDwHgg==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/abi": "^5.6.3",
-            "web3-utils": "1.7.4"
-          }
-        },
-        "web3-eth-accounts": {
-          "version": "1.7.4",
-          "integrity": "sha512-Y9vYLRKP7VU7Cgq6wG1jFaG2k3/eIuiTKAG8RAuQnb6Cd9k5BRqTm5uPIiSo0AP/u11jDomZ8j7+WEgkU9+Btw==",
-          "dev": true,
-          "requires": {
-            "@ethereumjs/common": "^2.5.0",
-            "@ethereumjs/tx": "^3.3.2",
-            "crypto-browserify": "3.12.0",
-            "eth-lib": "0.2.8",
-            "ethereumjs-util": "^7.0.10",
-            "scrypt-js": "^3.0.1",
-            "uuid": "3.3.2",
-            "web3-core": "1.7.4",
-            "web3-core-helpers": "1.7.4",
-            "web3-core-method": "1.7.4",
-            "web3-utils": "1.7.4"
           }
         },
         "web3-eth-contract": {
@@ -21940,6 +21749,7 @@
     },
     "antlr4ts": {
       "version": "0.5.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz",
       "integrity": "sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==",
       "dev": true
     },
@@ -22764,6 +22574,15 @@
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "chownr": {
@@ -22902,7 +22721,7 @@
       "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2",
+        "colors": "1.4.0",
         "object-assign": "^4.1.0",
         "string-width": "^2.1.1"
       }
@@ -23554,6 +23373,15 @@
           "version": "4.12.0",
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
+      }
+    },
+    "difflib": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
+      "integrity": "sha512-9YVwmMb0wQHQNr5J9m6BSj6fk4pfGITGQOOs+D9Fl+INODWFOfvhIU1hNv6GgR1RBoC/9NJcwu77zShxV0kT7w==",
+      "dev": true,
+      "requires": {
+        "heap": ">= 0.2.0"
       }
     },
     "dir-glob": {
@@ -24535,7 +24363,7 @@
       "dev": true,
       "requires": {
         "@ethersproject/abi": "^5.0.0-beta.146",
-        "@solidity-parser/parser": "^0.14.0",
+        "@solidity-parser/parser": "^0.15.0",
         "cli-table3": "^0.5.0",
         "colors": "1.4.0",
         "ethereum-cryptography": "^1.0.3",
@@ -24756,7 +24584,7 @@
             "which": "1.3.1",
             "wide-align": "1.1.3",
             "yargs": "13.3.2",
-            "yargs-parser": "13.1.2",
+            "yargs-parser": "5.0.1",
             "yargs-unparser": "1.6.0"
           }
         },
@@ -24888,7 +24716,7 @@
             "string-width": "^3.0.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.2"
+            "yargs-parser": "5.0.1"
           }
         },
         "yargs-unparser": {
@@ -25492,6 +25320,13 @@
     "fs.realpath": {
       "version": "1.0.0",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -26226,6 +26061,12 @@
         "no-case": "^2.2.0",
         "upper-case": "^1.1.3"
       }
+    },
+    "heap": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
+      "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==",
+      "dev": true
     },
     "help-me": {
       "version": "4.1.0",
@@ -28443,7 +28284,7 @@
       "integrity": "sha512-6JlV5BBTWzmDSq4kZ9PTXc3eLOX7DF5HpbqmmaF+kloyUwOZbJ12hIYsUaZh2fVgZdV2t0vWcvY6qhILhlzgqg==",
       "dev": true,
       "requires": {
-        "@solidity-parser/parser": "^0.14.3",
+        "@solidity-parser/parser": "^0.15.0",
         "emoji-regex": "^10.1.0",
         "escape-string-regexp": "^4.0.0",
         "semver": "^7.3.7",
@@ -29861,7 +29702,7 @@
             "which-module": "^1.0.0",
             "window-size": "^0.2.0",
             "y18n": "^3.2.1",
-            "yargs-parser": "^2.4.1"
+            "yargs-parser": "5.0.1"
           }
         }
       }
@@ -29877,30 +29718,120 @@
       "dev": true
     },
     "solidity-coverage": {
-      "version": "0.7.22",
-      "integrity": "sha512-I6Zd5tsFY+gmj1FDIp6w7OrUePx6ZpMgKQZg7dWgPaQHePLi3Jk+iJ8lwZxsWEoNy2Lcv91rMxATWHqRaFdQpw==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.2.tgz",
+      "integrity": "sha512-cv2bWb7lOXPE9/SSleDO6czkFiMHgP4NXPj+iW9W7iEKLBk7Cj0AGBiNmGX3V1totl9wjPrT0gHmABZKZt65rQ==",
       "dev": true,
       "requires": {
-        "@solidity-parser/parser": "^0.14.0",
-        "@truffle/provider": "^0.2.24",
+        "@ethersproject/abi": "^5.0.9",
+        "@solidity-parser/parser": "^0.15.0",
         "chalk": "^2.4.2",
         "death": "^1.1.0",
         "detect-port": "^1.3.0",
+        "difflib": "^0.2.4",
         "fs-extra": "^8.1.0",
         "ghost-testrpc": "^0.0.2",
         "global-modules": "^2.0.0",
         "globby": "^10.0.1",
         "jsonschema": "^1.2.4",
         "lodash": "^4.17.15",
+        "mocha": "7.1.2",
         "node-emoji": "^1.10.0",
         "pify": "^4.0.1",
         "recursive-readdir": "^2.2.2",
         "sc-istanbul": "^0.4.5",
         "semver": "^7.3.4",
         "shelljs": "^0.8.3",
-        "web3-utils": "^1.3.0"
+        "web3-utils": "^1.3.6"
       },
       "dependencies": {
+        "ansi-colors": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+          "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+          "dev": true
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "chokidar": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+          "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+          "dev": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.1",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.2.0"
+          }
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "flat": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+          "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
+          "dev": true,
+          "requires": {
+            "is-buffer": "~2.0.3"
+          }
+        },
         "fs-extra": {
           "version": "8.1.0",
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
@@ -29909,6 +29840,20 @@
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globby": {
@@ -29931,12 +29876,41 @@
           "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
           "dev": true
         },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
         "jsonfile": {
           "version": "4.0.0",
           "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+          "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2"
           }
         },
         "lru-cache": {
@@ -29947,6 +29921,107 @@
             "yallist": "^4.0.0"
           }
         },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "mocha": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
+          "integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "3.2.3",
+            "browser-stdout": "1.3.1",
+            "chokidar": "3.3.0",
+            "debug": "3.2.6",
+            "diff": "3.5.0",
+            "escape-string-regexp": "1.0.5",
+            "find-up": "3.0.0",
+            "glob": "7.1.3",
+            "growl": "1.10.5",
+            "he": "1.2.0",
+            "js-yaml": "3.13.1",
+            "log-symbols": "3.0.0",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.5",
+            "ms": "2.1.1",
+            "node-environment-flags": "1.0.6",
+            "object.assign": "4.1.0",
+            "strip-json-comments": "2.0.1",
+            "supports-color": "6.0.0",
+            "which": "1.3.1",
+            "wide-align": "1.1.3",
+            "yargs": "13.3.2",
+            "yargs-parser": "5.0.1",
+            "yargs-unparser": "1.6.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "object.assign": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+          "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "object-keys": "^1.0.11"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+          "dev": true
+        },
+        "readdirp": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+          "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+          "dev": true,
+          "requires": {
+            "picomatch": "^2.0.4"
+          }
+        },
         "semver": {
           "version": "7.3.8",
           "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
@@ -29955,15 +30030,105 @@
             "lru-cache": "^6.0.0"
           }
         },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
         "universalify": {
           "version": "0.1.2",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
           "dev": true
         },
         "yallist": {
           "version": "4.0.0",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "5.0.1"
+          }
+        },
+        "yargs-unparser": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+          "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+          "dev": true,
+          "requires": {
+            "flat": "^4.1.0",
+            "lodash": "^4.17.15",
+            "yargs": "^13.3.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "prettier-plugin-solidity": "^1.0.0-beta.10",
     "queue": "^6.0.2",
     "reconnecting-websocket": "^4.4.0",
-    "solidity-coverage": "^0.7.22",
+    "solidity-coverage": "^0.8.2",
     "terser": "^5.14.2",
     "ts-node": "^10.9.1",
     "typechain": "^8.1.0",
@@ -140,6 +140,8 @@
     "got": "11.8.5",
     "yargs-parser": "5.0.1",
     "colors": "$colors",
-    "hardhat": "$hardhat"
+    "hardhat": "$hardhat",
+    "solidity-coverage": "^0.8.2",
+    "@solidity-parser/parser": "^0.15.0"
   }
 }


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
- Exclude `Migrations.sol` from Solidity code coverage measurements
- Exclude `mocks` directory from Solidity code coverage measurements 
- Include `Poseidon.sol` and `MerkleTree_Stateless.sol` in Solidity code coverage measurements 
(enabled by updating `solidity-coverage` and `@solidity-parser/parser`)

## Does this close any currently open issues?
Nope

## What commands can I run to test the change? 
`npm ci`
`npx hardhat clean && npx hardhat coverage`
all unit test should run successfully and Solidity code coverage metrics should be printed (and exported to file)

## Any other comments?
Nope
