### PR TITLE
feat: allow serial circuit setup

### DIFF
--- a/nightfall-deployer/entrypoint.sh
+++ b/nightfall-deployer/entrypoint.sh
@@ -7,4 +7,17 @@ if [ -z "${ETH_PRIVATE_KEY}" ]; then
   while ! nc -z ${BLOCKCHAIN_WS_HOST} ${BLOCKCHAIN_PORT}; do sleep 3; done
 fi
 
+if [[ "${SKIP_DEPLOYMENT}" != "true" && "${PARALLEL_SETUP}" == "true" ]]; then
+  npx truffle compile --all
+
+  if [ -z "${UPGRADE}" ]; then
+    echo "Deploying contracts to ${ETH_NETWORK}"
+    npx truffle migrate --to 3 --network=${ETH_NETWORK}
+    echo 'Done'
+  else
+    echo 'Upgrading contracts'
+    npx truffle migrate -f 4 --network=${ETH_NETWORK} --skip-dry-run
+  fi
+fi
+
 npm start

--- a/nightfall-deployer/entrypoint.sh
+++ b/nightfall-deployer/entrypoint.sh
@@ -7,7 +7,8 @@ if [ -z "${ETH_PRIVATE_KEY}" ]; then
   while ! nc -z ${BLOCKCHAIN_WS_HOST} ${BLOCKCHAIN_PORT}; do sleep 3; done
 fi
 
-if [[ "${SKIP_DEPLOYMENT}" != "true" && "${PARALLEL_SETUP}" == "true" ]]; then
+if [[ "${SKIP_DEPLOYMENT}" != "true" && "${PARALLEL_SETUP}" == "false" ]]; then
+  echo "PARALLEL SETUP DISABLED...."
   npx truffle compile --all
 
   if [ -z "${UPGRADE}" ]; then

--- a/nightfall-deployer/src/index.mjs
+++ b/nightfall-deployer/src/index.mjs
@@ -74,7 +74,8 @@ async function main() {
   if (PARALLEL_SETUP === 'true') {
     await bootstrap();
   } else {
-    await setupCircuits();
+    await circuits.waitForWorker();
+    await circuits.setupCircuits();
     await safeSetupContracts();
   }
   try {

--- a/nightfall-deployer/src/index.mjs
+++ b/nightfall-deployer/src/index.mjs
@@ -7,7 +7,7 @@ import setupContracts from './contract-setup.mjs';
 
 const execPromise = promisify(child.exec);
 
-const { SKIP_DEPLOYMENT, UPGRADE = '', ETH_NETWORK } = process.env;
+const { SKIP_DEPLOYMENT, UPGRADE = '', ETH_NETWORK, PARALLEL_SETUP = 'true' } = process.env;
 
 async function execShellCommand(cmd) {
   const shellPromise = execPromise(cmd);
@@ -71,7 +71,12 @@ async function bootstrap() {
 
 async function main() {
   logger.info(`deployer starting bootstrap`);
-  await bootstrap();
+  if (PARALLEL_SETUP === 'true') {
+    await bootstrap();
+  } else {
+    await setupCircuits();
+    await safeSetupContracts();
+  }
   try {
     Web3.disconnect();
   } catch (err) {


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Im having some issues with the parallelization of deployment of circuits and contracts. It fails about 50% of the time when it never failed earlier. So, im allowing for an option to go to the old way. Default deployment is parallel. If you want serial deployment, define env `PARALLEL_SETUP=false`

As a side note, parallel deployment did not include the address of the deployed erc20 Mock token in the generated metadata

## Does this close any currently open issues?
No

## What commands can I run to test the change? 

## Any other comments?

