### PR TITLE
remove 'hosted-utils-api-server' service from multiproposer 'docker-compose'

### DIFF
--- a/docker/docker-compose.multiproposer-test.yml
+++ b/docker/docker-compose.multiproposer-test.yml
@@ -56,19 +56,6 @@ services:
       DEPLOY_MOCKED_SANCTIONS_CONTRACT: 'true'
       GAS_ESTIMATE_ENDPOINT: ${GAS_ESTIMATE_ENDPOINT}
 
-  hosted-utils-api-server:
-    build:
-      dockerfile: docker/hosted-utils-api-server.Dockerfile
-      context: ..
-    depends_on:
-      - worker
-    ports:
-      - 8087:80
-    volumes:
-      - type: volume
-        source: proving_files
-        target: /app/public/
-
   worker:
     image: ghcr.io/eyblockchain/nightfall3-worker:latest
     build:


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Remove 'hosted-utils-api-server' service from multiproposer 'docker-compose' since it is not required to run 'ping-pong' e2e test 

## Does this close any currently open issues?
Nope

## What commands can I run to test the change? 
Run `ping-pong-test` locally and/or via CI:
1. `NF_SERVICES_TO_START=blockchain,deployer,worker ./bin/setup-nightfall`
2. `CONFIRMATIONS=1  WHITELISTING=disable ./bin/start-multiproposer-test-env -g`
[in another terminal]
3. `npm ci`
4. `docker wait nightfall_3_deployer_1` (wait for deployer to finish)
5. `CONFIRMATIONS=1  npm run ping-pong`

## Any other comments?
Just avoiding building an image and starting a container unnecessarily 
