### PR TITLE
Publish block data to external services via webhooks

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -737,4 +737,11 @@ module.exports = {
   },
   TIMER_CHANGE_PROPOSER_SECOND: Number(process.env.TIMER_CHANGE_PROPOSER_SECOND) || 30,
   MAX_ROTATE_TIMES: Number(process.env.MAX_ROTATE_TIMES) || 2,
+  WEBHOOK: {
+    CALL_WEBHOOK_ON_CONFIRMATION: process.env.CALL_WEBHOOK_ON_CONFIRMATION,
+    CALL_WEBHOOK_MAX_RETRIES: process.env.CALL_WEBHOOK_MAX_RETRIES || 3,
+    CALL_WEBHOOK_INITIAL_BACKOFF: process.env.CALL_WEBHOOK_INITIAL_BACKOFF || 15000,
+    WEBHOOK_PATH: process.env.WEBHOOK_PATH, // For posting optional layer 2 transaction finalization details
+    WEBHOOK_SIGNING_KEY: process.env.WEBHOOK_SIGNING_KEY,
+  },
 };

--- a/nightfall-client/src/utils/dataPublisher.mjs
+++ b/nightfall-client/src/utils/dataPublisher.mjs
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import crypto from 'crypto';
+
+export default class DataPublisher {
+  constructor(options) {
+    this.options = options || [];
+  }
+
+  async publish(data) {
+    const promises = this.options.map(async destination => {
+      switch (destination.type) {
+        case 'webhook': {
+          await this.publishWebhook(destination, data);
+          break;
+        }
+
+        default:
+          throw new Error('Unknown destination type');
+      }
+    });
+
+    await Promise.all(promises);
+  }
+
+  publishWebhook = async (destination, data) => {
+    const headers = {};
+
+    if (destination.signingkey) {
+      const signature = await this.signWebhookPayload(data, destination.signingkey);
+      headers['X-Signature'] = signature;
+    }
+
+    const response = await axios.post(destination.url, data, { headers });
+
+    if (response.status !== 200) {
+      throw new Error('Webhook failed with status: ', response.status);
+    }
+  };
+
+  signWebhookPayload = (data, signingKey) => {
+    const hmac = crypto.createHmac('sha256', signingKey);
+    hmac.update(JSON.stringify(data));
+    return hmac.digest('hex');
+  };
+}

--- a/nightfall-client/src/utils/dataPublisher.mjs
+++ b/nightfall-client/src/utils/dataPublisher.mjs
@@ -1,45 +1,170 @@
+/* eslint-disable max-classes-per-file */
 import axios from 'axios';
 import crypto from 'crypto';
+import config from 'config';
 
+const {
+  WEBHOOK: { CALL_WEBHOOK_MAX_RETRIES, CALL_WEBHOOK_INITIAL_BACKOFF },
+} = config;
+
+/**
+ * Class for signing request payloads.
+ */
+class PayloadSigner {
+  /**
+   * @param {string} signingKey - The signing key.
+   */
+  constructor(signingkey) {
+    this.signingKey = signingkey;
+  }
+
+  /**
+   * Signs a payload.
+   * @param {*} data - The data to be signed.
+   * @returns {string} The signature.
+   * @throws {Error} If the data is not an object or is null.
+   */
+  sign(data) {
+    if (typeof data !== 'object' || data === null) {
+      throw new Error('Data must be an object');
+    }
+
+    const hmac = crypto.createHmac('sha256', this.signingKey);
+    hmac.update(JSON.stringify(data));
+    return hmac.digest('hex');
+  }
+}
+
+/**
+ * Class for handling retries with exponential backoff and jitter.
+ */
+class RetryHandler {
+  /**
+   * @param {number} maxRetries - The maximum number of retries.
+   * @param {number} initialBackoff - The initial backoff time in milliseconds.
+   */
+  constructor(maxRetries, initialBackoff) {
+    this.maxRetries = maxRetries;
+    this.initialBackoff = initialBackoff;
+  }
+
+  /**
+   * Executes a request function with retries.
+   * @param {Function} requestFunction - The function to execute with retries.
+   * @returns {*} The result of the request function.
+   * @throws {Error} If the request function fails after all retries.
+   */
+  async executeWithRetry(requestFunction, retries = 0) {
+    let timeIdToClear;
+    if (retries >= this.maxRetries) {
+      throw new Error('Failed to execute request after retries');
+    }
+
+    try {
+      return await requestFunction();
+    } catch (error) {
+      // Passing an invalid ID to clearTimeout() silently does nothing; no exception is thrown.
+      clearTimeout(timeIdToClear);
+      // Have an exponential back-off strategy with jitter
+      const newBackoff = this.initialBackoff * 2 ** retries + Math.random() * this.initialBackoff;
+      timeIdToClear = await new Promise(resolve => setTimeout(resolve, newBackoff));
+      return this.executeWithRetry(requestFunction, retries + 1);
+    }
+  }
+}
+
+/**
+ * Class for publishing data to webhook destinations.
+ */
+class WebhookPublisher {
+  /**
+   * @param {PayloadSigner} signer - The payload signer instance.
+   * @param {RetryHandler} retryHandler - The retry handler instance.
+   */
+  constructor(signer, retryHandler) {
+    this.signer = signer;
+    this.retryHandler = retryHandler;
+  }
+
+  /**
+   * Validates the destination configuration
+   * @param {Object} destination - the webhook destination configuration
+   * @throws {Error} If the destination configuration is invalid
+   */
+  static validateDestination(destination) {
+    if (!destination || typeof destination !== 'object') {
+      throw new Error('Invalid destination configuration: must be an object');
+    }
+
+    if (!destination.url || typeof destination.url !== 'string') {
+      throw new Error('Invalid destination configuration: url must be a string');
+    }
+  }
+
+  /**
+   * Publishes data to a webhook destination.
+   * @param {Object} destination - The webhook destination configuration.
+   * @param {*} data - The data to be published.
+   */
+  async publish(destination, data) {
+    WebhookPublisher.validateDestination(destination);
+    const headers = {};
+
+    if (destination.signingKey) {
+      const signature = this.signer.sign(data);
+      headers['X-Signature-SHA256'] = signature;
+    }
+
+    const requestFunction = async () => {
+      const response = await axios.post(destination.url, data, { headers });
+      if (response.status < 200 || response.status >= 300) {
+        throw new Error(`Webhook failed with status: ${response.status}`);
+      }
+    };
+
+    await this.retryHandler.executeWithRetry(requestFunction);
+  }
+}
+
+/**
+ * Class for publishing data to various destinations.
+ */
 export default class DataPublisher {
+  /**
+   * @param {Array} options - An array of destination configurations.
+   */
   constructor(options) {
     this.options = options || [];
   }
 
+  /**
+   * Publishes data to all configured destinations/transports.
+   * @param {*} data - The data to be published.
+   */
   async publish(data) {
     const promises = this.options.map(async destination => {
-      switch (destination.type) {
-        case 'webhook': {
-          await this.publishWebhook(destination, data);
-          break;
-        }
+      try {
+        const signer = new PayloadSigner(destination.signingKey);
+        const retryHandler = new RetryHandler(
+          destination.maxRetries || CALL_WEBHOOK_MAX_RETRIES,
+          destination.initialBackoff || CALL_WEBHOOK_INITIAL_BACKOFF,
+        );
 
-        default:
-          throw new Error('Unknown destination type');
+        switch (destination.type) {
+          case 'webhook': {
+            const publisher = new WebhookPublisher(signer, retryHandler);
+            await publisher.publish(destination, data);
+            break;
+          }
+          // Other destination types can be added here as needed
+          default:
+            console.error('Unknown destination type:', destination.type);
+        }
+      } catch (err) {
+        console.error('Unable to publish to destination: ', err);
       }
     });
 
-    await Promise.all(promises);
+    return Promise.all(promises);
   }
-
-  publishWebhook = async (destination, data) => {
-    const headers = {};
-
-    if (destination.signingkey) {
-      const signature = await this.signWebhookPayload(data, destination.signingkey);
-      headers['X-Signature'] = signature;
-    }
-
-    const response = await axios.post(destination.url, data, { headers });
-
-    if (response.status !== 200) {
-      throw new Error('Webhook failed with status: ', response.status);
-    }
-  };
-
-  signWebhookPayload = (data, signingKey) => {
-    const hmac = crypto.createHmac('sha256', signingKey);
-    hmac.update(JSON.stringify(data));
-    return hmac.digest('hex');
-  };
 }


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

This PR adds a `DataPublisher` utility class to the nightfall client, that is used to publish L2 block data to external services via webhook. This is enabled via the environment variable `CALL_WEBHOOK_ON_CONFIRMATION`. The url of the webhook is configurable via the environment variable `WEBHOOK_PATH`.

The `DataPublisher` supports multiple destinations(webhook for now, could be different transport mechanisms in future like grpc or socket), including multiple webhook destinations for fallback/backup.

The `PayloadSigner` class abstracts away the optional signing of the payload using HMAC. The signing key(secret) is configurable via the environment variable `WEBHOOK_SIGNING_KEY`.

The `RetryHandler` class abstracts away the retry mechanism with exponential backoff strategy that is configurable via environment variables `CALL_WEBHOOK_MAX_RETRIES` and `CALL_WEBHOOK_INITIAL_BACKOFF`.

## Does this close any currently open issues?
No

## What commands can I run to test the change? 

- Add the required environment variables to `docker-compose.dev.yml`:
```
   environment:
       - CALL_WEBHOOK_ON_CONFIRMATION=true
       - WEBHOOK_PATH=http://<webhook_url>
       - WEBHOOK_SIGNING_KEY=<secure_signing_key>
 ```
- Perform tokenisation/mint and wait for layer 2 block to be confirmed.
- Observe the published data on a destination webhook url.

