### PR TITLE
Nightfall may fail to sync when the blockchain history is large

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -200,6 +200,8 @@ module.exports = {
       keepalive: true,
       // Keep keepalive interval small so that socket doesn't die
       keepaliveInterval: 1500,
+      maxReceivedFrameSize: 10000000000,
+      maxReceivedMessageSize: 10000000000,
     },
     timeout: 0,
     reconnect: {

--- a/nightfall-client/src/services/process-calldata.mjs
+++ b/nightfall-client/src/services/process-calldata.mjs
@@ -5,6 +5,7 @@ much cheaper, although the offchain part is more complex.
 */
 import config from 'config';
 import Web3 from 'common-files/utils/web3.mjs';
+import logger from 'common-files/utils/logger.mjs';
 import Transaction from 'common-files/classes/transaction.mjs';
 import { unpackBlockInfo } from 'common-files/utils/block-utils.mjs';
 
@@ -14,6 +15,12 @@ async function getProposeBlockCalldata(eventData) {
   const web3 = Web3.connection();
   const { transactionHash } = eventData;
   const tx = await web3.eth.getTransaction(transactionHash);
+  if (tx === null) {
+    logger.error(
+      'The transaction was null. This may be a problem with the blockchain node you are connected to. Make sure it indexes old transactions.  For a Geth node set --txlookuplimit 0',
+    );
+    throw new Error('transaction retrieved from calldata had null value');
+  }
   // Remove the '0x' and function signature to recove rhte abi bytecode
   const abiBytecode = `0x${tx.input.slice(10)}`;
   const decoded = web3.eth.abi.decodeParameters(SIGNATURES.PROPOSE_BLOCK, abiBytecode);

--- a/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
+++ b/nightfall-optimist/src/event-handlers/transaction-submitted.mjs
@@ -55,7 +55,7 @@ async function transactionSubmittedEventHandler(eventParams) {
       checkDuplicatesInL2: true,
       checkDuplicatesInMempool: true,
     });
-
+    logger.info({ msg: 'Transaction was valid' });
     const transactionCommitments = transaction.commitments.filter(c => c !== ZERO);
     const transactionNullifiers = transaction.nullifiers.filter(n => n !== ZERO);
 

--- a/nightfall-optimist/src/services/state-sync.mjs
+++ b/nightfall-optimist/src/services/state-sync.mjs
@@ -28,6 +28,9 @@ export async function syncState(
   toBlock = 'latest',
   eventFilter = 'allEvents',
 ) {
+  logger.info({ msg: 'SyncState parameters', fromBlock, toBlock, eventFilter });
+  logger.info({ msg: 'Assembling ordered list of past events' });
+
   const proposersContractInstance = await getContractInstance(PROPOSERS_CONTRACT_NAME); // NewCurrentProposer (register)
   const shieldContractInstance = await getContractInstance(SHIELD_CONTRACT_NAME); // TransactionSubmitted
   const stateContractInstance = await getContractInstance(STATE_CONTRACT_NAME); // NewCurrentProposer, BlockProposed
@@ -57,6 +60,7 @@ export async function syncState(
     .concat(pastStateEvents)
     .concat(pastChallengeEvents)
     .sort((a, b) => a.blockNumber - b.blockNumber);
+  logger.info({ msg: 'replaying past events' });
   for (let i = 0; i < splicedList.length; i++) {
     const pastEvent = splicedList[i];
     switch (pastEvent.event) {

--- a/nightfall-optimist/src/services/state-sync.mjs
+++ b/nightfall-optimist/src/services/state-sync.mjs
@@ -35,24 +35,25 @@ export async function syncState(
   const shieldContractInstance = await getContractInstance(SHIELD_CONTRACT_NAME); // TransactionSubmitted
   const stateContractInstance = await getContractInstance(STATE_CONTRACT_NAME); // NewCurrentProposer, BlockProposed
   const challengesContractInstance = await getContractInstance(CHALLENGES_CONTRACT_NAME); // NewCurrentProposer, BlockProposed
-
-  const pastProposerEvents = await proposersContractInstance.getPastEvents(eventFilter, {
-    fromBlock,
-    toBlock,
-  });
-  const pastShieldEvents = await shieldContractInstance.getPastEvents(eventFilter, {
-    fromBlock,
-    toBlock,
-  });
-  const pastStateEvents = await stateContractInstance.getPastEvents(eventFilter, {
-    fromBlock,
-    toBlock,
-  });
-
-  const pastChallengeEvents = await challengesContractInstance.getPastEvents(eventFilter, {
-    fromBlock,
-    toBlock,
-  });
+  const [pastProposerEvents, pastShieldEvents, pastStateEvents, pastChallengeEvents] =
+    await Promise.all([
+      proposersContractInstance.getPastEvents(eventFilter, {
+        fromBlock,
+        toBlock,
+      }),
+      shieldContractInstance.getPastEvents(eventFilter, {
+        fromBlock,
+        toBlock,
+      }),
+      stateContractInstance.getPastEvents(eventFilter, {
+        fromBlock,
+        toBlock,
+      }),
+      challengesContractInstance.getPastEvents(eventFilter, {
+        fromBlock,
+        toBlock,
+      }),
+    ]);
 
   // Put all events together and sort chronologically as they appear on Ethereum
   const splicedList = pastProposerEvents
@@ -60,7 +61,7 @@ export async function syncState(
     .concat(pastStateEvents)
     .concat(pastChallengeEvents)
     .sort((a, b) => a.blockNumber - b.blockNumber);
-  logger.info({ msg: 'replaying past events' });
+  logger.info({ msg: 'Replaying past events' });
   for (let i = 0; i < splicedList.length; i++) {
     const pastEvent = splicedList[i];
     switch (pastEvent.event) {


### PR DESCRIPTION
When Nightfall attempts to sync, the Blockchain node's websocket frame size may cause problems.  This fix increases the framesize substantially in the web3js client, which should avoid the problem.

It's not really a bug but this PR also updates error logging to explicitly point out if any transaction retrieved from the blockchain is `null`. This can happen because some blockchain nodes do not index older transactions. It's not really a Nightfall bug, more of a blockchain-node setup issue. This change makes it easier for a developer to work out what the issue may be.