### PR TITLE
fix: do not throw if a proposer fails to respond

### DIFF
--- a/nightfall-client/src/utils/submitTransaction.mjs
+++ b/nightfall-client/src/utils/submitTransaction.mjs
@@ -49,7 +49,7 @@ export const submitTransaction = async (
     }
 
     logger.debug({ msg: 'Peer List', peerList });
-    await Promise.all(
+    await Promise.any(
       Object.keys(peerList).map(async address => {
         logger.debug(
           `offchain transaction - calling ${peerList[address]}/proposer/offchain-transaction`,


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Currently, when we submit transactions directly, we send the transaction to all proposers and await for them all to respond. It's good to send the transaction to all proposers to maximise the probability of it being incorporated into a block quickly.  However the `Promise.all` construction means that if any of these requests fail (perhaps a proposer was unreachable) then the whole submission process throws, and that may mean, depending on when the promise rejects, that fewer proposers receive our transaction or, in the worst case, none of them receive it, even if only one proposer was down.

We can fix that by using `Promise.any` this will make the await resolve as soon as one of the proposers receives the transaction.  At that point we can continue on, others may also receive the transaction, and it's good if they do, but we don't have to wait for that to happen.

## What commands can I run to test the change? 

Normal tests suffice

## Any other comments?

