### PR TITLE
fix: fix loop index in transform circuit

### DIFF
--- a/nightfall-deployer/circuits/transform.circom
+++ b/nightfall-deployer/circuits/transform.circom
@@ -105,7 +105,7 @@ template Transform(N,C) {
       nullifierValueBits[252] === 0;
     }
     for (var i = 0; i < C; i++) {
-      var commitmentValueBits[254] = Num2Bits(254)(commitmentsValues[0]);
+      var commitmentValueBits[254] = Num2Bits(254)(commitmentsValues[i]);
       commitmentValueBits[253] === 0;
       commitmentValueBits[252] === 0;
     }


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

The part fixed in the transform circuit checks that the commitment values do not overflow. The fix replaces commitmentsValues[0] by commitmentsValues[i] in line 108. As this is input in a loop, it make sense that the commitment values should be checked for every iteration. 

## Does this close any currently open issues?

## What commands can I run to test the change? 
npm t


## Any other comments?

