### PR TITLE
(nightfall-client) removes res.json for error case

### DIFF
--- a/nightfall-client/src/routes/burn.mjs
+++ b/nightfall-client/src/routes/burn.mjs
@@ -9,7 +9,6 @@ router.post('/', async (req, res, next) => {
     // convert commitment from GN to hex form for transmission
     res.json({ txDataToSign, transaction });
   } catch (err) {
-    res.json({ error: err.message });
     next(err);
   }
 });

--- a/nightfall-client/src/routes/deposit.mjs
+++ b/nightfall-client/src/routes/deposit.mjs
@@ -14,7 +14,6 @@ router.post('/', async (req, res, next) => {
     // convert commitment from GN to hex form for transmission
     res.json({ txDataToSign, transaction });
   } catch (err) {
-    res.json({ error: err.message });
     next(err);
   }
 });

--- a/nightfall-client/src/routes/tokenise.mjs
+++ b/nightfall-client/src/routes/tokenise.mjs
@@ -9,7 +9,6 @@ router.post('/', async (req, res, next) => {
     // convert commitment from GN to hex form for transmission
     res.json({ txDataToSign, transaction });
   } catch (err) {
-    res.json({ error: err.message });
     next(err);
   }
 });

--- a/nightfall-client/src/routes/transfer.mjs
+++ b/nightfall-client/src/routes/transfer.mjs
@@ -11,7 +11,6 @@ router.post('/', async (req, res, next) => {
     const { rawTransaction: txDataToSign, transaction } = await transfer(req.body);
     res.json({ txDataToSign, transaction });
   } catch (err) {
-    res.json({ error: err.message });
     next(err);
   }
 });

--- a/nightfall-client/src/routes/withdraw.mjs
+++ b/nightfall-client/src/routes/withdraw.mjs
@@ -11,7 +11,6 @@ router.post('/', async (req, res, next) => {
     const { rawTransaction: txDataToSign, transaction } = await withdraw(req.body);
     res.json({ txDataToSign, transaction });
   } catch (err) {
-    res.json({ error: err.message });
     next(err);
   }
 });

--- a/test/e2e/tokens/erc1155.test.mjs
+++ b/test/e2e/tokens/erc1155.test.mjs
@@ -307,7 +307,7 @@ describe('ERC1155 tests', () => {
           [],
         );
       } catch (err) {
-        expect(err.message).to.be.equal('provided commitments do not cover the value');
+        expect(err.response.data).to.be.equal('provided commitments do not cover the value');
       }
     });
 
@@ -334,7 +334,7 @@ describe('ERC1155 tests', () => {
           [erc20Commitments[0].commitmentHash],
         );
       } catch (err) {
-        expect(err.message).to.be.equal('provided commitments do not cover the fee');
+        expect(err.response.data).to.be.equal('provided commitments do not cover the fee');
       }
     });
   });

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -135,7 +135,9 @@ describe('ERC20 tests', () => {
         await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, fee, [], salt);
         expect.fail('Throw error, deposit did not fail');
       } catch (err) {
-        expect(err.message).to.include('You can not re-send a commitment that is already on-chain');
+        expect(err.response.data).to.include(
+          'You can not re-send a commitment that is already on-chain',
+        );
       }
     });
 
@@ -144,7 +146,7 @@ describe('ERC20 tests', () => {
         await nf3User.deposit(erc20Address, tokenType, transferValue, tokenId, transferValue);
         expect.fail('Throw error, deposit did not fail');
       } catch (err) {
-        expect(err.message).to.include('Value deposited needs to be greater than the fee');
+        expect(err.response.data).to.include('Value deposited needs to be greater than the fee');
       }
     });
   });
@@ -308,7 +310,7 @@ describe('ERC20 tests', () => {
           usedCommitments,
         );
       } catch (err) {
-        expect(err.message).to.be.equal('provided commitments do not cover the value');
+        expect(err.response.data).to.be.equal('provided commitments do not cover the value');
       }
     });
   });

--- a/test/e2e/tokens/erc721.test.mjs
+++ b/test/e2e/tokens/erc721.test.mjs
@@ -352,7 +352,7 @@ describe('ERC721 tests', () => {
         );
         expectTransaction(res);
       } catch (err) {
-        expect(err.message).to.be.equal('provided commitments do not cover the fee');
+        expect(err.response.data).to.be.equal('provided commitments do not cover the fee');
       }
     });
 
@@ -377,7 +377,9 @@ describe('ERC721 tests', () => {
         );
         expectTransaction(res);
       } catch (err) {
-        expect(err.message).to.include('Some of the commitments provided for the fee were invalid');
+        expect(err.response.data).to.include(
+          'Some of the commitments provided for the fee were invalid',
+        );
       }
     });
   });


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
This PR do a small refactor nightfall-client api routes.
some routes were explicitly doing response send via res.json event though error object is passed to common error handler middleware in `common-files/utils/httputils.mjs` file.
which will cause error such as response is already send, also sever logic written in common error handler would not have worked for these APIs


