### PR TITLE
Westlad/circuit fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ mumbai/
 .vscode/*
 .openzeppelin/
 *.log
+**/*.tmp
 mumbai/
 polygonpos/
 # wallet

--- a/doc/tmp
+++ b/doc/tmp
@@ -1,0 +1,179 @@
+### To export nightfall state
+
+In some circumstances, it may be useful to export the nightfall state so that it can be replicated at any point in time. For example, when doing load testing and many thousands of transactions needs to be generated, saving the nightfall state at the moment when all transactions have been generated may be beneficial.
+
+The exported nightfall state includes:
+
+- blockchain
+- file system (contracts and circuits)
+- client and optimist mondoDbs.
+
+This feature only works with `geth` and not with `ganache`.
+
+To export the nightfall state, run `./bin/export-nightfall <folder>` at the point where you want to save the state. Data is backup in `nightfall_3/backup` folder
+
+### To import nightfall state
+
+One can also import a previously exported state. To do so:
+
+```
+./bin/geth-standalone -i <FOLDER>
+./bin/start-nightfall -l -d
+./bin/import-nightfall <FOLDER>
+```
+
+Each command will need to be entered in a different window.
+
+## Testing
+
+Open a separate terminal window, cd to the nightfall_3 repo and run
+
+```sh
+npm test
+```
+
+This will test the application, creating transactions and assembling them into layer 2 blocks. By default, the application is configured to put only two transactions into a layer 2 block. This is to make the standard tests fast.
+
+### Measuring Block Gas used
+
+In reality, a value of two transactions per block, although convenient for testing, wouldn't make very efficient use of Optimism. A more realistic value is 32 transactions per layer 2 block. This value can be configured by the environment variable `TRANSACTIONS_PER_BLOCK`. This is important for the Block Gas measurement, which only makes sense for more realistic block sizes.
+
+To measure the Block Gas used per transaction, export the `TRANSACTIONS_PER_BLOCK` variable in both the terminal which will run at nightfall and the terminal from which the test will be run, setting it to the value at which you want to run the test (32 in the example here):
+
+```sh
+export TRANSACTIONS_PER_BLOCK=32
+```
+
+Any reasonable value will work but they must be the same for both nightfall and the test. Obviously, it only makes sense to compare performance at the same value of `TRANSACTIONS_PER_BLOCK`.
+
+Then start nightfall:
+
+```sh
+./bin/start-nightfall -g -d -s
+```
+
+Then, in the other terminal window run the test
+
+```sh
+npm run test-gas
+```
+
+The test will print out values of gas used for each type of transaction as it progresses.
+
+Do not forget to set the `TRANSACTIONS_PER_BLOCK` back to 2 when you have finished or the other tests may fail in strange ways.
+
+```sh
+export TRANSACTIONS_PER_BLOCK=2
+```
+
+### Test chain reorganisations
+
+In Layer 2 solutions, the Layer 2 state is held off-chain but created by a series of Layer 1 transactions (e.g. the proposal of a Layer 2 block). In the case of Nightfall_3 these Layer 2 state updates are signalled by blockchain Events being 'broadcast'. Thus, all Layer 2 solutions must be able to correct their Layer 2 state when it becomes invalidated by a Layer 1 chain reorganisation. This is actually quite hard to test because it requires one to be able to generate a chain reorganisation to order. To facilitate such a test, we create a private Geth-based blockchain (details of how to run this up are below) consisting of two clients, two miners and a bootnode. We can then freeze half of the nodes by pausing their containers and creating transaction on the un-paused nodes to create a 'split-brain'. Inverting the process to put different transactions on the other part of the network will create a chain fork and, when all the nodes are brought back online, a chain reorganisation will occur. Currently, test coverage is fairly limited because there are a number of sub-classes of chain fork that have to be simulated. We continue to work on these. These tests are run, once the private Geth blockchain is started, with:
+
+```sh
+npm test-chain-reorg
+```
+
+### Test ping-pong with multi proposers
+
+The ping-pong test uses 2 users and 2 proposers by default to test during a period of time:
+
+- 2 users sending deposit and transfer transactions between them
+- 2 proposers proposing blocks and rotating between them based on the PoS weighted round robin
+- checks for the users layer 2 balances
+- checks for the rotation, stake and statistics for the proposers
+
+To configure the proposers and clients there is a `multiproposer-test.env` you can copy from `example.multiproposer-test.env` for the environment variables for docker-compose file in `docker/docker-compose.multiproposer-test.yml` that define the containers `proposer_x`, `proposer_optimist_x` and `optimist_mongodb_x` for each proposer and the corresponding parameters for each container. You can add more proposers if needed configuring the parameters properly. In the same way, you can configure different clients with `client_x` sharing the same database `optimist_mongodb_x` because they have access to different mongo collections.
+
+To test localy you should run in a terminal
+
+```sh
+npm run build-adversary
+```
+
+This is because we are using a bad client and a lazy optimist in the tests and we should generate the transpilation of the code to use them. In the default test we are using:
+
+- 1 normal client
+- 1 bad client
+- 1 normal optimist
+- 1 lazy optimist
+
+Once we have the code built from the adversary we could start the test environment using:
+
+```sh
+./bin/start-multiproposer-test-env -g
+```
+
+that will start all the containers for the test, and in another terminal, once the Nightfall deployer has exited and proposers are ready:
+
+```sh
+npm run ping-pong
+```
+
+The test will run by default with accounts for user1 and user2 from the config. To run the test with specific accounts for user1 and user2 you have to create a `multiproposer-test.env` file in the root folder from a copy of `example.multiproposer-test.env`. Then you should fill in the information:
+
+- CLIENT1_API_URL, CLIENT2_API_URL with the clients that user1 and user2 will connect as client API to generate the transactions.
+- USER1_KEY, USER2_KEY with the private keys of the users.
+- USER1_MNEMONIC and USER2_MNEMONIC with the mnemonics of the users.
+- BLOCKCHAIN_WS_HOST with the blockchain you want to test When you execute the command `npm run ping-pong` the specific environment variables will be load for this test.
+
+If you want to run specific keys for the proposer_1 and proposer_2 you also can define PROPOSER_KEY, PROPOSER2_KEY environment variables in the `multiproposer-test.env` file and also OPTIMIST1_API_URL, OPTIMIST2_API_URL, OPTIMIST1_WS_URL, OPTIMIST2_WS_URL for the optimists of the proposers to call the making block in the test automatically for the current proposer.
+
+If you want to check the test with geth you can run the geth
+
+- Run up the private chain with `./bin/geth-standalone -s`
+- Start terminal logging with `./bin/geth-standalone -l` and wait for the DAG build to complete
+- Start multiproposer test containers in another terminal with the `-l` option
+  (`./bin/start-multiproposer-test-env -l`)
+
+To help fund the blockchain unlocked accounts of the test with some token `ERC20Mock` you have a script available that can run
+
+- `COMMAND=fund node ./nightfall-deployer/scripts/fund-accounts.mjs` to fund the accounts with some token.
+- `node ./nightfall-deployer/scripts/fund-accounts.mjs` to check the balance of the accounts.
+
+## Using a Geth private blockchain
+
+The script `./bin/geth-standalone` will run up a private blockchain consisting of a bootnode, two client nodes and two miners. This is required for testing chain reorganisations (Ganache does not simulate a chain-reorg) but can be used for other tests or general running. It's slower than using Ganache but it does provide a more real-life test. Note also that the private chain exposes a client
+on `host.docker.internal:8546`. On a Mac this will map to `localhost` but it won't work on any other machine. If you aren't on a Mac then you can do one of these 3 options:
+
+- If you are on a Linux you can edit `/etc/hosts` file and add a map from the private IP address of your connected interface to the domain `host.docker.internal`. In this case, `127.0.0.1` is not valid. You can check your private IP address with `ip address`.
+- Edit `nightfall-deployer/truffle-config.js` to point to the IP of your `localhost`
+- Use the docker-compose line `external_servers` to inject a hostname into the containers host file (see the GitHub workflows for further clues about how to do that).
+
+To use the private blockchain:
+
+- Run up the private chain with `./bin/geth-standalone -s`
+- Start terminal logging with `./bin/geth-standalone -l` and wait for the DAG build to complete
+- Start Nightfall in another terminal with the `-l` option (`./bin/start-nightfall -l`)
+
+That's it. You can shut down the geth blockchain with `./bin/geth-standalone -d` or pause/unpause it with `-p`, `-u`.
+
+## Software Development Kit
+
+Nightfall_3 provides an SDK which makes it easy to develop applications that use Nightfall_3. The SDK API is documented in `./doc/lib/Nf3.html` and is provided by the NF_3 class `./cli/lib/nf3.mjs`.
+
+## Apps
+
+Nightfall_3 provides some reference applications (which make use of the SDK) so that you can exercise its features. To use it:
+
+- run up nightfall_3 as described above and wait for the deployment to complete;
+- in the `apps` folder there are small applications like `proposer` or `challenger` you can run with `./bin/start-apps`. For example, `proposer` will start a small application running which will sign block proposal transactions;
+
+## Limitations
+
+Nightfall uses the G16 proof system, and we believe it is [not vulnerable](./doc/G16-malleability.md) to its malleability.
+
+## Troubleshooting
+
+If something goes wrong, you have some friends to help you, namely
+
+```sh
+docker system prune -a
+docker volume prune
+```
+
+These will hopefully delete every image, container and volume so you should have a clean slate. Mind that you need to run `./bin/setup-nightfall` again.
+
+# Deployment
+
+EY expects to deploy Nightfall as a fully-decentralised application shortly.

--- a/nightfall-deployer/circuits/burn.circom
+++ b/nightfall-deployer/circuits/burn.circom
@@ -7,6 +7,8 @@ include "./common/verifiers/commitments/verify_commitments_optional.circom";
 include "./common/verifiers/nullifiers/verify_nullifiers.circom";
 include "./common/verifiers/nullifiers/verify_nullifiers_optional.circom";
 include "./common/verifiers/verify_encryption.circom";
+include "../node_modules/circomlib/circuits/comparators.circom";
+include "../node_modules/circomlib/circuits/gates.circom";
 
 include "../node_modules/circomlib/circuits/bitify.circom";
 
@@ -83,10 +85,13 @@ template Burn(N,C) {
     tokenIdNum === 0;
     
     // Check that the recipient address is zero
-    assert(recipientAddress == 0);
+    // assert(recipientAddress == 0);
+    recipientAddress === 0;
 
     // Check that the first nullifier is different than zero
-    assert(nullifiers[0] != 0);
+    // assert(nullifiers[0] != 0);
+    signal n1 <== IsZero()(nullifiers[0]);
+    n1 === 0;
 
     // Convert the nullifiers values to numbers and calculate its sum
     var nullifiersSum = 0;
@@ -153,11 +158,21 @@ template Burn(N,C) {
     var checkCommitmentFee = VerifyCommitmentsOptional(1)(feeAddress, 0, [commitments[1]],[commitmentsValues[1]], [commitmentsSalts[1]], [recipientPublicKey[1]]);
     checkCommitmentFee === 1;
 
-    assert(commitmentsValues[0] == 0 || (
-        zkpPublicKeys[0] == recipientPublicKey[0][0] && zkpPublicKeys[1] == recipientPublicKey[0][1]));
+    // assert(commitmentsValues[0] == 0 || (
+    //   zkpPublicKeys[0] == recipientPublicKey[0][0] && zkpPublicKeys[1] == recipientPublicKey[0][1]));
+    signal a1 <== IsZero()(commitmentsValues[0]);
+    signal a2 <== IsEqual()([zkpPublicKeys[0], recipientPublicKey[0][0]]);
+    signal a3 <== IsEqual()([zkpPublicKeys[1], recipientPublicKey[0][1]]);
+    signal r <== OR()(a1, AND()(a2, a3));
+    r === 1;
 
-    assert(commitmentsValues[1] == 0 || (
-        zkpPublicKeys[0] == recipientPublicKey[1][0] && zkpPublicKeys[1] == recipientPublicKey[1][1]));
+    // assert(commitmentsValues[1] == 0 || (
+    //    zkpPublicKeys[0] == recipientPublicKey[1][0] && zkpPublicKeys[1] == recipientPublicKey[1][1]));
+    signal b1 <== IsZero()(commitmentsValues[1]);
+    signal b2 <== IsEqual()([zkpPublicKeys[0], recipientPublicKey[1][0]]);
+    signal b3 <== IsEqual()([zkpPublicKeys[1], recipientPublicKey[1][1]]);
+    signal s <== OR()(b1, AND()(b2, b3));
+    s === 1;
 }
 
 component main {public [value, fee, circuitHash, tokenType, historicRootBlockNumberL2, tokenId, ercAddress, recipientAddress, commitments, nullifiers, compressedSecrets,roots, feeAddress]} = Burn(3,2);

--- a/nightfall-deployer/circuits/burn.circom
+++ b/nightfall-deployer/circuits/burn.circom
@@ -67,7 +67,7 @@ template Burn(N,C) {
     
     // Check that the transaction does not have nullifiers nor commitments duplicated
     var checkDuplicates = VerifyDuplicates(N,C)(nullifiers, commitments);
-    checkDuplicates === 1;
+    checkDuplicates === 0;
 
     // Check that ercAddress is zero
     ercAddress === 0;

--- a/nightfall-deployer/circuits/common/verifiers/commitments/verify_commitments_generic.circom
+++ b/nightfall-deployer/circuits/common/verifiers/commitments/verify_commitments_generic.circom
@@ -3,6 +3,8 @@ pragma circom 2.1.2;
 include "../../../../node_modules/circomlib/circuits/comparators.circom";
 include "../../../../node_modules/circomlib/circuits/mux1.circom";
 include "../../../../node_modules/circomlib/circuits/poseidon.circom";
+include "../../../../node_modules/circomlib/circuits/comparators.circom";
+include "../../../../node_modules/circomlib/circuits/gates.circom";
 
 /**
  * Verifies that a commitment can be reconstructed from its preimage values. As long as the commitment comes from either the ercAddress
@@ -28,6 +30,8 @@ template VerifyCommitmentsGeneric(C) {
 
     signal output valid;
 
+    signal r[C];
+
     for(var i=0; i < C; i++) {
         // Check if the commitment value is zero
         var isCommitmentValueZero = IsZero()(newCommitmentsValues[i]);
@@ -45,7 +49,9 @@ template VerifyCommitmentsGeneric(C) {
         var commitmentFee = Mux1()([calculatedCommitmentHashFee, 0], isCommitmentValueZero);
 
         // Check either one of the two reconstructed commitments matches with the public transaction commitment hash 
-        assert(commitment == commitmentsHashes[i] || commitmentFee == commitmentsHashes[i]);
+        //  assert(commitment == commitmentsHashes[i] || commitmentFee == commitmentsHashes[i]);
+        r[i] <== OR()(IsEqual()([commitment, commitmentsHashes[i]]), IsEqual()([commitmentFee, commitmentsHashes[i]]));
+        r[i] === 1;
     }
 
     valid <== 1;

--- a/nightfall-deployer/circuits/common/verifiers/nullifiers/verify_nullifiers_optional.circom
+++ b/nightfall-deployer/circuits/common/verifiers/nullifiers/verify_nullifiers_optional.circom
@@ -55,10 +55,10 @@ template VerifyNullifiersOptional(N) {
         var calculatedRoot = CalculateRoot()(orders[i], calculatedCommitmentHash, paths[i]);
         
         // Check if the calculated root matches with the public root
-        var isEqualRoots = IsEqual()([calculatedRoot, roots[i]]);
+        var IsEqualRoots = IsEqual()([calculatedRoot, roots[i]]);
         
         // Check that the root is valid
-        var isValidRoot = Mux1()([isEqualRoots, 1], isNullifierValueZero);
+        var isValidRoot = Mux1()([IsEqualRoots, 1], isNullifierValueZero);
         isValidRoot === 1;
     }
 

--- a/nightfall-deployer/circuits/common/verifiers/verify_duplicates.circom
+++ b/nightfall-deployer/circuits/common/verifiers/verify_duplicates.circom
@@ -16,16 +16,16 @@ template VerifyDuplicates(N, C) {
     signal input commitments[C];
     signal output valid;
 
+    var x = 0;
     signal r[N][N];
     signal s[C][C];
-
 
     // Check that there are no nullifiers duplicated
     for(var i = 0; i < N; i++) {
         for(var j = i+1; j < N; j++) {
             // assert(nullifiers[j] == 0 || nullifiers[i] != nullifiers[j]);
-            r[i][j] <== OR()(IsZero()(nullifiers[j]), NOT()(IsEqual()([nullifiers[i], nullifiers[j]])));
-            r[i][j] === 1;
+             r[i][j] <-- NOR()(IsZero()(nullifiers[j]), NOT()(IsEqual()([nullifiers[i], nullifiers[j]])));
+             x += r[i][j];
         }
     }
 
@@ -33,10 +33,10 @@ template VerifyDuplicates(N, C) {
     for(var i = 0; i < C; i++) {
          for(var j = i+1; j < C; j++) {
             // assert(commitments[j] == 0 || commitments[i] != commitments[j]);
-            s[i][j] <== OR()(IsZero()(commitments[j]), IsEqual()([commitments[i], commitments[j]]));
-            s[i][j] === 1;
+            s[i][j] <-- NOR()(IsZero()(commitments[j]), NOT()(IsEqual()([commitments[i], commitments[j]])));
+            x += s[i][j];
         }
     }
-
-    valid <== 1;
+    x === 0;
+    valid <== x;
 }

--- a/nightfall-deployer/circuits/common/verifiers/verify_duplicates.circom
+++ b/nightfall-deployer/circuits/common/verifiers/verify_duplicates.circom
@@ -1,5 +1,8 @@
 pragma circom 2.1.2;
 
+include "../../../node_modules/circomlib/circuits/comparators.circom";
+include "../../../node_modules/circomlib/circuits/gates.circom";
+
 /**
  * Check that there are no duplicate commitments nor nullifiers in the same transaction
  * Note: There might be multiple zero commitments / nullifiers. 
@@ -11,20 +14,27 @@ pragma circom 2.1.2;
 template VerifyDuplicates(N, C) {
     signal input nullifiers[N];
     signal input commitments[C];
-
     signal output valid;
+
+    signal r[N][N];
+    signal s[C][C];
+
 
     // Check that there are no nullifiers duplicated
     for(var i = 0; i < N; i++) {
         for(var j = i+1; j < N; j++) {
-            assert(nullifiers[j] == 0 || nullifiers[i] != nullifiers[j]);
+            // assert(nullifiers[j] == 0 || nullifiers[i] != nullifiers[j]);
+            r[i][j] <== OR()(IsZero()(nullifiers[j]), NOT()(IsEqual()([nullifiers[i], nullifiers[j]])));
+            r[i][j] === 1;
         }
     }
 
     // Check that there are no commitments duplicated
     for(var i = 0; i < C; i++) {
          for(var j = i+1; j < C; j++) {
-            assert(commitments[j] == 0 || commitments[i] != commitments[j]);
+            // assert(commitments[j] == 0 || commitments[i] != commitments[j]);
+            s[i][j] <== OR()(IsZero()(commitments[j]), IsEqual()([commitments[i], commitments[j]]));
+            s[i][j] === 1;
         }
     }
 

--- a/nightfall-deployer/circuits/common/verifiers/verify_duplicates.circom
+++ b/nightfall-deployer/circuits/common/verifiers/verify_duplicates.circom
@@ -24,7 +24,7 @@ template VerifyDuplicates(N, C) {
     for(var i = 0; i < N; i++) {
         for(var j = i+1; j < N; j++) {
             // assert(nullifiers[j] == 0 || nullifiers[i] != nullifiers[j]);
-             r[i][j] <-- NOR()(IsZero()(nullifiers[j]), NOT()(IsEqual()([nullifiers[i], nullifiers[j]])));
+             r[i][j] <== NOR()(IsZero()(nullifiers[j]), NOT()(IsEqual()([nullifiers[i], nullifiers[j]])));
              x += r[i][j];
         }
     }
@@ -33,7 +33,7 @@ template VerifyDuplicates(N, C) {
     for(var i = 0; i < C; i++) {
          for(var j = i+1; j < C; j++) {
             // assert(commitments[j] == 0 || commitments[i] != commitments[j]);
-            s[i][j] <-- NOR()(IsZero()(commitments[j]), NOT()(IsEqual()([commitments[i], commitments[j]])));
+            s[i][j] <== NOR()(IsZero()(commitments[j]), NOT()(IsEqual()([commitments[i], commitments[j]])));
             x += s[i][j];
         }
     }

--- a/nightfall-deployer/circuits/deposit.circom
+++ b/nightfall-deployer/circuits/deposit.circom
@@ -3,6 +3,8 @@ pragma circom 2.1.2;
 include "./common/verifiers/verify_duplicates.circom";
 include "./common/verifiers/commitments/verify_commitments.circom";
 include "./common/utils/array_uint32_to_bits.circom";
+include "../node_modules/circomlib/circuits/comparators.circom";
+include "../node_modules/circomlib/circuits/gates.circom";
 
 include "../node_modules/circomlib/circuits/bitify.circom";
 
@@ -52,7 +54,9 @@ template Deposit(N,C) {
     compressedSecrets[1] === 0;
     
     // Check that ercAddress is different than zero
-    assert(ercAddress != 0);
+    // assert(ercAddress != 0);
+    signal a1 <== IsZero()(ercAddress);
+    a1 === 0;
 
     var tokenIdBits[256] = ArrayUint32ToBits(8)(tokenId);
     var tokenIdNum = Bits2Num(256)(tokenIdBits);
@@ -60,13 +64,24 @@ template Deposit(N,C) {
     //ERC20 -> Value > 0 and Id == 0
     //ERC721 -> Value == 0
     //ERC1155 -> Value > 0
-    assert((tokenType == 1 && value == 0) || (tokenType != 1 && value != 0));
-    assert((tokenType == 0 && tokenIdNum == 0) || tokenType != 0);
+    // assert((tokenType == 1 && value == 0) || (tokenType != 1 && value != 0));
+    signal b1 <== IsZero()(tokenType - 1);
+    signal b2 <== IsZero()(value);
+    signal r1 <== XOR()(b1, b2);
+    r1 === 0;
+
+    // assert((tokenType == 0 && tokenIdNum == 0) || tokenType != 0);
+    signal c1 <== IsZero()(tokenType);
+    signal c2 <== IsZero()(tokenIdNum);
+    signal r2 <== OR()(AND()(c1, c2), NOT()(c1));
+    r2 === 1;
 
     recipientAddress === 0;
 
     // Check that the first commitment is different than zero
-    assert(commitments[0] != 0);
+    // assert(commitments[0] != 0);
+    signal d1 <== IsZero()(commitments[0]);
+    d1 === 0;
     
     // Convert the commitment values to numbers and calculate its sum
     var commitmentsSum = 0;

--- a/nightfall-deployer/circuits/deposit.circom
+++ b/nightfall-deployer/circuits/deposit.circom
@@ -47,7 +47,7 @@ template Deposit(N,C) {
 
     // Check that the transaction does not have nullifiers nor commitments duplicated
     var checkDuplicates = VerifyDuplicates(N,C)(nullifiers, commitments);
-    checkDuplicates === 1;
+    checkDuplicates === 0;
 
     // Check that compressed secrets is zero
     compressedSecrets[0] === 0;

--- a/nightfall-deployer/circuits/depositfee.circom
+++ b/nightfall-deployer/circuits/depositfee.circom
@@ -60,7 +60,7 @@ template DepositFee(N,C) {
 
     // Check that the transaction does not have nullifiers nor commitments duplicated
     var checkDuplicates = VerifyDuplicates(N,C)(nullifiers, commitments);
-    checkDuplicates === 1;
+    checkDuplicates === 0;
 
     // Check that compressed secrets is zero
     compressedSecrets[0] === 0;

--- a/nightfall-deployer/circuits/tokenise.circom
+++ b/nightfall-deployer/circuits/tokenise.circom
@@ -7,6 +7,8 @@ include "./common/verifiers/commitments/verify_commitments_optional.circom";
 include "./common/verifiers/commitments/verify_commitments.circom";
 include "./common/verifiers/nullifiers/verify_nullifiers_optional.circom";
 include "./common/verifiers/verify_encryption.circom";
+include "../node_modules/circomlib/circuits/comparators.circom";
+include "../node_modules/circomlib/circuits/gates.circom";
 
 include "../node_modules/circomlib/circuits/bitify.circom";
 
@@ -86,7 +88,9 @@ template Tokenise(N,C) {
     recipientAddress === 0;
 
     // Check that the first commitment is different than zero
-    assert(commitments[0] != 0);
+    // assert(commitments[0] != 0);
+    signal a1 <== IsZero()(commitments[0]);
+    a1 === 0;
  
     // Convert the nullifiers values to numbers and calculate its sum
     var nullifiersSum = 0;
@@ -137,8 +141,13 @@ template Tokenise(N,C) {
     checkCommitmentFee === 1;
 
     // Verify the fee change
-    assert(commitmentsValues[1] == 0 || (
-        zkpPublicKeys[0] == recipientPublicKey[1][0] && zkpPublicKeys[1] == recipientPublicKey[1][1]));
+    // assert(commitmentsValues[1] == 0 || (
+    //     zkpPublicKeys[0] == recipientPublicKey[1][0] && zkpPublicKeys[1] == recipientPublicKey[1][1]));
+    signal b1 <== IsZero()(commitmentsValues[1]);
+    signal b2 <== IsEqual()([zkpPublicKeys[0], recipientPublicKey[1][0]]);
+    signal b3 <== IsEqual()([zkpPublicKeys[1], recipientPublicKey[1][1]]);
+    signal r <== OR()(b1, AND()(b2, b3));
+    r === 1;
 }
 
 component main {public [value, fee, circuitHash, tokenType, historicRootBlockNumberL2, tokenId, ercAddress, recipientAddress, commitments, nullifiers, compressedSecrets,roots, feeAddress]} = Tokenise(2,2);

--- a/nightfall-deployer/circuits/tokenise.circom
+++ b/nightfall-deployer/circuits/tokenise.circom
@@ -67,7 +67,7 @@ template Tokenise(N,C) {
     
     // Check that the transaction does not have nullifiers nor commitments duplicated
     var checkDuplicates = VerifyDuplicates(N,C)(nullifiers, commitments);
-    checkDuplicates === 1;
+    checkDuplicates === 0;
 
     // Check that ercAddress is zero
     ercAddress === 0;

--- a/nightfall-deployer/circuits/transfer.circom
+++ b/nightfall-deployer/circuits/transfer.circom
@@ -68,7 +68,7 @@ template Transfer(N,C) {
     
     // Check that the transaction does not have nullifiers nor commitments duplicated
     var checkDuplicates = VerifyDuplicates(N,C)(nullifiers, commitments);
-    checkDuplicates === 1;
+    checkDuplicates === 0;
 
     // Check that the ercAddress is different than zero (it contains one of the 4 encrypted KemDem values)
     // assert(ercAddress != 0);

--- a/nightfall-deployer/circuits/transfer.circom
+++ b/nightfall-deployer/circuits/transfer.circom
@@ -8,6 +8,8 @@ include "./common/verifiers/commitments/verify_commitments.circom";
 include "./common/verifiers/nullifiers/verify_nullifiers.circom";
 include "./common/verifiers/nullifiers/verify_nullifiers_generic.circom";
 include "./common/verifiers/verify_encryption.circom";
+include "../node_modules/circomlib/circuits/comparators.circom";
+include "../node_modules/circomlib/circuits/gates.circom";
 
 include "../node_modules/circomlib/circuits/bitify.circom";
 
@@ -69,22 +71,34 @@ template Transfer(N,C) {
     checkDuplicates === 1;
 
     // Check that the ercAddress is different than zero (it contains one of the 4 encrypted KemDem values)
-    assert(ercAddress != 0);
+    // assert(ercAddress != 0);
+    signal a1 <== IsZero()(ercAddress);
+    a1 === 0;
 
     // Check that the recipientAddress is different than zero (it contains the second cipher text)
-    assert(recipientAddress != 0);
+    // assert(recipientAddress != 0);
+    signal b1 <== IsZero()(recipientAddress);
+    b1 === 0;
 
     // Check that at least one of the compressed secrets is not zero
-    assert(compressedSecrets[0] != 0 || compressedSecrets[1] != 0);
+    // assert(compressedSecrets[0] != 0 || compressedSecrets[1] != 0);
+    signal c1 <== IsZero()(compressedSecrets[0]);
+    signal c2 <== IsZero()(compressedSecrets[1]);
+    signal r <== AND()(c1, c2);
+    r === 0;
 
     // Check that value is zero
     value === 0;
 
     // Check that the first commitment is different than zero
-    assert(commitments[0] != 0);
+    // assert(commitments[0] != 0);
+    signal d1 <== IsZero()(commitments[0]);
+    d1 === 0;
 
     // Check that the first nullifier is different than zero
-    assert(nullifiers[0] != 0);
+    // assert(nullifiers[0] != 0);
+    signal e1 <== IsZero()(nullifiers[0]);
+    e1 === 0;
 
     // Convert the nullifiers values to numbers and calculate its sum
     var nullifiersSum = 0;
@@ -153,13 +167,22 @@ template Transfer(N,C) {
     checkGenericCommitments.valid === 1;
 
     // Verify the withdraw change
-    assert(commitmentsValues[C - 2] == 0 || (
-        zkpPublicKeys[0] == recipientPublicKey[C - 2][0] && zkpPublicKeys[1] == recipientPublicKey[C - 2][1]));
+    //assert(commitmentsValues[C - 2] == 0 || (
+    //    zkpPublicKeys[0] == recipientPublicKey[C - 2][0] && zkpPublicKeys[1] == recipientPublicKey[C - 2][1]));
+    signal f1 <== IsZero()(commitmentsValues[C - 2]);
+    signal f2 <== IsEqual()([zkpPublicKeys[0], recipientPublicKey[C - 2][0]]);
+    signal f3 <== IsEqual()([zkpPublicKeys[1], recipientPublicKey[C - 2][1]]);
+    signal s <== OR()(f1, AND()(f2, f3));
+    s === 1;
     
     // Verify the fee change
-    assert(commitmentsValues[C - 1] == 0 || (
-        zkpPublicKeys[0] == recipientPublicKey[C - 1][0] && zkpPublicKeys[1] == recipientPublicKey[C - 1][1]));
-
+    // assert(commitmentsValues[C - 1] == 0 || (
+    //     zkpPublicKeys[0] == recipientPublicKey[C - 1][0] && zkpPublicKeys[1] == recipientPublicKey[C - 1][1]));
+    signal g1 <== IsZero()(commitmentsValues[C - 1]);
+    signal g2 <== IsEqual()([zkpPublicKeys[0], recipientPublicKey[C - 1][0]]);
+    signal g3 <== IsEqual()([zkpPublicKeys[1], recipientPublicKey[C - 1][1]]);
+    signal t <== OR()(g1, AND()(g2, g3));
+    t === 1;
 
     var tokenIdBits[256] = ArrayUint32ToBits(8)(tokenId);
     // Check that the encryption of the recipient's commitment preimage was performed appropiately

--- a/nightfall-deployer/circuits/transform.circom
+++ b/nightfall-deployer/circuits/transform.circom
@@ -75,7 +75,7 @@ template Transform(N,C) {
     
     // Check that the transaction does not have nullifiers nor commitments duplicated
     var checkDuplicates = VerifyDuplicates(N,C)(nullifiers, commitments);
-    checkDuplicates === 1;
+    checkDuplicates === 0;
 
     // Check that ercAddress is zero
     ercAddress === 0;

--- a/nightfall-deployer/circuits/transform.circom
+++ b/nightfall-deployer/circuits/transform.circom
@@ -93,10 +93,13 @@ template Transform(N,C) {
     tokenIdNum === 0;
     
     // Check that the recipient address is zero
-    assert(recipientAddress == 0);
+    // assert(recipientAddress == 0);
+    recipientAddress === 0;
 
     // Check that the first nullifier is different than zero
-    assert(nullifiers[0] != 0);
+    // assert(nullifiers[0] != 0);
+    signal a1 <== IsZero()(nullifiers[0]);
+    a1 === 0;
 
     // check that none of the values overflow
     for (var i = 0; i < N; i++) {
@@ -105,7 +108,7 @@ template Transform(N,C) {
       nullifierValueBits[252] === 0;
     }
     for (var i = 0; i < C; i++) {
-      var commitmentValueBits[254] = Num2Bits(254)(commitmentsValues[0]);
+      var commitmentValueBits[254] = Num2Bits(254)(commitmentsValues[i]);
       commitmentValueBits[253] === 0;
       commitmentValueBits[252] === 0;
     }

--- a/nightfall-deployer/circuits/withdraw.circom
+++ b/nightfall-deployer/circuits/withdraw.circom
@@ -60,7 +60,7 @@ template Withdraw(N,C) {
     
     // Check that the transaction does not have nullifiers nor commitments duplicated
     var checkDuplicates = VerifyDuplicates(N,C)(nullifiers, commitments);
-    checkDuplicates === 1;
+    checkDuplicates === 0;
     
     // Check that compressed secrets is zero
     compressedSecrets[0] === 0;

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -71,7 +71,7 @@ describe('ERC20 tests', () => {
 
   before(async () => {
     await nf3User.init(mnemonics.user1);
-    console.log( '**********************KEY DATA********************');
+    console.log('**********************KEY DATA********************');
     console.log(mnemonics.user1);
     console.log(nf3User.zkpKeys);
     await nf3User2.init(mnemonics.user2);

--- a/test/e2e/tokens/erc20.test.mjs
+++ b/test/e2e/tokens/erc20.test.mjs
@@ -71,6 +71,9 @@ describe('ERC20 tests', () => {
 
   before(async () => {
     await nf3User.init(mnemonics.user1);
+    console.log( '**********************KEY DATA********************');
+    console.log(mnemonics.user1);
+    console.log(nf3User.zkpKeys);
     await nf3User2.init(mnemonics.user2);
     if (DEPLOY_MOCKED_SANCTIONS_CONTRACT) await nf3UserSanctioned.init(mnemonics.sanctionedUser);
 

--- a/test/unit/circuits/common/verifiers/verify_duplicates.circom.test.mjs
+++ b/test/unit/circuits/common/verifiers/verify_duplicates.circom.test.mjs
@@ -50,7 +50,7 @@ describe('Test verify duplicates', function () {
     };
 
     const output = {
-      valid: 1,
+      valid: 0,
     };
 
     const w = await circuit.calculateWitness(input, { logOutput: false });


### PR DESCRIPTION
This PR patches the nightfall circuits which used `assert`.  In Circom, use of `assert` does not generate any constraints.

With grateful thanks to [simon.perriard@chainsecurity.com](mailto:simon.perriard@chainsecurity.com) for spotting this.
