### PR TITLE
Set ci job timeouts

### DIFF
--- a/.github/workflows/on-pull-request-master.yml
+++ b/.github/workflows/on-pull-request-master.yml
@@ -7,6 +7,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Cancel in-progress runs only if triggered by 'pull_request'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   DOCKER_BUILDKIT: 1 # enable docker buildkit
   # Whitelisting is disabled during testing for backwards compatibility with these tests.  It must not be disabled in production.

--- a/.github/workflows/on-pull-request-master.yml
+++ b/.github/workflows/on-pull-request-master.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   dependency-review:
     runs-on: ubuntu-20.04
+    timeout-minutes: 20
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3
@@ -20,6 +21,7 @@ jobs:
 
   eslint-check:
     runs-on: ubuntu-20.04
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -35,6 +37,7 @@ jobs:
 
   general-tests:
     runs-on: ubuntu-20.04
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -50,6 +53,7 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-20.04
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -73,6 +77,7 @@ jobs:
 
   unit-test-circuits:
     runs-on: ubuntu-20.04
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -103,6 +108,7 @@ jobs:
       ENDPOINTS_WHITELISTED: '/commitment/salt\?.*, /contract-address/\w+/?'
       NF_SERVICES_TO_START: blockchain,client,deployer,worker
     runs-on: ubuntu-20.04
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -192,6 +198,7 @@ jobs:
       CONFIRMATIONS: 1
       NF_SERVICES_TO_START: blockchain,client,deployer,mongodb,optimist,rabbitmq,worker
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -239,6 +246,7 @@ jobs:
       CONFIRMATIONS: 1
       NF_SERVICES_TO_START: blockchain,client,deployer,mongodb,optimist,rabbitmq,worker
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -287,6 +295,7 @@ jobs:
       NF_SERVICES_TO_START: blockchain,client,deployer,mongodb,optimist,rabbitmq,worker
       DEPLOY_MOCKED_SANCTIONS_CONTRACT: true
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -335,6 +344,7 @@ jobs:
       CONFIRMATIONS: 1
       NF_SERVICES_TO_START: blockchain,client,deployer,mongodb,optimist,rabbitmq,worker
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -382,6 +392,7 @@ jobs:
       CONFIRMATIONS: 1
       NF_SERVICES_TO_START: blockchain,client,deployer,mongodb,optimist,rabbitmq,worker
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -429,6 +440,7 @@ jobs:
       CONFIRMATIONS: 1
       NF_SERVICES_TO_START: blockchain,client,deployer,mongodb,optimist,rabbitmq,worker
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -470,12 +482,14 @@ jobs:
         with:
           name: ganache-test-logs
           path: ./ganache-test.log
+
   x509-test:
     env:
       WHITELISTING: enable
       CONFIRMATIONS: 1
       NF_SERVICES_TO_START: blockchain,client,deployer,mongodb,optimist,rabbitmq,worker
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -519,6 +533,7 @@ jobs:
 
   administrator-test:
     runs-on: ubuntu-20.04
+    timeout-minutes: 45
     env:
       CONFIRMATIONS: 1
       NF_SERVICES_TO_START: administrator,blockchain,client,deployer,mongodb,optimist,rabbitmq,worker
@@ -566,6 +581,7 @@ jobs:
 
   optimist-sync-test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 50
     env:
       CONFIRMATIONS: 1
       NF_SERVICES_TO_START: blockchain,client,deployer,mongodb,optimist,rabbitmq,worker
@@ -616,6 +632,7 @@ jobs:
       CONFIRMATIONS: 1
       NF_SERVICES_TO_START: blockchain,client,deployer,mongodb,optimist,rabbitmq,worker,lazy-optimist,bad-client
     runs-on: ubuntu-20.04
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -667,6 +684,7 @@ jobs:
       CONFIRMATIONS: 1
       NF_SERVICES_TO_START: blockchain,deployer,worker
     runs-on: ubuntu-20.04
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -738,6 +756,7 @@ jobs:
       NF_SERVICES_TO_START: blockchain,client,deployer,mongodb,optimist,rabbitmq,worker
     name: check gas transactions per block
     runs-on: ubuntu-20.04
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -783,6 +802,7 @@ jobs:
   test-apps:
     name: check apps for liveliness
     runs-on: ubuntu-20.04
+    timeout-minutes: 45
     env:
       NF_SERVICES_TO_START: blockchain,deployer,optimist,worker
     steps:
@@ -820,7 +840,7 @@ jobs:
             curl -i http://localhost:8092/healthcheck
           attempt_limit: 10
           attempt_delay: 30000
-      
+
       - name: 'Check challenger liveliness'
         uses: Wandalen/wretry.action@v1.0.36
         with:
@@ -848,12 +868,12 @@ jobs:
             ./test-apps.log
             ./test-proposer.log
 
-
   periodic-payment-test:
     env:
       CONFIRMATIONS: 1
       NF_SERVICES_TO_START: blockchain,client,deployer,mongodb,optimist,rabbitmq,worker
     runs-on: ubuntu-20.04
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/on-pull-request-master.yml
+++ b/.github/workflows/on-pull-request-master.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [master]
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 env:
   DOCKER_BUILDKIT: 1 # enable docker buildkit
   # Whitelisting is disabled during testing for backwards compatibility with these tests.  It must not be disabled in production.


### PR DESCRIPTION
A few suggestions for the ci workflows:

1. The default time-out for a github ci job is 360m (6h) and unfortunately setting a default time-out at the entire workflow scope is [not yet supported](https://github.com/orgs/community/discussions/10690) so to prevent a job from hanging for so long, it is useful to set a sensible (but not too strict) time-out per job explicitly (specific limits are flexible)
2. A nice optimization: when triggered due to a PR and new commits are pushed while jobs are still in-progress they will be [cancelled ](https://docs.github.com/en/actions/using-jobs/using-concurrency) in favor of the newly triggered jobs (stopping stale jobs running on invalidated PR)
3. (optional) Also added 'workflow_dispatch' as a trigger so that workflow can be [started manually](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) via web (Actions tab) to anyone who has permissions to do so (will only appear there after PR is merged). Useful for troubleshooting and nicer than empty commits.

