### PR TITLE
Fix: update GitHub action and remove deprecation warnings about node v12

### DIFF
--- a/.github/workflows/on-pull-request-master.yml
+++ b/.github/workflows/on-pull-request-master.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
       - name: Install Circom
@@ -318,7 +318,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
 
@@ -375,7 +375,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
 
@@ -432,7 +432,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
 
@@ -489,7 +489,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
 
@@ -716,7 +716,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
 
@@ -780,7 +780,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
 
@@ -995,7 +995,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.17.0'
 

--- a/.github/workflows/on-pull-request-master.yml
+++ b/.github/workflows/on-pull-request-master.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   DOCKER_BUILDKIT: 1 # enable docker buildkit
-# Whitelisting is disabled during testing for backwards compatibility with these tests.  It must not be disabled in production.
+  # Whitelisting is disabled during testing for backwards compatibility with these tests.  It must not be disabled in production.
   WHITELISTING: disable
 
 jobs:
@@ -125,7 +125,7 @@ jobs:
           ./bin/start-nightfall -g -d &> authentication-test.log &disown
 
       - name: Wait for images to be ready
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             docker wait nightfall_3_deployer_1
@@ -224,7 +224,7 @@ jobs:
           ./bin/start-nightfall -g -d &> circuit-test.log &disown
 
       - name: Wait for images to be ready
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             docker wait nightfall_3_deployer_1
@@ -281,7 +281,7 @@ jobs:
           ./bin/start-nightfall -g -d &> ganache-test.log &disown
 
       - name: Wait for images to be ready
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             docker wait nightfall_3_deployer_1
@@ -338,7 +338,7 @@ jobs:
           ./bin/start-nightfall -g -d &> ganache-test.log &disown
 
       - name: Wait for images to be ready
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             docker wait nightfall_3_deployer_1
@@ -395,7 +395,7 @@ jobs:
           ./bin/start-nightfall -g -d &> ganache-test.log &disown
 
       - name: Wait for images to be ready
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             docker wait nightfall_3_deployer_1
@@ -452,7 +452,7 @@ jobs:
           ./bin/start-nightfall -g -d &> ganache-test.log &disown
 
       - name: Wait for images to be ready
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             docker wait nightfall_3_deployer_1
@@ -510,7 +510,7 @@ jobs:
           ./bin/start-nightfall -g -d &> ganache-test.log &disown
 
       - name: Wait for images to be ready
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             docker wait nightfall_3_deployer_1
@@ -567,7 +567,7 @@ jobs:
           ./bin/start-nightfall -g -d &> x509-test.log &disown
 
       - name: Wait for images to be ready
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             docker wait nightfall_3_deployer_1
@@ -623,7 +623,7 @@ jobs:
           ./bin/start-nightfall -g -d &> administrator-test.log &disown
 
       - name: Wait for images to be ready
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             docker wait nightfall_3_deployer_1
@@ -680,7 +680,7 @@ jobs:
           ./bin/start-nightfall -g -d &> optimist-sync-test.log &disown
 
       - name: Wait for images to be ready
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             docker wait nightfall_3_deployer_1
@@ -742,7 +742,7 @@ jobs:
           ./bin/start-nightfall -g -d -a &> adversary-test.log &disown
 
       - name: Wait for images to be ready
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             docker wait nightfall_3_deployer_1
@@ -806,7 +806,7 @@ jobs:
           ./bin/start-multiproposer-test-env -g &> ping-pong-test.log &disown
 
       - name: Wait for images to be ready
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             docker wait nightfall_3_deployer_1
@@ -818,7 +818,7 @@ jobs:
         run: cat ping-pong-test.log
 
       - name: 'Check client1 liveliness'
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             curl -i http://localhost:8083/healthcheck
@@ -826,7 +826,7 @@ jobs:
           attempt_delay: 30000
 
       - name: 'Check client2 liveliness'
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             curl -i http://localhost:8086/healthcheck
@@ -884,7 +884,7 @@ jobs:
           ./bin/start-nightfall -g -d &> test-gas.log &disown
 
       - name: Wait for images to be ready
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             docker wait nightfall_3_deployer_1
@@ -941,7 +941,7 @@ jobs:
           ./bin/start-nightfall -g -d &> test-apps.log &disown
 
       - name: Wait for images to be ready
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             docker wait nightfall_3_deployer_1
@@ -958,7 +958,7 @@ jobs:
 
       - name: 'Check proposer liveliness'
 
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             curl -i http://localhost:8092/healthcheck
@@ -966,7 +966,7 @@ jobs:
           attempt_delay: 30000
 
       - name: 'Check challenger liveliness'
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             curl -i http://localhost:8192/healthcheck
@@ -1015,7 +1015,7 @@ jobs:
           ./bin/start-nightfall -g -d &> periodic-payment-test.log &disown
 
       - name: Wait for images to be ready
-        uses: Wandalen/wretry.action@v1.0.11
+        uses: Wandalen/wretry.action@v1.0.36
         with:
           command: |
             docker wait nightfall_3_deployer_1

--- a/.github/workflows/on-pull-request-master.yml
+++ b/.github/workflows/on-pull-request-master.yml
@@ -654,7 +654,7 @@ jobs:
           path: ./administrator-test.log
 
   optimist-sync-test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     env:
       CONFIRMATIONS: 1
       NF_SERVICES_TO_START: blockchain,client,deployer,mongodb,optimist,rabbitmq,worker


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

As per GitHub announcement from September 22, 2022, [GitHub Actions: All Actions will begin running on Node16 instead of Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). This PR updates outdated action to the latest version, that runs on top of node.js v16 and removes deprecation warning.

<img width="1624" alt="Screenshot 2023-02-23 at 20 29 07" src="https://user-images.githubusercontent.com/3697104/221023309-2c61ea5f-5554-4082-9e9c-24f3d188a85f.png">
