### PR TITLE
fix: fixing unrestricted deposits

### DIFF
--- a/nightfall-deployer/migrations/2_deploy_upgradeable.js
+++ b/nightfall-deployer/migrations/2_deploy_upgradeable.js
@@ -101,7 +101,7 @@ module.exports = async function (deployer) {
 
     console.log(
       `Max allowed deposit value for ${token.name}: ${(
-        BigInt(token.amount) / BigInt(4)
+        BigInt(token.amount) < BigInt(0) ? token.amount : (BigInt(token.amount) / BigInt(4)).toString(),
       ).toString()}`,
     ); // BigInt division returns whole number which is a floor. Not Math.floor() needed
 

--- a/nightfall-deployer/migrations/2_deploy_upgradeable.js
+++ b/nightfall-deployer/migrations/2_deploy_upgradeable.js
@@ -101,7 +101,7 @@ module.exports = async function (deployer) {
 
     console.log(
       `Max allowed deposit value for ${token.name}: ${(
-        BigInt(token.amount) < BigInt(0) ? token.amount : (BigInt(token.amount) / BigInt(4)).toString(),
+        BigInt(token.amount) < BigInt(0) ? token.amount : (BigInt(token.amount) / BigInt(4)).toString()
       ).toString()}`,
     ); // BigInt division returns whole number which is a floor. Not Math.floor() needed
 

--- a/nightfall-deployer/migrations/2_deploy_upgradeable.js
+++ b/nightfall-deployer/migrations/2_deploy_upgradeable.js
@@ -108,7 +108,7 @@ module.exports = async function (deployer) {
     console.log(`Max allowed withdraw value for ${token.name}: ${token.amount}`);
     await shield.setRestriction(
       token.address,
-      (BigInt(token.amount) / BigInt(4)).toString(),
+      BigInt(token.amount) < BigInt(0) ? BigInt(token.amount) : (BigInt(token.amount) / BigInt(4)).toString(),
       token.amount,
     );
   }

--- a/nightfall-deployer/migrations/2_deploy_upgradeable.js
+++ b/nightfall-deployer/migrations/2_deploy_upgradeable.js
@@ -108,7 +108,7 @@ module.exports = async function (deployer) {
     console.log(`Max allowed withdraw value for ${token.name}: ${token.amount}`);
     await shield.setRestriction(
       token.address,
-      BigInt(token.amount) < BigInt(0) ? BigInt(token.amount) : (BigInt(token.amount) / BigInt(4)).toString(),
+      BigInt(token.amount) < BigInt(0) ? token.amount : (BigInt(token.amount) / BigInt(4)).toString(),
       token.amount,
     );
   }

--- a/nightfall-deployer/migrations/3_test_tokens_migration.js
+++ b/nightfall-deployer/migrations/3_test_tokens_migration.js
@@ -42,9 +42,9 @@ module.exports = function (deployer, _, accounts) {
         el => el.name === 'ERC20Mock',
       );
       await shield.setRestriction(
-        token.address,
-        BigInt(token.amount) < BigInt(0) ? BigInt(token.amount) : (BigInt(token.amount) / BigInt(4)).toString(),
-        token.amount,
+        ERC20Mock.address,
+        BigInt(erc20Mock.amount) < BigInt(0) ? BigInt(erc20Mock.amount) : (BigInt(erc20Mock.amount) / BigInt(4)).toString(),
+        erc20Mock.amount,
       );
     } catch (err) {
       console.warn(

--- a/nightfall-deployer/migrations/3_test_tokens_migration.js
+++ b/nightfall-deployer/migrations/3_test_tokens_migration.js
@@ -42,9 +42,9 @@ module.exports = function (deployer, _, accounts) {
         el => el.name === 'ERC20Mock',
       );
       await shield.setRestriction(
-        ERC20Mock.address,
-        (BigInt(erc20Mock.amount) / BigInt(4)).toString(),
-        erc20Mock.amount,
+        token.address,
+        BigInt(token.amount) < BigInt(0) ? BigInt(token.amount) : (BigInt(token.amount) / BigInt(4)).toString(),
+        token.amount,
       );
     } catch (err) {
       console.warn(

--- a/nightfall-deployer/migrations/3_test_tokens_migration.js
+++ b/nightfall-deployer/migrations/3_test_tokens_migration.js
@@ -43,7 +43,7 @@ module.exports = function (deployer, _, accounts) {
       );
       await shield.setRestriction(
         ERC20Mock.address,
-        BigInt(erc20Mock.amount) < BigInt(0) ? BigInt(erc20Mock.amount) : (BigInt(erc20Mock.amount) / BigInt(4)).toString(),
+        BigInt(erc20Mock.amount) < BigInt(0) ? erc20Mock.amount : (BigInt(erc20Mock.amount) / BigInt(4)).toString(),
         erc20Mock.amount,
       );
     } catch (err) {


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
To remove restrictions on deposits and withdrawals, we typically set a value of `-1` on the restriction amount (it needs to be negative). However, since we divide the restricted amount by 4, the result is a `0` effectively preventing any deposit. 

## Does this close any currently open issues?
No

## What commands can I run to test the change? 

## Any other comments?

