### PR TITLE
save transaction only if it hasn't been proposed previously

### DIFF
--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -290,8 +290,9 @@ export async function saveTransaction(_transaction) {
 
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
-  const query = { transactionHash: transaction.transactionHash };
-  const update = { $set: transaction };
+  // ensure that the update will never modify a transaction that has already been proposed
+  const query = { transactionHash: transaction.transactionHash, mempool: false };
+  const update = { $setOnInsert: transaction };
 
   return db.collection(TRANSACTIONS_COLLECTION).updateOne(query, update, { upsert: true });
 }

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -291,13 +291,9 @@ export async function saveTransaction(_transaction) {
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
   const query = { transactionHash: transaction.transactionHash };
-  const update = { $setOnInsert: transaction };
+  const update = { $set: transaction };
 
-  await db.collection(TRANSACTIONS_COLLECTION).updateOne(query, update, { upsert: true });
-  await new Promise(resolve => setTimeout(() => resolve(), 100));
-  return db
-    .collection(TRANSACTIONS_COLLECTION)
-    .updateOne({ transactionHash: transaction.transactionHash, blockNumberL2: -1 }, update);
+  return db.collection(TRANSACTIONS_COLLECTION).updateOne(query, update, { upsert: true });
 }
 
 /**

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -278,8 +278,6 @@ export async function saveTransaction(_transaction) {
   const transaction = {
     _id: _transaction.transactionHash,
     ..._transaction,
-    mempool,
-    blockNumberL2,
   };
 
   logger.debug({
@@ -292,7 +290,7 @@ export async function saveTransaction(_transaction) {
   const db = connection.db(OPTIMIST_DB);
   // ensure that the update will never modify a transaction that has already been proposed
   const query = { transactionHash: transaction.transactionHash, mempool: false };
-  const update = { $setOnInsert: transaction };
+  const update = { $set: transaction, $setOnInsert: { mempool, blockNumberL2 } };
 
   return db.collection(TRANSACTIONS_COLLECTION).updateOne(query, update, { upsert: true });
 }


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Optimist's `blockProposedEventHandler` writes transactions to dB without any check. There is at least one example why this is incorrect. If a bad client sends a duplicated transaction, this transaction may overwrite a previous transaction  from a correct block, and a duplicated commitment will not be found anymore.

An example of this issue can be seen in optimist resync test (attached some log file with a summary of these events)
[sync-test.txt](https://github.com/EYBlockchain/nightfall_3/files/11283624/sync-test.txt)
, where in the last subtest, a bad client/proposer submits a block including a duplicated transaction from the previous block. It can be seen that the optimist detects an incorrect block due to an incorrect frontier (i imagine that the bad proposer did not bother to make one correct). However, optimist overwrites the previously proposed transaction in the db, it proposes it again later in a different block with a correct frontier, and optimist cannot detect duplicated commitment because the original transaction was overwritten and therefore there is no duplicate found.

The idea is to store only those transactions that have not been successfully proposed earlier. For that, `storeTransaction` should check that successfully transactions are not overwritten. I am not too happy with the implementation suggested in this PR, as I hope it can be done in a single operation. However, i could only work out a two step operation:
1. Only insert new transactions.
2. Only update transactions with blockNumberL2 = -1

Alternatively, a different solution could be to have the optimist check for duplicated commitments from blocks rather than from transactions in dB, but this change is too advanced for me and i may be missing something in my analysis. For now, i am happy to show that there is a problem and the root cause is understood. Correct solution can come later
## Does this close any currently open issues?

## What commands can I run to test the change? 

## Any other comments?

