### PR TITLE
fix: add salt to challenge

### DIFF
--- a/nightfall-deployer/contracts/Challenges.sol
+++ b/nightfall-deployer/contracts/Challenges.sol
@@ -357,7 +357,10 @@ contract Challenges is Stateful, Config {
         challengeAccepted(transaction.blockL2);
     }
 
-    function challengeHistoricRootBlockNumber(TransactionInfoBlock calldata transaction) external {
+    function challengeHistoricRootBlockNumber(
+        TransactionInfoBlock calldata transaction,
+        bytes32 salt
+    ) external {
         checkCommit(msg.data);
         state.areBlockAndTransactionReal(
             transaction.blockL2,

--- a/nightfall-optimist/src/services/challenges.mjs
+++ b/nightfall-optimist/src/services/challenges.mjs
@@ -319,12 +319,15 @@ export async function createChallenge(block, transactions, err) {
       }
 
       txDataToSign = await challengeContractInstance.methods
-        .challengeHistoricRootBlockNumber({
-          blockL2: Block.buildSolidityStruct(block),
-          transaction: Transaction.buildSolidityStruct(transactions[transactionIndex]),
-          transactionIndex,
-          transactionSiblingPath,
-        })
+        .challengeHistoricRootBlockNumber(
+          {
+            blockL2: Block.buildSolidityStruct(block),
+            transaction: Transaction.buildSolidityStruct(transactions[transactionIndex]),
+            transactionIndex,
+            transactionSiblingPath,
+          },
+          salt,
+        )
         .encodeABI();
       break;
     }

--- a/test/adversary.test.mjs
+++ b/test/adversary.test.mjs
@@ -49,7 +49,7 @@ const eventLogs = [];
 const challengeSelectors = {
   challengeRoot: '0x25009307',
   challengeCommitment: '0x1c80a5a5',
-  challengeHistoricRoot: '0xf0b86f27',
+  challengeHistoricRoot: '0x2a0f8b42',
   challengeLeafCount: '0xb8424d42',
   challengeFrontier: '0x60f611d5',
   challengeNullifier: '0xda5370ca',

--- a/test/unit/SmartContracts/challenges.unit.test.mjs
+++ b/test/unit/SmartContracts/challenges.unit.test.mjs
@@ -593,13 +593,17 @@ describe('Challenges contract Challenges functions', function () {
       transactionIndex: 0,
       transactionSiblingPath: siblingPath,
     };
+    const salt = '0x06032a0304000000000000000000000000000000000000000000000000000000';
     // eslint-disable-next-line prefer-destructuring
     const data = (
-      await challenges.populateTransaction.challengeHistoricRootBlockNumber(TransactionInfoBlock)
+      await challenges.populateTransaction.challengeHistoricRootBlockNumber(
+        TransactionInfoBlock,
+        salt,
+      )
     ).data;
     const hashedData = ethers.utils.solidityKeccak256(['bytes'], [data]);
     await challenges.commitToChallenge(hashedData);
-    const tx = await challenges.challengeHistoricRootBlockNumber(TransactionInfoBlock);
+    const tx = await challenges.challengeHistoricRootBlockNumber(TransactionInfoBlock, salt);
 
     const receipt = await tx.wait();
 
@@ -681,14 +685,18 @@ describe('Challenges contract Challenges functions', function () {
       transactionIndex: 0,
       transactionSiblingPath: siblingPath,
     };
+    const salt = '0x06032a0304000000000000000000000000000000000000000000000000000000';
     // eslint-disable-next-line prefer-destructuring
     const data = (
-      await challenges.populateTransaction.challengeHistoricRootBlockNumber(TransactionInfoBlock)
+      await challenges.populateTransaction.challengeHistoricRootBlockNumber(
+        TransactionInfoBlock,
+        salt,
+      )
     ).data;
     const hashedData = ethers.utils.solidityKeccak256(['bytes'], [data]);
     await challenges.commitToChallenge(hashedData);
     await expect(
-      challenges.challengeHistoricRootBlockNumber(TransactionInfoBlock),
+      challenges.challengeHistoricRootBlockNumber(TransactionInfoBlock, salt),
     ).to.be.rejectedWith('Historic roots are not greater than L2BlockNumber on chain');
   });
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

This is a bug fix.  The 'historic root block number not correct' challenge is not salted.  This means that if the challenge commitment is front-run, the original challenger would be locked out from sending a new commitment because they could not generate a new commit hash by changing their salt.

## Does this close any currently open issues?

No

## What commands can I run to test the change? 

There is no change to the standard tests.

## Any other comments?

