### PR TITLE
fix transaction save

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,7 @@ mumbai/
 cli/build/*
 wallet/cli/*
 mumbai/
+polygonpos/
 wallet/src/components/Assets/
 test/adversary/lazy-optimist/*
 test/adversary/adversary-cli/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ mumbai/
 .openzeppelin/
 *.log
 mumbai/
+polygonpos/
 # wallet
 wallet/build
 wallet/cli

--- a/nightfall-client/src/services/database.mjs
+++ b/nightfall-client/src/services/database.mjs
@@ -195,18 +195,30 @@ Transaction Collection
 */
 
 /**
-Function to save a (unprocessed) Transaction
-*/
+ * Save an unprocessed transaction
+ */
 export async function saveTransaction(_transaction) {
+  const { mempool = true, blockNumberL2 = -1 } = _transaction;
   const transaction = {
     _id: _transaction.transactionHash,
     ..._transaction,
+    mempool,
+    blockNumberL2,
   };
+  logger.debug({
+    msg: 'Saving transaction',
+    transactionHash: _transaction.transactionHash,
+    blockNumber: _transaction.blockNumber,
+  });
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(COMMITMENTS_DB);
-  const query = { transactionHash: transaction.transactionHash };
-  const update = { $set: transaction };
-  return db.collection(TRANSACTIONS_COLLECTION).updateOne(query, update, { upsert: true });
+  return db.collection(TRANSACTIONS_COLLECTION).insertOne(transaction);
+}
+
+export async function updateTransaction(transactionHash, updates) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(COMMITMENTS_DB);
+  return db.collection(TRANSACTIONS_COLLECTION).updateOne({ transactionHash }, { $set: updates });
 }
 
 /*

--- a/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
+++ b/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
@@ -63,8 +63,15 @@ async function transactionSubmittedEventHandler(eventParams) {
       transactionCommitments,
       transactionNullifiers,
     );
-
-    await saveTransaction({ ...transaction });
+    try {
+      await saveTransaction({ ...transaction });
+    } catch (err) {
+      if (err.message.includes('E11000'))
+        logger.warn(
+          `Ignored submitted duplicate transaction. This is probably a resynchronisation artifact`,
+        );
+      else throw new Error(err);
+    }
   } catch (err) {
     if (err instanceof TransactionError) {
       logger.warn(

--- a/nightfall-optimist/src/services/database.mjs
+++ b/nightfall-optimist/src/services/database.mjs
@@ -281,19 +281,20 @@ export async function saveTransaction(_transaction) {
     mempool,
     blockNumberL2,
   };
-
   logger.debug({
-    msg: 'Saving transaction with layer 1 block number',
+    msg: 'Saving transaction',
     transactionHash: _transaction.transactionHash,
     blockNumber: _transaction.blockNumber,
   });
-
   const connection = await mongo.connection(MONGO_URL);
   const db = connection.db(OPTIMIST_DB);
-  const query = { transactionHash: transaction.transactionHash };
-  const update = { $set: transaction };
+  return db.collection(TRANSACTIONS_COLLECTION).insertOne(transaction);
+}
 
-  return db.collection(TRANSACTIONS_COLLECTION).updateOne(query, update, { upsert: true });
+export async function updateTransaction(transactionHash, updates) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(OPTIMIST_DB);
+  return db.collection(TRANSACTIONS_COLLECTION).updateOne({ transactionHash }, { $set: updates });
 }
 
 /**

--- a/test/adversary/transpile-optimist-adversary.mjs
+++ b/test/adversary/transpile-optimist-adversary.mjs
@@ -81,7 +81,7 @@ const transpileTransactionSubmitEventHandler = _pathToSrc => {
   // Remove transaction check from the optimist so that bad transactions can be added into a blocks
 
   const srcTxDataToSignPreamble = /(\n|.)*(?=await checkTransaction)/g;
-  const srcTxDataToSignPostamble = /await saveTransaction(\n|.)*/g;
+  const srcTxDataToSignPostamble = /\s*try\s*{\n\s+?await saveTransaction(\n|.)*/g;
   const [srcPre] = srcFile.match(srcTxDataToSignPreamble);
   const [srcPost] = srcFile.match(srcTxDataToSignPostamble);
   srcFile = `${srcPre}\n${srcPost}`;


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

When a duplicate transaction is received, it can, under certain circumstances, overwrite the earlier example of the duplicate in the database. This results in the duplicate transaction not being detected.

## Does this close any currently open issues?

No

## What commands can I run to test the change? 

Conventional `npm test` is fine. The logs of the optimist-resync test will now show a correct resync of block 7, which contains the last-created deposit transaction.  Previously it did not.

## Any other comments?

